### PR TITLE
Fix checkbox inconsistency: label [ ] -> [ ] label

### DIFF
--- a/django/applications/catmaid/static/croppingtool.js
+++ b/django/applications/catmaid/static/croppingtool.js
@@ -123,15 +123,18 @@ function CroppingTool() {
 	//! RGB slices/single channel checkbox
 	var rgb_slices_container = create_tb_box();
 	var rgb_slices_p1 = document.createElement("p");
-	rgb_slices_p1.innerHTML = "RGB slices&nbsp;";
+	var rgb_slices_label = document.createElement("label");
+	rgb_slices_label.setAttribute("for", "check_crop_rgb_slices")
+	rgb_slices_label.innerHTML = "RGB slices";
+	rgb_slices_p1.appendChild(rgb_slices_label);
 	this.check_rgb_slices = document.createElement("input");
 	this.check_rgb_slices.setAttribute("type", "checkbox");
 	this.check_rgb_slices.setAttribute("id", "check_crop_rgb_slices");
 	var rgb_slices_p2 = document.createElement("p");
 	rgb_slices_p2.appendChild(this.check_rgb_slices);
 	// fill containers
-	rgb_slices_container.appendChild(rgb_slices_p1);
 	rgb_slices_container.appendChild(rgb_slices_p2);
+	rgb_slices_container.appendChild(rgb_slices_p1);
 	// add container to the toolbar
 	toolbar.insertBefore(rgb_slices_container, toolbar_button);
 	added_elements.push(rgb_slices_container);

--- a/django/applications/catmaid/templates/catmaid/classification/show_graph.html
+++ b/django/applications/catmaid/templates/catmaid/classification/show_graph.html
@@ -2,12 +2,12 @@
 {% block classification-content %}
 <input type="hidden" id="link_id" value="{{ graph_id  }}" />
 <input type="button" id="refresh_classification_graph" value="refresh" style="display:block; float:left;" />
-&nbsp; Synchronize <input type="checkbox" id="synchronize_classification_graph" checked="yes" />
-&nbsp; Display super-classes <input type="checkbox" id="display_super_classes" />
-&nbsp; Previews <input type="checkbox" id="display_previews" checked="yes" />
+&nbsp; <input type="checkbox" id="synchronize_classification_graph" checked="yes" /><label for="synchronize_classification_graph">Synchronize</label>
+&nbsp; <input type="checkbox" id="display_super_classes" /><label for=display_super_classes">Display super-classes</label>
+&nbsp; <input type="checkbox" id="display_previews" checked="yes" /><label for="display_previews">Previews</label>
 {% get_obj_perms user for project as "project_perms" %}
 {% if "can_annotate" in project_perms %}
-    &nbsp; Edit tools <input type="checkbox" id="display_edit_tools" checked="yes" /><br />
+    &nbsp; <input type="checkbox" id="display_edit_tools" checked="yes" /><label for="display_edit_tools">Edit tools</label><br />
     &nbsp; <a id="remove_classification_link" href="{% url 'remove_classification_graph' project.id workspace.id graph_id %}">Remove this graph</a>
     &nbsp; <a id="add_classification_link" href="{% url 'add_classification_graph' project.id workspace.id %}">Add/Link new graph</a>
     &nbsp; <a id="autofill_classification_link" href="{% url 'autofill_classification_graph' project.id workspace.id graph_id %}">Auto fill this graph</a>

--- a/django/applications/catmaid/templates/catmaid/index.html
+++ b/django/applications/catmaid/templates/catmaid/index.html
@@ -205,7 +205,7 @@
 				<div class="box"><p>y&nbsp;</p><p><input type="text" id="y" name="y" size="5" /><img src="{{ STATIC_URL }}widgets/themes/kde/input_topdown.gif" alt="" usemap="#ymap" /></p></div>
 				<div id="sliders_box"></div>
 				<div class="box" id="zoom_level_box"><p>zoom-level&nbsp;&nbsp;</p><div id="slider_s"></div><p>&nbsp;&nbsp;</p></div>
-				<div class="box"><p>display reference lines&nbsp;</p><p><input type="checkbox" id="displayreflines" name="displayreflines" checked="checked" /></p></div>
+				<div class="box"><p><input type="checkbox" id="displayreflines" name="displayreflines" checked="checked" /></p><p><label for="displayreflines">display reference lines</label></p></div>
 				<div class="box_right"><p><a id="a_url" name="a_url" title="This is the URL to this view. You can bookmark it or send it to the people." href="">URL to this view</a></p></div>
 				<div class="toolbar_fill"></div>
 			</div>
@@ -273,10 +273,10 @@
 			<div id="toolbar_ontology" class="toolbar" style="display:none">
 				<div id="ontology_workspace" class="box">
 					<p>Work space:&nbsp;</p>
-					<p><input type="radio" name="ontology_space" value="project" checked /></p>
-					<p>&nbsp;project specific</p>
-					<p><input type="radio" name="ontology_space" value="classification" />
-					<p>&nbsp;project independent</p>
+					<p><input type="radio" id="ontology_workspace_project_specific" name="ontology_space" value="project" checked /></p>
+					<p><label for="ontology_workspace_project_specific">&nbsp;project specific</label></p>
+					<p><input type="radio" name="ontology_space" id="ontology_workspace_project_independent" value="classification" />
+					<p><label for="ontology_workspace_project_independent">&nbsp;project independent</label></p>
 				</div>
 				<div class="toolbar_fill"></div>
 			</div>


### PR DESCRIPTION
This commit fixes some checkboxes that had their label to the left to add some consistency.

While at it, I also added label tags, so the labels can be clicked to (de)activate their checkboxes/radios.

Checkboxes concerned:
"Display reference lines" in Navigator
"RGB slices" in crop tool
4 checkboxes in classification editor
