### PR TITLE
navigate with synchronized real magnification instead scale-level

### DIFF
--- a/django/applications/catmaid/static/project.js
+++ b/django/applications/catmaid/static/project.js
@@ -343,7 +343,9 @@ function Project( pid )
 	}
 
 	/**
-	 * move all stacks to the physical coordinates
+	 * move all stacks to the physical coordinates, except sp, sp is a
+	 * stack specific scale level that cannot be traced back to where it
+	 * came from, so we just pass it through 
 	 */
 	this.moveTo = function(
 		zp,
@@ -364,6 +366,60 @@ function Project( pid )
 		}
 
 		self.moveToInStacks( zp, yp, xp, sp, stacksToMove, completionCallback );
+	};
+
+
+	this.moveToProjectInStacks = function(
+		zp,
+		yp,
+		xp,
+		res,
+		stacks,
+		completionCallback)
+	{
+		var stackToMove;
+		if (stacks.length === 0) {
+			// FIXME: do we need a callback for tool.redraw as well?
+			if ( tool && tool.redraw )
+				tool.redraw();
+			if (typeof completionCallback !== "undefined") {
+				completionCallback();
+			}
+		} else {
+			stackToMove = stacks.shift();
+			stackToMove.moveToProject( zp,
+					    yp,
+					    xp,
+					    res,
+					    function () {
+						    self.moveToProjectInStacks( zp, yp, xp, res, stacks, completionCallback );
+					    });
+		}
+	}
+
+	/**
+	 * move all stacks to the physical coordinates, at a given resolution
+	 * in units per pixels
+	 */
+	this.moveToProject = function(
+		zp,
+		yp,
+		xp,
+		res,
+		completionCallback)
+	{
+		var stacksToMove = [];
+		self.coordinates.x = xp;
+		self.coordinates.y = yp;
+		self.coordinates.z = zp;
+
+		
+		for ( var i = 0; i < stacks.length; ++i )
+		{
+			stacksToMove.push( stacks[ i ] );
+		}
+
+		self.moveToProjectInStacks( zp, yp, xp, res, stacksToMove, completionCallback );
 	};
 
   this.updateTool = function()

--- a/django/applications/catmaid/static/stack.js
+++ b/django/applications/catmaid/static/stack.js
@@ -563,9 +563,50 @@ function Stack(
 
 	/**
 	 * move to project-coordinates
+	 * 
+	 * @Deprecated Do not use this method as it mixes project coordinates with a stack-dependent scale level parameter
 	 */
 	this.moveTo = function( zp, yp, xp, sp, completionCallback )
 	{
+		var layersWithBeforeMove = [], l;
+		for ( var key in layers ) {
+			if (layers.hasOwnProperty(key)) {
+				l = layers[key];
+				// if (l.beforeMove) {
+				if( typeof l.beforeMove === 'function') {
+					layersWithBeforeMove.push(l);
+				}
+			}
+		}
+
+		self.moveToAfterBeforeMoves( zp, yp, xp, sp, completionCallback, layersWithBeforeMove );
+	}
+
+	var bestScaleLevel = function( res )
+	{
+		var l = ( res / resolution.x );
+		var sp;
+		if ( l >= 1 )
+			for ( sp = 0; l > 1; l >>= 1, ++sp );
+		else
+		{
+			l = ( resolution.x / res );
+			for ( sp = 0; l > 1; l >>= 1, --sp );
+		}
+		return sp;
+	}
+
+	/**
+	 * move to project-coordinates passing project coordinates and resolution
+	 * 
+	 * This assumes that all layers have identical scale levels and
+	 * resolution, i.e. that of the stack, fix as needed.
+	 *
+	 * @param res spatial resolution in units per pixel
+	 */
+	this.moveToProject = function( zp, yp, xp, res, completionCallback )
+	{
+		var sp = bestScaleLevel( res );
 		var layersWithBeforeMove = [], l;
 		for ( var key in layers ) {
 			if (layers.hasOwnProperty(key)) {
@@ -585,11 +626,11 @@ function Stack(
 	 */
 	this.moveToPixel = function( zs, ys, xs, ss )
 	{
-		project.moveTo(
+		project.moveToProject(
 			self.stackToProjectZ( zs, ys, xs ),
 			self.stackToProjectY( zs, ys, xs ),
 			self.stackToProjectX( zs, ys, xs ),
-			ss );
+			ss >= 0 ? resolution.x * ( 1 << ss ) : resolution.x / ( 1 << -ss ) );
 
 		return true;
 	}
@@ -868,7 +909,7 @@ function Stack(
 	self.xc = 0;
 
 	self.scale = 1 / Math.pow( 2, self.s );
-	self.old_scale = self.scale;
+ 	self.old_scale = self.scale;
 
 	self.is_trackem2_stack = trakem2_project;
 	self.orientation = orientation;
@@ -927,4 +968,3 @@ Stack.SCALE_BAR_UNITS = new Array(
 			unescape( "%u03BCm" ),
 			"mm",
 			"m" );
-


### PR DESCRIPTION
Added moveToProject methods to both project.js and stack that synchronize
magnification by project scale instead of passing stack.s scale_level.
This enables to to browse multiple stacks with different resolutions at
the best matching magnification.

TODO make that optional
TODO a new stack is not opened with the correct magnification, only the
first navigation action synchronizes
