### PR TITLE
Bug fix for loading stack(s) URLs that was introduced with "Current" project menu

### DIFF
--- a/httpdocs/init.js
+++ b/httpdocs/init.js
@@ -32,6 +32,7 @@ var requestQueue;
 var project;
 var project_view;
 var projects_available;
+var projects_available_ready = false;
 
 var project_menu;
 var project_menu_open;
@@ -228,6 +229,7 @@ function handle_updateProjects(status, text, xml) {
       alert(e.error);
     } else {
       // maintain a list of projects/sessions available
+      projects_available_ready = false;
       if (projects_available)
       {
         delete projects_available;
@@ -274,6 +276,7 @@ function handle_updateProjects(status, text, xml) {
           pp.appendChild(catalogueElement);
         }
       }
+      projects_available_ready = true;
       project_menu_open.update(e)
     }
     if (project) {
@@ -804,13 +807,26 @@ var realInit = function()
 		login( account, password );
 	else
 		login();
-	
+
 	if ( pid && sids.length > 0 )
 	{
-		for ( var i = 0; i < sids.length; ++i )
+		// Make sure that the client-side project list is ready before
+		// we load the stacks.
+		var wait_for_projects = function()
 		{
-			openProjectStack( pid, sids[ i ] )
-		}
+			if ( projects_available_ready )
+			{
+				for ( var i = 0; i < sids.length; ++i )
+				{
+					openProjectStack( pid, sids[ i ] )
+				}
+			}
+			else
+			{
+				setTimeout(wait_for_projects, 10);
+			}
+		};
+		wait_for_projects();
 	}
 	
 	// the text-label toolbar


### PR DESCRIPTION
The "Current" project menu relies on information about projects and stacks available being built up on the client side. This build up happens asynchronously and therefore it has to be checked if that information is already there before trying to load a stack(s) URL.
