### PR TITLE
Tests: Fix test_authentication, missing CATMAID_URL

### DIFF
--- a/django/applications/catmaid/tests/test_common_apis.py
+++ b/django/applications/catmaid/tests/test_common_apis.py
@@ -255,7 +255,7 @@ class ViewPageTests(TestCase):
     def test_authentication(self):
         # Try to access the password change view without logging in
         response = self.client.get('/user/password_change/')
-        self.assertEqual('http://testserver/accounts/login?next=/user/password_change/',
+        self.assertEqual('http://testserver/accounts/login?next=' + settings.CATMAID_URL + 'user/password_change/',
                          response['Location'])
         self.assertEqual(response.status_code, 302)
         # Now insert a fake session and expect a successful request


### PR DESCRIPTION
This adds `settings.CATMAID_URL` to the expected URL. Otherwise, the test will fail in an environment where CATMAID is set up to be accesssible via a subdirectory (and not "/").
