### PR TITLE
Update h5py to 2.3.1 in pip-frozen

### DIFF
--- a/django/pip-frozen
+++ b/django/pip-frozen
@@ -1,7 +1,7 @@
 Django==1.6.5
 distribute==0.7.3
 django-devserver==0.8.0
-h5py==2.2.1
+h5py==2.3.1
 psycopg2==2.4.1
 sqlparse==0.1.3
 wsgiref==0.1.2


### PR DESCRIPTION
Building h5py <= 2.3.0 fails with the latest hdf5 (1.8.13).
This was fixed in h5py 2.3.1, see https://github.com/h5py/h5py/issues/446.
New in 2.3: http://docs.h5py.org/en/2.3/whatsnew/2.3.html
