### PR TITLE
Connect postsynaptic treenodes with existing connectors via alt-shift click

### DIFF
--- a/django/applications/catmaid/static/widgets/overlay.js
+++ b/django/applications/catmaid/static/widgets/overlay.js
@@ -1213,6 +1213,7 @@ SkeletonAnnotations.SVGOverlay.prototype.whenclicked = function (e) {
       targetTreenodeID = atn.id;
       if (SkeletonAnnotations.TYPE_NODE === atn.type) {
         if (e.shiftKey) {
+          // Create a new connector and a new link
           var synapse_type = e.altKey ? 'post' : 'pre';
           statusBar.replaceLast("created connector, with " + synapse_type + "synaptic treenode id " + atn.id);
           var self = this;

--- a/django/applications/catmaid/static/widgets/overlay_node.js
+++ b/django/applications/catmaid/static/widgets/overlay_node.js
@@ -725,7 +725,7 @@ SkeletonElements.prototype.mouseEventManager = new (function()
         // to existing treenode or connectornode
         if (atnType === SkeletonAnnotations.TYPE_CONNECTORNODE) {
           if (!mayEdit()) {
-            alert("You lack permissions to declare node #" + node.id + "as postsynaptic to connector #" + atnID);
+            alert("You lack permissions to declare node #" + node.id + " as postsynaptic to connector #" + atnID);
             return;
           }
           // careful, atnID is a connector
@@ -873,7 +873,8 @@ SkeletonElements.prototype.mouseEventManager = new (function()
         if (atnType === SkeletonAnnotations.TYPE_CONNECTORNODE) {
           alert("Can not join two connector nodes!");
         } else if (atnType === SkeletonAnnotations.TYPE_NODE) {
-          catmaidSVGOverlay.createLink(atnID, connectornode.id, "presynaptic_to");
+          var synapse_type = e.altKey ? 'post' : 'pre';
+          catmaidSVGOverlay.createLink(atnID, connectornode.id, synapse_type + "synaptic_to");
           statusBar.replaceLast("Joined node #" + atnID + " with connector #" + connectornode.id);
         }
       } else {


### PR DESCRIPTION
When a treenode is activated, alt-shift clicking on an existing
connector creates a link with the node postsynaptic to the connector.
This allows interface parity with creating a new connector to which
the activated node is postsynaptic by alt-shift clicking in empty
areas. Closes acardona/CATMAID#712.

I am a new contributor, so please let me know if there are any PR workflows or style guidelines to be aware of, since none are mentioned on catmaid.org. This is a minor patch but I imitated the style in existing code where appropriate.

Editing permissions enforcement is unclear w.r.t. link creation. At some places in `mc_click` in `overlay_node.js`, global permissions are checked, while in other cases granular per-node permissions are checked. However synaptic linking in `connector_mc_check` checks no permissions, whether global, for either node, or for either skeleton.
