### PR TITLE
change slider delays for faster z-scrolling

### DIFF
--- a/django/applications/catmaid/static/navigator.js
+++ b/django/applications/catmaid/static/navigator.js
@@ -251,7 +251,7 @@ function Navigator()
 	{
 		if ( changeSliceDelayedTimer ) window.clearTimeout( changeSliceDelayedTimer );
 		changeSliceDelayedParam = { z : val };
-		changeSliceDelayedTimer = window.setTimeout( changeSliceDelayedAction, 100 );
+		changeSliceDelayedTimer = window.setTimeout( changeSliceDelayedAction, 30 );
 	}
 	
 	this.changeSlice = function( val )

--- a/django/applications/catmaid/static/navigator.js
+++ b/django/applications/catmaid/static/navigator.js
@@ -251,7 +251,7 @@ function Navigator()
 	{
 		if ( changeSliceDelayedTimer ) window.clearTimeout( changeSliceDelayedTimer );
 		changeSliceDelayedParam = { z : val };
-		changeSliceDelayedTimer = window.setTimeout( changeSliceDelayedAction, 30 );
+		changeSliceDelayedTimer = window.setTimeout( changeSliceDelayedAction, 50 );
 	}
 	
 	this.changeSlice = function( val )

--- a/django/applications/catmaid/static/widgets/slider.js
+++ b/django/applications/catmaid/static/widgets/slider.js
@@ -213,7 +213,7 @@ Slider = function(
   var decrease = function()
   {
     setByIndex( Math.max( 0, ind - 1 ) );
-    timer = window.setTimeout( decrease, 250 );
+    timer = window.setTimeout( decrease, 100 );
     return;
   }
   
@@ -239,7 +239,7 @@ Slider = function(
   var increase = function()
   {
     setByIndex( Math.min( values.length - 1, ind + 1 ) );
-    timer = window.setTimeout( increase, 250 );
+    timer = window.setTimeout( increase, 100 );
     return;
   }
   


### PR DESCRIPTION
There is a delay of 250ms between two slider movement steps (e.g. when holding the mouse down next to the slider handle) of the sliders in Navigator too. I found that everything looks and feels much smoother if that delay is reduced to 100ms and the delay between slider movement and actual tile loading is reduced from 100 to 30.

Maybe you like it. No complaints in the last two months here in Dresden.