### PR TITLE
Classification Editor: High z-index for imagepreview div

### DIFF
--- a/django/applications/catmaid/static/widgets/classification_editor.js
+++ b/django/applications/catmaid/static/widgets/classification_editor.js
@@ -349,6 +349,7 @@ var ClassificationEditor = new function()
                         $("#imagepreview")
                             .css("top", (e.pageY - preview_y_offset) + "px")
                             .css("left", (e.pageX + preview_x_offset) + "px")
+                            .attr("class", "ui-front")
                             .fadeIn("fast");
                     }
                 },


### PR DESCRIPTION
Before this fix, the resize_handle div (z-index=8) from the
window manager would be on top of the image preview in the
Classification tree.
