### PR TITLE
URL to this link: blank target

### DIFF
--- a/django/applications/catmaid/templates/catmaid/index.html
+++ b/django/applications/catmaid/templates/catmaid/index.html
@@ -91,7 +91,7 @@
 				<div id="sliders_box"></div>
 				<div class="box" id="zoom_level_box"><p>zoom-level</p><div id="slider_s"></div><p>&nbsp;&nbsp;</p></div>
 				<div class="box"><p><input type="checkbox" id="displayreflines" name="displayreflines" checked="checked" /></p><p><label for="displayreflines">display reference lines</label></p></div>
-				<div class="box_right"><p><a id="a_url" name="a_url" title="This is the URL to this view. You can bookmark it or send it to the people." href="">URL to this view</a></p></div>
+				<div class="box_right"><p><a id="a_url" name="a_url" title="This is the URL to this view. You can bookmark it or send it to the people." href="" target="_blank">URL to this view</a></p></div>
 				<div class="toolbar_fill"></div>
 			</div>
 			<!--


### PR DESCRIPTION
A pragmatic "fix" for #778: Open the link in a new window/tab.
