### PR TITLE
Prevent full screen redraws when updating the tile layer (Chrome)

### DIFF
--- a/django/applications/catmaid/static/widgets/themes/kde/stack.css
+++ b/django/applications/catmaid/static/widgets/themes/kde/stack.css
@@ -358,3 +358,8 @@ div.sliceView div.cropBox p.close
 .clear {
   clear: both;
 }
+
+div.sliceTiles > * {
+	-webkit-transform: translateZ(0);	/* Pre-chrome36 */
+	will-change: top, left;			/* Post-chrome36 */
+}


### PR DESCRIPTION
Provide a hint to Chrome to use textures (likely on the video card) for the tiles, greatly speeding up redraw times.
