### PR TITLE
Don't attempt to create super-user during syncdb

### DIFF
--- a/django/applications/catmaid/models.py
+++ b/django/applications/catmaid/models.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.db import models
 from django.db.models import Q
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, post_syncdb
 from datetime import datetime
 import sys
 import re
@@ -929,6 +929,22 @@ def new_create_anonymous_user(sender, **kwargs):
 
 import guardian
 guardian.management.create_anonymous_user = new_create_anonymous_user
+
+# ------------------------------------------------------------------------
+
+# Prevent interactive question about wanting a superuser created.  (This code
+# has to go in this "models" module so that it gets processed by the "syncdb"
+# command during database creation.)
+#
+# From http://stackoverflow.com/questions/1466827/ --
+
+from django.contrib.auth import models as auth_models
+from django.contrib.auth.management import create_superuser
+
+post_syncdb.disconnect(
+    create_superuser,
+    sender=auth_models,
+    dispatch_uid='django.contrib.auth.management.create_superuser')
 
 # ------------------------------------------------------------------------
 

--- a/sphinx-doc/source/installation.rst
+++ b/sphinx-doc/source/installation.rst
@@ -190,8 +190,6 @@ Now create some required tables with::
 
     ./manage.py syncdb
 
-When prompted to create a superuser, **SAY NO** at this stage.
-
 And bring the database schema up to date for applications that
 mange changes to their tables with South::
 


### PR DESCRIPTION
All users in CATMAID have a user profile attached and every new user
gets automatically one created. This, however, does only work if the
model tables have been created already. This is not the case when syncdb
asks if it should create a superuser. This commit disables this question
and removes the note in the manual about saying "no" to it. Still, a
superuser has to be created manually.
