### PR TITLE
Removed redundant leading '/' from '/small/' in getOverviewURL for ti…

### DIFF
--- a/django/applications/catmaid/static/js/tile-source.js
+++ b/django/applications/catmaid/static/js/tile-source.js
@@ -183,7 +183,7 @@
     };
 
     this.getOverviewURL = function(stack, slicePixelPosition) {
-      return baseURL + '/small/' + slicePixelPosition[0] + '.' + fileExtension;
+      return baseURL + 'small/' + slicePixelPosition[0] + '.' + fileExtension;
     };
 
     this.getOverviewLayer = function( layer ) {


### PR DESCRIPTION
…le source 5 to make it consistent with getTileURL function.

The extra '/' has not caused trouble for true file system data but is a problem for web services.