### PR TITLE
Fixed test_search_with_several_nodes

### DIFF
--- a/django/applications/vncbrowser/tests.py
+++ b/django/applications/vncbrowser/tests.py
@@ -1228,6 +1228,9 @@ class ViewPageTests(TestCase):
                 {"id":2364, "name":"skeleton 2364", "class_name":"skeleton"},
                 {"id":2388, "name":"skeleton 2388", "class_name":"skeleton"},
                 {"id":2411, "name":"skeleton 2411", "class_name":"skeleton"},
+                {"id":2433, "name":"skeleton 2433", "class_name":"skeleton"},
+                {"id":2440, "name":"skeleton 2440", "class_name":"skeleton"},
+                {"id":2451, "name":"skeleton 2451", "class_name":"skeleton"},
                 {"id":361, "name":"skeleton 361", "class_name":"skeleton"},
                 {"id":373, "name":"skeleton 373", "class_name":"skeleton"}]
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Test now expects the same results as executing the query with the PHP
function returns. This test is relatively volatile, but can't think of a better
way to do it that doesn't include replicating the search code in the test.
