### PR TITLE
Add gap junction connector

### DIFF
--- a/django/applications/catmaid/control/connector.py
+++ b/django/applications/catmaid/control/connector.py
@@ -634,7 +634,7 @@ def connector_user_info(request, project_id):
     treenode_id = int(request.GET.get('treenode_id'))
     connector_id = int(request.GET.get('connector_id'))
     cursor = connection.cursor()
-    relation_names = ('presynaptic_to', 'postsynaptic_to', 'abutting')
+    relation_names = ('presynaptic_to', 'postsynaptic_to', 'abutting', 'gapjunction_with')
     relations = get_relation_to_id_map(project_id, relation_names, cursor)
     relation_id = relations[request.GET.get('relation_name')]
     cursor.execute('''

--- a/django/applications/catmaid/control/connector.py
+++ b/django/applications/catmaid/control/connector.py
@@ -106,7 +106,7 @@ def _many_to_many_synapses(skids1, skids2, relation_name, project_id):
     cursor = connection.cursor()
     
     relations = get_relation_to_id_map(project_id, cursor=cursor)
-    gapjunction_id = relations.get('gapjunction_with') or -1
+    gapjunction_id = relations.get('gapjunction_with', -1)
     
     cursor.execute('''
     SELECT tc1.connector_id, c.location_x, c.location_y, c.location_z,

--- a/django/applications/catmaid/control/node.py
+++ b/django/applications/catmaid/control/node.py
@@ -275,7 +275,7 @@ def node_list_tuples_query(user, params, project_id, atnid, includeLabels, tn_pr
         # given the join with treenode_connector
         presynaptic_to = relation_map['presynaptic_to']
         postsynaptic_to = relation_map['postsynaptic_to']
-        gapjunction_with = relation_map['gapjunction_with']
+        gapjunction_with = relation_map.get('gapjunction_with', -1)
         for row in crows:
             # Collect treeenode IDs related to connectors but not yet in treenode_ids
             # because they lay beyond adjacent sections

--- a/django/applications/catmaid/control/node.py
+++ b/django/applications/catmaid/control/node.py
@@ -268,12 +268,14 @@ def node_list_tuples_query(user, params, project_id, atnid, includeLabels, tn_pr
         # so that repeated tnid entries are overwritten.
         pre = defaultdict(dict)
         post = defaultdict(dict)
+        gj = defaultdict(dict)
         other = defaultdict(dict)
 
         # Process crows (rows with connectors) which could have repeated connectors
         # given the join with treenode_connector
         presynaptic_to = relation_map['presynaptic_to']
         postsynaptic_to = relation_map['postsynaptic_to']
+        gapjunction_with = relation_map['gapjunction_with']
         for row in crows:
             # Collect treeenode IDs related to connectors but not yet in treenode_ids
             # because they lay beyond adjacent sections
@@ -290,6 +292,8 @@ def node_list_tuples_query(user, params, project_id, atnid, includeLabels, tn_pr
                     pre[cid][tnid] = row[7]
                 elif row[5] == postsynaptic_to:
                     post[cid][tnid] = row[7]
+                elif row[5] == gapjunction_with:
+                    gj[cid][tnid] = row[7]
                 else:
                     other[cid][tnid] = row[7]
 
@@ -305,6 +309,7 @@ def node_list_tuples_query(user, params, project_id, atnid, includeLabels, tn_pr
             connectors[i] = (cid, c[1], c[2], c[3], c[4],
                     [kv for kv in  pre[cid].iteritems()],
                     [kv for kv in post[cid].iteritems()],
+                    [kv for kv in   gj[cid].iteritems()],
                     [kv for kv in other[cid].iteritems()],
                     is_superuser or c[8] == user_id or c[8] in domain)
 

--- a/django/applications/catmaid/control/skeleton.py
+++ b/django/applications/catmaid/control/skeleton.py
@@ -798,7 +798,7 @@ def _skeleton_info_raw(project_id, skeletons, op):
     # Obtain partner skeletons and their info
     incoming, incoming_reviewers = _connected_skeletons(skeletons, op, relation_ids['postsynaptic_to'], relation_ids['presynaptic_to'], relation_ids['model_of'], cursor)
     outgoing, outgoing_reviewers = _connected_skeletons(skeletons, op, relation_ids['presynaptic_to'], relation_ids['postsynaptic_to'], relation_ids['model_of'], cursor)
-    gapjunctions, gapjunctions_reviewers = _connected_skeletons(skeletons, op, relation_ids['gapjunction_with'], relation_ids['gapjunction_with'], relation_ids['model_of'], cursor)
+    gapjunctions, gapjunctions_reviewers = _connected_skeletons(skeletons, op, relation_ids.get('gapjunction_with', -1), relation_ids.get('gapjunction_with', -1), relation_ids['model_of'], cursor)
 
     def prepare(partners):
         for partnerID in partners.keys():

--- a/django/applications/catmaid/control/skeleton.py
+++ b/django/applications/catmaid/control/skeleton.py
@@ -581,6 +581,11 @@ def split_skeleton(request, project_id=None):
         relation__relation_name__endswith = 'synaptic_to',
         treenode__in=change_list,
     ).update(skeleton=new_skeleton)
+    tcgj = TreenodeConnector.objects.filter(
+        relation__relation_name = 'gapjunction_with',
+        treenode__in=change_list,
+    ).update(skeleton=new_skeleton)
+    
     # setting new root treenode's parent to null
     Treenode.objects.filter(id=treenode_id).update(parent=None, editor=request.user)
 

--- a/django/applications/catmaid/control/skeleton.py
+++ b/django/applications/catmaid/control/skeleton.py
@@ -733,6 +733,7 @@ def _connected_skeletons(skeleton_ids, op, relation_id_1, relation_id_2, model_o
     WHERE t1.skeleton_id IN (%s)
       AND t1.relation_id = %s
       AND t1.connector_id = t2.connector_id
+      AND t1.id != t2.id
       AND t2.relation_id = %s
     ''' % (','.join(map(str, skeleton_ids)), int(relation_id_1), int(relation_id_2)))
 
@@ -790,12 +791,14 @@ def _skeleton_info_raw(project_id, skeletons, op):
     WHERE project_id=%s
       AND (relation_name='presynaptic_to'
         OR relation_name='postsynaptic_to'
+        OR relation_name='gapjunction_with'
         OR relation_name='model_of')''' % project_id)
     relation_ids = dict(cursor.fetchall())
 
     # Obtain partner skeletons and their info
     incoming, incoming_reviewers = _connected_skeletons(skeletons, op, relation_ids['postsynaptic_to'], relation_ids['presynaptic_to'], relation_ids['model_of'], cursor)
     outgoing, outgoing_reviewers = _connected_skeletons(skeletons, op, relation_ids['presynaptic_to'], relation_ids['postsynaptic_to'], relation_ids['model_of'], cursor)
+    gapjunctions, gapjunctions_reviewers = _connected_skeletons(skeletons, op, relation_ids['gapjunction_with'], relation_ids['gapjunction_with'], relation_ids['model_of'], cursor)
 
     def prepare(partners):
         for partnerID in partners.keys():
@@ -809,8 +812,9 @@ def _skeleton_info_raw(project_id, skeletons, op):
 
     prepare(incoming)
     prepare(outgoing)
+    prepare(gapjunctions)
 
-    return incoming, outgoing, incoming_reviewers, outgoing_reviewers
+    return incoming, outgoing, gapjunctions, incoming_reviewers, outgoing_reviewers, gapjunctions_reviewers
 
 @api_view(['POST'])
 @requires_user_role([UserRole.Annotate, UserRole.Browse])
@@ -911,13 +915,15 @@ def skeleton_info_raw(request, project_id=None):
     op = str(request.POST.get('boolean_op')) # values: AND, OR
     op = {'AND': 'AND', 'OR': 'OR'}[op] # sanitize
 
-    incoming, outgoing, incoming_reviewers, outgoing_reviewers = _skeleton_info_raw(project_id, skeletons, op)
+    incoming, outgoing, gapjunctions, incoming_reviewers, outgoing_reviewers, gapjunctions_reviewers = _skeleton_info_raw(project_id, skeletons, op)
 
     return HttpResponse(json.dumps({
                 'incoming': incoming,
                 'outgoing': outgoing,
+                'gapjunctions': gapjunctions,
                 'incoming_reviewers': incoming_reviewers,
-                'outgoing_reviewers': outgoing_reviewers}),
+                'outgoing_reviewers': outgoing_reviewers,
+                'gapjunctions_reviewers': gapjunctions_reviewers}),
             content_type='application/json')
 
 

--- a/django/applications/catmaid/control/skeletonexport.py
+++ b/django/applications/catmaid/control/skeletonexport.py
@@ -116,7 +116,7 @@ def compact_skeleton(request, project_id=None, skeleton_id=None, with_connectors
         # Fetch all connectors with their partner treenode IDs
         pre = relations['presynaptic_to']
         post = relations['postsynaptic_to']
-        gj = relations['gapjunction_with']
+        gj = relations.get('gapjunction_with', -1)
         cursor.execute('''
             SELECT tc.treenode_id, tc.connector_id, tc.relation_id,
                    c.location_x, c.location_y, c.location_z

--- a/django/applications/catmaid/control/skeletonexport.py
+++ b/django/applications/catmaid/control/skeletonexport.py
@@ -124,8 +124,8 @@ def compact_skeleton(request, project_id=None, skeleton_id=None, with_connectors
                  connector c
             WHERE tc.skeleton_id = %s
               AND tc.connector_id = c.id
-              AND (tc.relation_id = %s OR tc.relation_id = %s)
-        ''' % (skeleton_id, pre, post))
+              AND (tc.relation_id = %s OR tc.relation_id = %s OR tc.relation_id = %s)
+        ''' % (skeleton_id, pre, post, gj))
 
         connectors = tuple((row[0], row[1], 1 if row[2] == post else 0 if row[2] != gj else 2, row[3], row[4], row[5]) for row in cursor.fetchall())
 

--- a/django/applications/catmaid/control/skeletonexport.py
+++ b/django/applications/catmaid/control/skeletonexport.py
@@ -116,6 +116,7 @@ def compact_skeleton(request, project_id=None, skeleton_id=None, with_connectors
         # Fetch all connectors with their partner treenode IDs
         pre = relations['presynaptic_to']
         post = relations['postsynaptic_to']
+        gj = relations['gapjunction_with']
         cursor.execute('''
             SELECT tc.treenode_id, tc.connector_id, tc.relation_id,
                    c.location_x, c.location_y, c.location_z
@@ -126,7 +127,7 @@ def compact_skeleton(request, project_id=None, skeleton_id=None, with_connectors
               AND (tc.relation_id = %s OR tc.relation_id = %s)
         ''' % (skeleton_id, pre, post))
 
-        connectors = tuple((row[0], row[1], 1 if row[2] == post else 0, row[3], row[4], row[5]) for row in cursor.fetchall())
+        connectors = tuple((row[0], row[1], 1 if row[2] == post else 0 if row[2] != gj else 2, row[3], row[4], row[5]) for row in cursor.fetchall())
 
     if 0 != with_tags:
         # Fetch all node tags

--- a/django/applications/catmaid/control/tracing.py
+++ b/django/applications/catmaid/control/tracing.py
@@ -30,6 +30,7 @@ needed_relations = {
     'postsynaptic_to': "Something is postsynaptic to something else.",
     'annotated_with': "Something is annotated by something else.",
     'abutting': "Two things abut against each other",
+    'gapjunction_with': "Something has a gap junction with something else", 
 }
 
 def check_tracing_setup_view(request, project_id=None):

--- a/django/applications/catmaid/fixtures/catmaid_testdata.json
+++ b/django/applications/catmaid/fixtures/catmaid_testdata.json
@@ -4385,7 +4385,21 @@
       "relation_name": "postsynaptic_to", 
       "user": 1
     }
-  }, 
+  },  
+  {
+    "pk": 25, 
+    "model": "catmaid.relation", 
+    "fields": {
+      "description": null, 
+      "isreciprocal": false, 
+      "creation_time": "2010-08-26T15:21:35.859Z", 
+      "uri": null, 
+      "edition_time": "2010-08-26T15:21:35.859Z", 
+      "project": 3, 
+      "relation_name": "gapjunction_with", 
+      "user": 1
+    }
+  },
   {
     "pk": 35, 
     "model": "catmaid.relation", 

--- a/django/applications/catmaid/static/css/screen.css
+++ b/django/applications/catmaid/static/css/screen.css
@@ -611,6 +611,9 @@ div#classification_graph_object img.roiimage {
   width: 50%;
   vertical-align: top;
 }
+.connectivity_widget .table_container_half.gapjunction_visible {
+  width: 33%;
+}
 
 .connectivity_widget .table_container_wide {
   width: 100%;
@@ -619,6 +622,10 @@ div#classification_graph_object img.roiimage {
 
 .connectivity_widget .table_container_wide:last-child {
   margin-bottom: 0;
+}
+.connectivity_widget .table_container_hidden,
+.connectivity_widget .column_hidden {
+  display: none;
 }
 
 .connectivity_widget .content {

--- a/django/applications/catmaid/static/js/WindowMaker.js
+++ b/django/applications/catmaid/static/js/WindowMaker.js
@@ -2837,6 +2837,20 @@ var WindowMaker = new function()
         autoUpdateLabel.appendChild(autoUpdate);
         contentbutton.appendChild(autoUpdateLabel);
 
+        var gapjunctionToggle = document.createElement('input');
+        gapjunctionToggle.setAttribute('id', 'connectivity-gapjunctiontable-toggle-' + widgetID);
+        gapjunctionToggle.setAttribute('type', 'checkbox');
+        if (SC.showGapjunctionTable) {
+          gapjunctionToggle.setAttribute('checked', 'checked');
+        }
+        gapjunctionToggle.onchange = (function() {
+          this.showGapjunctionTable = this.checked;
+        }).bind(SC);
+        var gapjunctionLabel = document.createElement('label');
+        gapjunctionLabel.appendChild(document.createTextNode('Show gap junctions'));
+        gapjunctionLabel.appendChild(gapjunctionToggle);
+        contentbutton.appendChild(gapjunctionLabel);
+
         content.appendChild( contentbutton );
 
         var container = createContainer( "connectivity_widget" + widgetID );

--- a/django/applications/catmaid/static/js/tools/tracingtool.js
+++ b/django/applications/catmaid/static/js/tools/tracingtool.js
@@ -404,6 +404,8 @@
                     clearTopbars('Connector ' + node.id + ' (no presynatpic partner)');
                   }
                 }));
+          } else if (SkeletonAnnotations.SUBTYPE_GAPJUNCTION_CONNECTOR === node.subtype) {
+            clearTopbars('Gap junction connector #' + node.id);
           } else {
             clearTopbars('Abutting connector #' + node.id);
           }

--- a/django/applications/catmaid/static/js/widgets/3dviewer.js
+++ b/django/applications/catmaid/static/js/widgets/3dviewer.js
@@ -1714,9 +1714,12 @@
                         todo:      new THREE.MeshBasicMaterial({color: 0xff0000, opacity:0.6, transparent: true}),
                         custom:    new THREE.MeshBasicMaterial({color: 0xaa70ff, opacity:0.6, transparent: true})};
     this.textGeometryCache = new WebGLApplication.prototype.Space.prototype.TextGeometryCache();
-    this.synapticColors = [new THREE.MeshBasicMaterial( { color: 0xff0000, opacity:0.6, transparent:false  } ), new THREE.MeshBasicMaterial( { color: 0x00f6ff, opacity:0.6, transparent:false  } )];
+    this.synapticColors = [new THREE.MeshBasicMaterial( { color: 0xff0000, opacity:0.6, transparent:false } ), 
+                           new THREE.MeshBasicMaterial( { color: 0x00f6ff, opacity:0.6, transparent:false } ),
+                           new THREE.MeshBasicMaterial( { color: 0x9f25c2, opacity:0.6, transparent:false } )];
     this.connectorLineColors = {'presynaptic_to': new THREE.LineBasicMaterial({color: 0xff0000, opacity: 1.0, linewidth: 6}),
-                                'postsynaptic_to': new THREE.LineBasicMaterial({color: 0x00f6ff, opacity: 1.0, linewidth: 6})};
+                                'postsynaptic_to': new THREE.LineBasicMaterial({color: 0x00f6ff, opacity: 1.0, linewidth: 6}),
+                                'gapjunction_with': new THREE.LineBasicMaterial({color: 0x9f25c2, opacity: 1.0, linewidth: 6})};
   };
 
   WebGLApplication.prototype.Space.prototype.StaticContent.prototype = {};
@@ -1751,6 +1754,7 @@
     }, this);
     this.synapticColors[0].dispose();
     this.synapticColors[1].dispose();
+    this.synapticColors[2].dispose();
   };
 
   WebGLApplication.prototype.Space.prototype.StaticContent.prototype.createBoundingBox = function(stack) {
@@ -3059,8 +3063,8 @@
 
   WebGLApplication.prototype.Space.prototype.Skeleton.prototype = {};
 
-  WebGLApplication.prototype.Space.prototype.Skeleton.prototype.CTYPES = ['neurite', 'presynaptic_to', 'postsynaptic_to'];
-  WebGLApplication.prototype.Space.prototype.Skeleton.prototype.synapticTypes = ['presynaptic_to', 'postsynaptic_to'];
+  WebGLApplication.prototype.Space.prototype.Skeleton.prototype.CTYPES = ['neurite', 'presynaptic_to', 'postsynaptic_to', 'gapjunction_with'];
+  WebGLApplication.prototype.Space.prototype.Skeleton.prototype.synapticTypes = ['presynaptic_to', 'postsynaptic_to', 'gapjunction_with'];
 
   WebGLApplication.prototype.Space.prototype.Skeleton.prototype.initialize_objects = function(options) {
     this.visible = true;
@@ -3076,11 +3080,13 @@
     this.geometry[CTYPES[0]] = new THREE.Geometry();
     this.geometry[CTYPES[1]] = new THREE.Geometry();
     this.geometry[CTYPES[2]] = new THREE.Geometry();
+    this.geometry[CTYPES[3]] = new THREE.Geometry();
 
         this.actor = {}; // has three keys (the CTYPES), each key contains the edges of each type
         this.actor[CTYPES[0]] = new THREE.LineSegments(this.geometry[CTYPES[0]], this.line_material);
         this.actor[CTYPES[1]] = new THREE.LineSegments(this.geometry[CTYPES[1]], this.space.staticContent.connectorLineColors[CTYPES[1]]);
         this.actor[CTYPES[2]] = new THREE.LineSegments(this.geometry[CTYPES[2]], this.space.staticContent.connectorLineColors[CTYPES[2]]);
+        this.actor[CTYPES[3]] = new THREE.LineSegments(this.geometry[CTYPES[3]], this.space.staticContent.connectorLineColors[CTYPES[3]]);
 
     this.specialTagSpheres = {};
     this.synapticSpheres = {};
@@ -3113,6 +3119,7 @@
     // Dispose only of the geometries. Materials for connectors are shared
     this.actor[this.CTYPES[1]].geometry.dispose();
     this.actor[this.CTYPES[2]].geometry.dispose();
+    this.actor[this.CTYPES[3]].geometry.dispose();
 
     [this.actor, this.synapticSpheres, this.radiusVolumes,
      this.specialTagSpheres].forEach(function(ob) {
@@ -4129,6 +4136,7 @@
     this.connectorgeometry = {};
     this.connectorgeometry[this.CTYPES[1]] = new THREE.Geometry();
     this.connectorgeometry[this.CTYPES[2]] = new THREE.Geometry();
+    this.connectorgeometry[this.CTYPES[3]] = new THREE.Geometry();
 
     this.synapticTypes.forEach(function(type) {
       // Vertices is an array of Vector3, every two a pair, the first at the connector and the second at the node

--- a/django/applications/catmaid/static/js/widgets/connectivity.js
+++ b/django/applications/catmaid/static/js/widgets/connectivity.js
@@ -560,7 +560,7 @@
      * threshold columns.
      */
     var gapjunctionTable = function(visible) {
-      gapjunctions.toggleClass('table_container_hidden', !visible)
+      gapjunctions.toggleClass('table_container_hidden', !visible);
       incoming.toggleClass('gapjunction_visible', visible);
       outgoing.toggleClass('gapjunction_visible', visible);
       gapjunctions.toggleClass('gapjunction_visible', visible);

--- a/django/applications/catmaid/static/js/widgets/overlay.js
+++ b/django/applications/catmaid/static/js/widgets/overlay.js
@@ -1694,7 +1694,7 @@ SkeletonAnnotations.TracingOverlay.prototype.createGapjunctionTreenode = functio
     return;
   }
   this.createTreenodeWithLink(connectorID, phys_x, phys_y, phys_z, radius, 
-      confidence, pos_x, pos_y, pos_z, "gapjunction_with", afterCreate)
+      confidence, pos_x, pos_y, pos_z, "gapjunction_with", afterCreate);
 };
 
 /**

--- a/django/applications/catmaid/static/js/widgets/overlay_node.js
+++ b/django/applications/catmaid/static/js/widgets/overlay_node.js
@@ -1348,7 +1348,7 @@
                 CATMAID.error("The selected connector is of unknown type: " + connectornode.subtype);
                 return;
               }
-              catmaidTracingOverlay.createLink(atnID, connectornode.id, linkType, function() { alert(1)});
+              catmaidTracingOverlay.createLink(atnID, connectornode.id, linkType);
               CATMAID.statusBar.replaceLast("Joined node #" + atnID + " with connector #" + connectornode.id);
             }
           } else {

--- a/django/applications/catmaid/static/js/widgets/overlay_node.js
+++ b/django/applications/catmaid/static/js/widgets/overlay_node.js
@@ -1538,7 +1538,7 @@
         } else {
           var def;
           if (is_pre == 2) def = 'markerArrowGj';
-          else if (is_pre == 1) def = 'markerArrowPre'
+          else if (is_pre == 1) def = 'markerArrowPre';
           else def = 'markerArrowPost';
           opts['marker-end'] = 'url(#' + def + this.hrefSuffix + ')';
         }

--- a/django/applications/catmaid/tests/test_common_apis.py
+++ b/django/applications/catmaid/tests/test_common_apis.py
@@ -2199,7 +2199,9 @@ class ViewPageTests(TestCase):
             "outgoing": {"361": {"skids": {"235": [0, 0, 0, 0, 1]}, "num_nodes": 9},
                          "373": {"skids": {"235": [0, 0, 0, 0, 2]}, "num_nodes": 5}},
             "incoming": {"235": {"skids": {"373": [0, 0, 0, 0, 2]}, "num_nodes": 28}},
-            "incoming_reviewers": []}
+            "incoming_reviewers": [],
+            "gapjunctions": {},
+            "gapjunctions_reviewers": []}
         self.assertEqual(expected_result, parsed_response)
 
         # Test for conjunctive connectivity.
@@ -2214,7 +2216,9 @@ class ViewPageTests(TestCase):
             "outgoing_reviewers": [],
             "outgoing": {},
             "incoming": {},
-            "incoming_reviewers": []}
+            "incoming_reviewers": [],
+            "gapjunctions": {},
+            "gapjunctions_reviewers": []}
         self.assertEqual(expected_result, parsed_response)
 
     def test_treenode_info_nonexisting_treenode_failure(self):
@@ -2994,7 +2998,7 @@ class ViewPageTests(TestCase):
                 [2423, 2415, 4140, 6460, 0, 5, -1, 2411, True],
         ]
         expected_c_result = [
-                [2400, 3400, 5620, 0, 5, [[2394, 5], [2415, 5]], [[2374, 5]], [], True],
+                [2400, 3400, 5620, 0, 5, [[2394, 5], [2415, 5]], [[2374, 5]], [], [], True],
         ]
         response = self.client.post('/%d/node/list' % (self.test_project_id,), {
             'z1': 0,
@@ -3037,8 +3041,8 @@ class ViewPageTests(TestCase):
                 [2423, 2415, 4140, 6460, 0, 5, -1, 2411, 3]
         ]
         expected_c_result = [
-                [356, 6730.0, 2700.0, 0.0, 5, [[285, 5]], [[377, 5], [367, 5]], [], True],
-                [421, 6260.0, 3990.0, 0.0, 5, [[415, 5]], [[409, 5]], [], True]
+                [356, 6730.0, 2700.0, 0.0, 5, [[285, 5]], [[377, 5], [367, 5]], [], [], True],
+                [421, 6260.0, 3990.0, 0.0, 5, [[415, 5]], [[409, 5]], [], [], True]
         ]
 
         response = self.client.post('/%d/node/list' % (self.test_project_id,), {


### PR DESCRIPTION
This adds a basic gap junction connector, which is compatible with the 3D Viewer and Connectivity widget. Gap junctions are currently ignored by all other widgets. The feature does not affect any current functions and does not clutter the compatible widgets (only adds one "show gap junctions" checkbox to the Connectivity widget). Gap junctions are added using the alt Key alone, as it did not previously have any functions (shift+alt and other combinations still work as previously).

We would like to use this feature to annotate and analyse gap junctions in _C. elegans_ serial electron microscopy data sets, where gap junctions are visible and essential for neuronal circuit functions. We hope that you agree with our additions, as it would help everyone in the _C. elegans_ community using CATMAID.

The feature has previously been suggested in [catmaid/CATMAID#333](https://github.com/catmaid/CATMAID/issues/333).