### PR TITLE
Remove sort filter call from dataview template

### DIFF
--- a/django/applications/catmaid/templates/catmaid/project_tags_data_view.html
+++ b/django/applications/catmaid/templates/catmaid/project_tags_data_view.html
@@ -44,7 +44,7 @@
 						title="There are {{ tprojects|length }} projects for the tags {{ ct }} and {{ rt }}.">
 				{% endif %}
 				{% for p in tprojects %}
-					{% with stacks=stacks_of|get:p.id|sort|filter_stacks:linked_stacks %}
+					{% with stacks=stacks_of|get:p.id|filter_stacks:linked_stacks %}
 					{% is_highlighted p.id highlight_tags tag_index as highlight %}
 
 					{# Make the project name a link if we are not forced to have #}


### PR DESCRIPTION
The "sort" filter in the DataView template was supposed to sort Stacks but used the Stack objects instead of their ids. This lead to the Stacks ending up in a somewhat random order.

Since the stacks already come in sorted, no sorting needs to be done here.
