### PR TITLE
Fix bug in create_project_stack where transactions were not committed before they were required.

### DIFF
--- a/scripts/database/create_project_stack.py
+++ b/scripts/database/create_project_stack.py
@@ -120,7 +120,7 @@ while True:
         continue
 
     insert = 'INSERT INTO stack (title, dimension, resolution, image_base, comment, num_zoom_levels, file_extension) '
-    insert += 'VALUES (%s, %s, %s, %s, %s) RETURNING id'
+    insert += 'VALUES (%s, %s, %s, %s, %s, %s, %s) RETURNING id'
     c.execute(insert, (title, dimension, resolution, image_base, comment, num_zoom_levels, file_extension) )
     stack_id = c.fetchone()[0]
 


### PR DESCRIPTION
Specifically, setup-tracing-for-project.py expected the project to exist
in the db, but the transaction is not committed.  I'm not familiar with
the transaction semantics, but the proposed fix solves the problem, if
not in the best way.
