### PR TITLE
Add an option to specify the PostgreSQL port

### DIFF
--- a/inc/db.pg.class.php
+++ b/inc/db.pg.class.php
@@ -50,6 +50,7 @@ class DB
 	var $user;
 	var $pw;
 	var $db;
+	var $port;
 	var $handle;
 
     var $debug = false;
@@ -60,13 +61,14 @@ class DB
 	 */  
 	function DB( $mode = 'read' )
 	{
-		global $db_host, $db_user, $db_pw, $db_db;
+		global $db_host, $db_user, $db_pw, $db_db, $db_port;
 		$this->host = $db_host[ $mode ];
 		$this->user = $db_user[ $mode ];
 		$this->pw = $db_pw[ $mode ];
 		$this->db = $db_db[ $mode ];
-		
-		$this->handle = pg_connect( 'host='.$this->host.' port=5432 dbname='.$this->db.' user='.$this->user.' password= '.$this->pw ) or die( pg_last_error() );
+		$this->port = isset( $db_port[ $mode ] ) ? $db_port[ $mode ] : 5432;
+
+		$this->handle = pg_connect( 'host='.$this->host.' port='.$this->port.' dbname='.$this->db.' user='.$this->user.' password= '.$this->pw ) or die( pg_last_error() );
 	}
 	/**#@-*/
 	

--- a/inc/setup.inc.php.template
+++ b/inc/setup.inc.php.template
@@ -11,10 +11,13 @@
  * @access private
  */
 $db_host[ 'write' ]	= 'localhost';
+$db_port[ 'write' ]	= '5432'
 $db_user[ 'write' ]	= 'catmaid_user';
 $db_pw[ 'write' ]	= 'password';
 $db_db[ 'write' ]	= 'catmaid';
+
 $db_host[ 'read' ]	= 'localhost';
+$db_port[ 'read' ]	= '5432'
 $db_user[ 'read' ]	= 'catmaid_user';
 $db_pw[ 'read' ]	= 'password';
 $db_db[ 'read' ]	= 'catmaid';

--- a/scripts/database/common.py
+++ b/scripts/database/common.py
@@ -14,6 +14,7 @@ except:
     print >> sys.stderr, '''Your %s file should look like:
 
 host: localhost
+port: 5432
 database: catmaid
 username: catmaid_user
 password: password_of_your_catmaid_user''' % (path,)
@@ -21,11 +22,13 @@ password: password_of_your_catmaid_user''' % (path,)
 
 # Make a variable for each of these so that they can be imported:
 db_host = conf['host']
+db_port = conf['port']
 db_database = conf['database']
 db_username = conf['username']
 db_password = conf['password']
 
 db_connection = psycopg2.connect(host=db_host,
+                                 port=db_port,
                                  database=db_database,
                                  user=db_username,
                                  password=db_password)


### PR DESCRIPTION
PostgreSQL 9 is now required, but many people on Debian-based
systems will have version 8 installed alongside, distinguished
by port number.  This mean that we must support configuring the
port that PostgreSQL is listening on.
