### PR TITLE
Don't show tracing tools by default when opening second stack.

### DIFF
--- a/django/applications/catmaid/static/project.js
+++ b/django/applications/catmaid/static/project.js
@@ -300,14 +300,14 @@ function Project( pid )
 			document.getElementById("toolbox_edit").style.display = "block";
 			//document.getElementById("toolbox_data").style.display = "block";
 			//document.getElementById("toolbox_segmentation").style.display = "block";
-			document.getElementById("toolbox_data").style.display = "block";
+			//document.getElementById("toolbox_data").style.display = "block";
 		}
 		else 
 		{
 			document.getElementById("toolbox_edit").style.display = "none";
 			//document.getElementById("toolbox_data").style.display = "none";
 			//document.getElementById("toolbox_segmentation").style.display = "none";
-			document.getElementById("toolbox_data").style.display = "none";
+			//document.getElementById("toolbox_data").style.display = "none";
 		}
 		window.onresize();
 		


### PR DESCRIPTION
When opening a second stack, the tracing toolbox (toolbox_data) will show, although it shouldn't.

project.js:setEditable() will unhide the tracing toolbox whenever a (editable) stack is opened. setTool() will then hide the toolbox again, but only if the stack opened is the first one (see project.js:70).

I didn't look into this any further, @tomka since we already discussed this, could you please check if this is a valid fix?
