### PR TITLE
Add "Project > Current" menu if a project has more than one stack and the project is opened

### DIFF
--- a/httpdocs/project.js
+++ b/httpdocs/project.js
@@ -228,6 +228,7 @@ function Project( pid )
 		self.id = 0;
 		document.onkeydown = null;
 		document.getElementById( "content" ).style.display = "block";
+		document.getElementById( "project_menu_current" ).style.display = "none";
         // TODO: bars should be unset by tool on unregister
 		document.getElementById("toolbox_edit").style.display = "none";
 		document.getElementById("toolbox_data").style.display = "none";


### PR DESCRIPTION
I don't know if this could be useful to you, but here it definitely is.

Detail part of the commit message:

If a project has more than one stack a new menu item is created when a stack
of the project is opened. This item ("Project > Current") is a shortcut for
finding the current project in the "Project > Open" menu. If the number of
projects increases, this can be very handy.
