### PR TITLE
Add two directories to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ django/projects/mysite/settings_apache.py
 django/projects/mysite/django.wsgi
 django/projects/mysite/settings.py
 /django/static/neurohdf
+/django/env
+/django/build
 /inc/setup.inc.php
 /logs/
 /temp/


### PR DESCRIPTION
It would help me if Django's virtualenv "env" and "build" folders could be ignored by default.
