### PR TITLE
Fix some more url template tags for Django > 1.4

### DIFF
--- a/django/applications/catmaid/templates/catmaid/admin/dataview/change_form.html
+++ b/django/applications/catmaid/templates/catmaid/admin/dataview/change_form.html
@@ -9,7 +9,7 @@
 		update_data_view_comment = function() {
 			$.ajax({
 				type: 'POST',
-				url: "{% url catmaid.control.data_view.get_data_view_type_comment %}",
+				url: "{% url 'catmaid.control.data_view.get_data_view_type_comment' %}",
 				data: {'data_view_type_id': $('#id_data_view_type').val()},
 				success: function(data, status) {
 					$('#data_view_config_help').text(data.comment);

--- a/django/applications/vncbrowser/templates/vncbrowser/common.html
+++ b/django/applications/vncbrowser/templates/vncbrowser/common.html
@@ -10,7 +10,7 @@
     <script src="{{ static }}js/treelines.js" type="text/javascript" charset="utf-8"></script>
     <script type="text/javascript">
         {% if project_id %}
-            var projectIndexURL = "{% url vncbrowser.views.index project_id=project_id %}";
+            var projectIndexURL = "{% url 'vncbrowser.views.index' project_id=project_id %}";
         {% endif %}
     </script>
     {% block extrascript %}
@@ -27,8 +27,8 @@
        Not logged in
     {% endif %}
     {% if project_id %}
-    <a href="{% url vncbrowser.views.index project_id=project_id %}">All neurons (text)</a>
-    | <a href="{% url vncbrowser.views.visual_index project_id=project_id %}">All neurons (visual)</a>
+    <a href="{% url 'vncbrowser.views.index' project_id=project_id %}">All neurons (text)</a>
+    | <a href="{% url 'vncbrowser.views.visual_index' project_id=project_id %}">All neurons (visual)</a>
     {% endif %}
   </div>
 

--- a/django/applications/vncbrowser/templates/vncbrowser/index.html
+++ b/django/applications/vncbrowser/templates/vncbrowser/index.html
@@ -5,10 +5,10 @@
 {% block main %}
 
 <p class="intro">
-  Alternatively, you can use the <a href="{% url vncbrowser.views.visual_index project_id=project_id %}">visual index and search page</a>.
+  Alternatively, you can use the <a href="{% url 'vncbrowser.views.visual_index' project_id=project_id %}">visual index and search page</a>.
 </p>
 
-<form method="post" action="{% url vncbrowser.views.index project_id=project_id %}">
+<form method="post" action="{% url 'vncbrowser.views.index' project_id=project_id %}">
   {{ search_form }}
   <input type="submit" value="Search">
 </form>
@@ -17,19 +17,19 @@
     <table class="hor-minimalist-b hor-minimalist-b-wider">
       <tbody>
         <tr>
-          <th><a href="{% url vncbrowser.views.index order_by='name', project_id=project_id %}">Neuron</a>
-              <a href="{% url vncbrowser.views.index order_by='namer', project_id=project_id %}">&#8593;</a></th>
-          <th><a href="{% url vncbrowser.views.index order_by='cellbody', project_id=project_id %}">Cell Body Location</a>
-              <a href="{% url vncbrowser.views.index order_by='cellbodyr', project_id=project_id %}">&#8593;</a></th>
-          <th><a href="{% url vncbrowser.views.index order_by='gal4', project_id=project_id %}">Possible GAL4 Lines</a>
-              <a href="{% url vncbrowser.views.index order_by='gal4r', project_id=project_id %}">&#8593;</a></th>
+          <th><a href="{% url 'vncbrowser.views.index' order_by=name project_id=project_id %}">Neuron</a>
+              <a href="{% url 'vncbrowser.views.index' order_by=namer project_id=project_id %}">&#8593;</a></th>
+          <th><a href="{% url 'vncbrowser.views.index' order_by=cellbody project_id=project_id %}">Cell Body Location</a>
+              <a href="{% url 'vncbrowser.views.index' order_by=cellbodyr project_id=project_id %}">&#8593;</a></th>
+          <th><a href="{% url 'vncbrowser.views.index' order_by=gal4 project_id=project_id %}">Possible GAL4 Lines</a>
+              <a href="{% url 'vncbrowser.views.index' order_by=gal4r project_id=project_id %}">&#8593;</a></th>
         </tr>
         {% for n in all_neurons_list %}
             <tr>
-              <td><a href="{% url vncbrowser.views.view neuron_id=n.id, project_id=project_id %}">{{ n.name }}</a></td>
+              <td><a href="{% url 'vncbrowser.views.view' neuron_id=n.id project_id=project_id %}">{{ n.name }}</a></td>
               <td>{{ n.cached_cell_body }}</td>
               <td>{% for l in n.cached_sorted_lines %}
-                    <a href="{% url vncbrowser.views.line line_id=l.id, project_id=project_id %}">{{ l.name }}</a>
+                    <a href="{% url 'vncbrowser.views.line' line_id=l.id project_id=project_id %}">{{ l.name }}</a>
                 {% endfor %}
               </td>
           </tr>

--- a/django/applications/vncbrowser/templates/vncbrowser/line.html
+++ b/django/applications/vncbrowser/templates/vncbrowser/line.html
@@ -7,7 +7,7 @@
 <h4>Linked with the following neurons:</h4>
 <ul>
 {% for n in neurons %}
-<li><a href="{% url vncbrowser.views.view project_id=project_id, neuron_id=n.id %}">{{ n.name }}</a></li>
+<li><a href="{% url 'vncbrowser.views.view' project_id=project_id neuron_id=n.id %}">{{ n.name }}</a></li>
 {% endfor %}
 </ul>
 

--- a/django/applications/vncbrowser/templates/vncbrowser/multiple_presynaptic_terminals.html
+++ b/django/applications/vncbrowser/templates/vncbrowser/multiple_presynaptic_terminals.html
@@ -18,7 +18,7 @@
               <td>{{ cc.number }}</td>
               <td>
                  {% for s in stacks %}
-                    <a href="{% url vncbrowser.views.goto_connector project_id=project_id, connector_id=cc.connector, stack_id=s.id %}">View in stack {{ s.title }}</a><br>
+                    <a href="{% url 'vncbrowser.views.goto_connector' project_id=project_id connector_id=cc.connector stack_id=s.id %}">View in stack {{ s.title }}</a><br>
                  {% endfor %}
               </td>
           </tr>

--- a/django/applications/vncbrowser/templates/vncbrowser/view.html
+++ b/django/applications/vncbrowser/templates/vncbrowser/view.html
@@ -28,7 +28,7 @@
 
       <div id="lines">
       <h4>GAL4 Lines</h4>
-      <form action="{% url vncbrowser.views.lines_add project_id=project_id %}" method="post">
+      <form action="{% url 'vncbrowser.views.lines_add' project_id=project_id %}" method="post">
       <p><label for="id_name">Line: </label><input type="text" name="line_name"></input>
       <input type="submit" value="Add"></input><input type="hidden" name="neuron_id" value="{{neuron.id}}"></input>
       </p>
@@ -36,7 +36,7 @@
     {% if lines %}
         <ul>
         {% for l in lines %}
-            <li><a href="{% url vncbrowser.views.line project_id=project_id, line_id=l.id %}">{{ l.name }}</a> <form action="{% url vncbrowser.views.lines_delete project_id=project_id %}" method="POST" class="delete-form inline-form">
+            <li><a href="{% url 'vncbrowser.views.line' project_id=project_id, line_id=l.id %}">{{ l.name }}</a> <form action="{% url 'vncbrowser.views.lines_delete' project_id=project_id %}" method="POST" class="delete-form inline-form">
                                <input type="hidden" name="neuron_id" value="{{neuron.id}}">
                                <input type="hidden" name="line_name" value="{{l.name}}">
                                <input class="delete-submit" type="submit" value="delete">
@@ -50,7 +50,7 @@
 
         <div id="cell-body-location">
         <h4>Cell Body Location</h4>
-        <form action="{% url vncbrowser.views.set_cell_body %}" method="POST">
+        <form action="{% url 'vncbrowser.views.set_cell_body' %}" method="POST">
            {% for choice in cell_body_choices %}
              <input type="radio" {% ifequal choice.1 neuron.cell_body_location %}CHECKED{% endifequal %} name="cell-body-choice" id="choice-{{ choice.0 }}" value="{{ choice.0 }}">
              <input type="hidden" name="neuron_id" value="{{neuron.id}}">
@@ -77,7 +77,7 @@
 
     <p>
         {% for skeleton in skeletons %}
-        <a href="{% url catmaid.control.skeleton_swc skeleton_id=skeleton.id, project_id=project_id %}">Save SWC file (for
+        <a href="{% url 'catmaid.control.skeleton_swc' skeleton_id=skeleton.id, project_id=project_id %}">Save SWC file (for
             skeleton {{skeleton.id}} of neuron "{{neuron.name}}")</a><br>
         {% endfor %}
         <br />
@@ -94,7 +94,7 @@
             {% for c in incoming %}
             <tr>
                 <td>{{ c.id__count }}</td>
-                <td><a href="{% url vncbrowser.views.view project_id=project_id, neuron_id=c.id %}">{{c.name}}</a></td>
+                <td><a href="{% url 'vncbrowser.views.view' project_id=project_id, neuron_id=c.id %}">{{c.name}}</a></td>
                 <td><input type="checkbox" class="show-neuron" id="p{{project_id}}c{{c.id}}"></td>
             </tr>
             {% endfor %}
@@ -110,7 +110,7 @@
     {% for c in outgoing %}
     <tr>
       <td>{{ c.id__count }}</td>
-      <td><a href="{% url vncbrowser.views.view project_id=project_id, neuron_id=c.id %}">{{c.name}}</a></td>
+      <td><a href="{% url 'vncbrowser.views.view' project_id=project_id, neuron_id=c.id %}">{{c.name}}</a></td>
       <td><input type="checkbox" class="show-neuron" id="p{{project_id}}c{{c.id}}"></td>
     </tr>
     {% endfor %}

--- a/django/applications/vncbrowser/templates/vncbrowser/visual_index.html
+++ b/django/applications/vncbrowser/templates/vncbrowser/visual_index.html
@@ -5,11 +5,11 @@
 {% block main %}
 
     <p class="intro">
-       Alternatively, you can use the <a href="{% url vncbrowser.views.index project_id=project_id %}">standard index page</a>.
-       <a href="{% url vncbrowser.views.visual_index project_id=project_id %}{{ search_form.minimal_search_path }}">Link to this search</a>
+       Alternatively, you can use the <a href="{% url 'vncbrowser.views.index' project_id=project_id %}">standard index page</a>.
+       <a href="{% url 'vncbrowser.views.visual_index' project_id=project_id %}{{ search_form.minimal_search_path }}">Link to this search</a>
     </p>
 
-<form method="post" action="{% url vncbrowser.views.visual_index project_id=project_id %}" class="search">
+<form method="post" action="{% url 'vncbrowser.views.visual_index' project_id=project_id %}" class="search">
   {{ search_form }}
   <input type="submit" value="Search">
 </form>
@@ -17,7 +17,7 @@
   <div class="pagination">
       <span class="step-links">
           {% if sorted_neurons_page.has_previous %}
-              <a href="{% url vncbrowser.views.visual_index project_id=project_id %}{{ search_form.minimal_search_path }}/page/{{ sorted_neurons_page.previous_page_number }}  ">previous</a>
+              <a href="{% url 'vncbrowser.views.visual_index' project_id=project_id %}{{ search_form.minimal_search_path }}/page/{{ sorted_neurons_page.previous_page_number }}  ">previous</a>
           {% endif %}
 
           <span class="current">
@@ -25,7 +25,7 @@
           </span>
 
           {% if sorted_neurons_page.has_next %}
-              <a href="{% url vncbrowser.views.visual_index project_id=project_id %}{{ search_form.minimal_search_path }}/page/{{ sorted_neurons_page.next_page_number }}  ">next</a>
+              <a href="{% url 'vncbrowser.views.visual_index' project_id=project_id %}{{ search_form.minimal_search_path }}/page/{{ sorted_neurons_page.next_page_number }}  ">next</a>
           {% endif %}
       </span>
   </div>
@@ -41,9 +41,9 @@
           <tr>
             <td><div class="thumbnail-neuron" id="{{ n.id }}"></div></td>
             <td>{{ n.cached_cell_body_location }}</td>
-            <td><a href="{% url vncbrowser.views.view project_id=project_id, neuron_id=n.id %}">{{ n.name }}</a></td>
+            <td><a href="{% url 'vncbrowser.views.view' project_id=project_id, neuron_id=n.id %}">{{ n.name }}</a></td>
             <td>{% for l in n.cached_sorted_lines %}
-                  <a href="{% url vncbrowser.views.line project_id=project_id, line_id=l.id %}">{{ l.name }}</a>
+                  <a href="{% url 'vncbrowser.views.line' project_id=project_id, line_id=l.id %}">{{ l.name }}</a>
                 {% endfor %}
             </td>
           </tr>
@@ -57,7 +57,7 @@
   <div class="pagination">
       <span class="step-links">
           {% if sorted_neurons_page.has_previous %}
-              <a href="{% url vncbrowser.views.visual_index project_id=project_id %}{{ search_form.minimal_search_path }}/page/{{ sorted_neurons_page.previous_page_number }}  ">previous</a>
+              <a href="{% url 'vncbrowser.views.visual_index' project_id=project_id %}{{ search_form.minimal_search_path }}/page/{{ sorted_neurons_page.previous_page_number }}  ">previous</a>
           {% endif %}
 
           <span class="current">
@@ -65,7 +65,7 @@
           </span>
 
           {% if sorted_neurons_page.has_next %}
-              <a href="{% url vncbrowser.views.visual_index project_id=project_id %}{{ search_form.minimal_search_path }}/page/{{ sorted_neurons_page.next_page_number }}  ">next</a>
+              <a href="{% url 'vncbrowser.views.visual_index' project_id=project_id %}{{ search_form.minimal_search_path }}/page/{{ sorted_neurons_page.next_page_number }}  ">next</a>
           {% endif %}
       </span>
   </div>

--- a/django/applications/vncbrowser/templates/vncbrowser/visual_line.html
+++ b/django/applications/vncbrowser/templates/vncbrowser/visual_line.html
@@ -20,9 +20,9 @@
           <tr>
             <td><div class="thumbnail-neuron" id="{{ n.id }}"></div></td>
             <td>{{ n.cell_body|cell_body_location }}</td>
-            <td><a href="{% url vncbrowser.views.view n.id %}">{{ n.name }})</a></td>
+            <td><a href="{% url 'vncbrowser.views.view' n.id %}">{{ n.name }})</a></td>
             <td>{% for l in n.lines.all %}
-                  <a href="{% url vncbrowser.views.visual_line l.name %}">{{ l.name }}</a>
+                  <a href="{% url 'vncbrowser.views.visual_line' l.name %}">{{ l.name }}</a>
                 {% endfor %}
             </td>
           </tr>


### PR DESCRIPTION
As of Django 1.5, the url template tag's first argument must be a quoted literal and the arguments cannot be comma-seperated anymore.

This commit fixes all occurences of `{% url` followed by a character other than `'` or `"`.
