### PR TITLE
Fix for small copy & paste bug in navigator

### DIFF
--- a/httpdocs/navigator.js
+++ b/httpdocs/navigator.js
@@ -519,7 +519,7 @@ function Navigator()
 		{
 			try
 			{
-				self.input_x.onmousewheel = YXMouseWheel;
+				self.input_y.onmousewheel = YXMouseWheel;
 			}
 			catch ( error ) {}
 		}
@@ -589,7 +589,7 @@ function Navigator()
 		{
 			try
 			{
-				self.input_x.onmousewheel = null;
+				self.input_y.onmousewheel = null;
 			}
 			catch ( error ) {}
 		}


### PR DESCRIPTION
Instead of referencing the y input box the x input box was referenced twice.
