### PR TITLE
Fixed minor issues with gap junction connectors

### DIFF
--- a/django/applications/catmaid/control/skeletonexport.py
+++ b/django/applications/catmaid/control/skeletonexport.py
@@ -126,8 +126,10 @@ def compact_skeleton(request, project_id=None, skeleton_id=None, with_connectors
               AND tc.connector_id = c.id
               AND (tc.relation_id = %s OR tc.relation_id = %s OR tc.relation_id = %s)
         ''' % (skeleton_id, pre, post, gj))
+        
+        relation_index = {pre: 0, post: 1, gj: 2}
 
-        connectors = tuple((row[0], row[1], 1 if row[2] == post else 0 if row[2] != gj else 2, row[3], row[4], row[5]) for row in cursor.fetchall())
+        connectors = tuple((row[0], row[1], relation_index.get(row[2], -1), row[3], row[4], row[5]) for row in cursor.fetchall())
 
     if 0 != with_tags:
         # Fetch all node tags

--- a/django/applications/catmaid/static/js/WindowMaker.js
+++ b/django/applications/catmaid/static/js/WindowMaker.js
@@ -331,11 +331,11 @@ var WindowMaker = new function()
           '<tr>' +
             '<th>Connector</th>' +
             '<th>Node 1</th>' +
-            '<th>Presyn. neuron</th>' +
+            '<th class="typeheader">Presyn. neuron</th>' +
             '<th>C 1</th>' +
             '<th>Creator 1</th>' +
             '<th>Node 2</th>' +
-            '<th>Postsyn. neuron</th>' +
+            '<th class="typeheader">Postsyn. neuron</th>' +
             '<th>C 2</th>' +
             '<th>Creator 2</th>' +
           '</tr>' +
@@ -344,11 +344,11 @@ var WindowMaker = new function()
           '<tr>' +
             '<th>Connector</th>' +
             '<th>Node 1</th>' +
-            '<th>Presyn. neuron</th>' +
+            '<th class="typeheader">Presyn. neuron</th>' +
             '<th>C 1</th>' +
             '<th>Creator 1</th>' +
             '<th>Node 2</th>' +
-            '<th>Postsyn. neuron</th>' +
+            '<th class="typeheader">Postsyn. neuron</th>' +
             '<th>C 2</th>' +
             '<th>Creator 2</th>' +
           '</tr>' +

--- a/django/applications/catmaid/static/js/WindowMaker.js
+++ b/django/applications/catmaid/static/js/WindowMaker.js
@@ -331,11 +331,11 @@ var WindowMaker = new function()
           '<tr>' +
             '<th>Connector</th>' +
             '<th>Node 1</th>' +
-            '<th class="typeheader">Presyn. neuron</th>' +
+            '<th class="preheader">Presyn. neuron</th>' +
             '<th>C 1</th>' +
             '<th>Creator 1</th>' +
             '<th>Node 2</th>' +
-            '<th class="typeheader">Postsyn. neuron</th>' +
+            '<th class="postheader">Postsyn. neuron</th>' +
             '<th>C 2</th>' +
             '<th>Creator 2</th>' +
           '</tr>' +
@@ -344,11 +344,11 @@ var WindowMaker = new function()
           '<tr>' +
             '<th>Connector</th>' +
             '<th>Node 1</th>' +
-            '<th class="typeheader">Presyn. neuron</th>' +
+            '<th class="preheader">Presyn. neuron</th>' +
             '<th>C 1</th>' +
             '<th>Creator 1</th>' +
             '<th>Node 2</th>' +
-            '<th class="typeheader">Postsyn. neuron</th>' +
+            '<th class="postheader">Postsyn. neuron</th>' +
             '<th>C 2</th>' +
             '<th>Creator 2</th>' +
           '</tr>' +

--- a/django/applications/catmaid/static/js/widgets/3dviewer.js
+++ b/django/applications/catmaid/static/js/widgets/3dviewer.js
@@ -4354,9 +4354,10 @@
     connectors.forEach(function(con) {
       // con[0]: treenode ID
       // con[1]: connector ID
-      // con[2]: 0 for pre, 1 for post
+      // con[2]: 0 for pre, 1 for post, 2 for gap junction, -1 for other to be skipped
       // indices 3,4,5 are x,y,z for connector
       // indices 4,5,6 are x,y,z for node
+      if (con[2] === -1) return;
       var v1 = new THREE.Vector3(con[3], con[4], con[5]);
       v1.node_id = con[1];
       var v2 = vs[con[0]];

--- a/django/applications/catmaid/static/js/widgets/connectorselection.js
+++ b/django/applications/catmaid/static/js/widgets/connectorselection.js
@@ -22,9 +22,21 @@
             alert(json.error);
             return;
           }
-          var text = 'Synapses ' + ('presynaptic_to' === relation ? 'post' : 'pre') +
-              'synaptic to neuron' + (skids1.length > 1 ? 's' : '') + ' ' + skids1.map(CATMAID.NeuronNameService.getInstance().getName).join(', ');
-          show_table(text, json);
+          var text;
+          if ('presynaptic_to' === relation) {
+            text = 'Synapses presynaptic to';
+          } else if ('postsynaptic_to' === relation) {
+            text = 'Synapses postsynaptic to';
+          } else if ('gapjunction_with' === relation) {
+            text = 'Gap junctions with';
+          }
+          if (text !== undefined) {
+            text += ' neuron' + (skids1.length > 1 ? 's' : '') + ' '
+                 + skids1.map(CATMAID.NeuronNameService.getInstance().getName).join(', ');
+            show_table(text, json, relation);
+          } else {
+            alert('Unsupported relation: ' + relation);
+          }
         });
   };
 
@@ -100,10 +112,21 @@
     });
   };
 
-  var show_table = function(header, connectors) {
+  var show_table = function(header, connectors, relation) {
     WindowMaker.show('create-connector-selection');
     // Write the label
     $('#connector-selection-label').text(header);
+    
+    // Set proper table titles
+    if (relation == 'presynaptic_to' || relation == 'postsynaptic_to' || relation === undefined) {
+      $('#connectorselectiontable th.typeheader').html(function() {
+        return $(this).html().replace("Neuron 1", "Presyn. neuron").replace("Neuron 2", "Postsyn. neuron");
+      });
+    } else {
+      $('#connectorselectiontable th.typeheader').html(function() {
+        return $(this).html().replace("Presyn. neuron", "Neuron 1").replace("Postsyn. neuron", "Neuron 2");
+      });
+    }
 
     // Split up the JSON reply
     var locations = {}; // keys are connector IDs

--- a/django/applications/catmaid/static/js/widgets/connectorselection.js
+++ b/django/applications/catmaid/static/js/widgets/connectorselection.js
@@ -118,15 +118,21 @@
     $('#connector-selection-label').text(header);
     
     // Set proper table titles
+    var titles;
     if (relation == 'presynaptic_to' || relation == 'postsynaptic_to' || relation === undefined) {
-      $('#connectorselectiontable th.typeheader').html(function() {
-        return $(this).html().replace("Neuron 1", "Presyn. neuron").replace("Neuron 2", "Postsyn. neuron");
-      });
+      titles = ['Presyn. neuron', 'Postsyn. neuron'];
     } else {
-      $('#connectorselectiontable th.typeheader').html(function() {
-        return $(this).html().replace("Presyn. neuron", "Neuron 1").replace("Postsyn. neuron", "Neuron 2");
-      });
+      titles = ['Neuron 1', 'Neuron 2'];
     }
+    $('#connectorselectiontable thead th.preheader div').html(function() {
+      return titles[0] + $(this).children()[0].outerHTML;
+    });
+    $('#connectorselectiontable thead th.postheader div').html(function() {
+      return titles[1] + $(this).children()[0].outerHTML;
+    });
+    $('#connectorselectiontable tfoot th.preheader').html(titles[0]);
+    $('#connectorselectiontable tfoot th.postheader').html(titles[1]);
+
 
     // Split up the JSON reply
     var locations = {}; // keys are connector IDs

--- a/django/applications/catmaid/static/js/widgets/morphology_analysis.js
+++ b/django/applications/catmaid/static/js/widgets/morphology_analysis.js
@@ -120,7 +120,10 @@ MorphologyPlot.prototype.append = function(models) {
       function(skeleton_id) { return {}; }, // post
       (function(skeleton_id, json) {
         this.lines[skeleton_id] = {nodes: json[0],
-                                   connectors: json[1]};
+                                   connectors: json[1].filter(function(con) {
+                                     // Filter out non-synaptic connections
+                                     return con[2] === 0 || con[2] === 1;
+                                   })};
       }).bind(this),
       (function(skeleton_id) {
         // Failed loading

--- a/django/applications/catmaid/static/libs/catmaid/arbor_parser.js
+++ b/django/applications/catmaid/static/libs/catmaid/arbor_parser.js
@@ -74,8 +74,10 @@
     var io = [{count: 0},
               {count: 0}];
     for (var i=0; i<rows.length; ++i) {
-      var row = rows[i],
-          t = io[row[2]], // 2: type: 0 for pre, 1 for post
+      var row = rows[i];
+      // Skip non-synaptic connectors
+      if (row[2] !== 0 && row[2] !== 1) continue;
+      var t = io[row[2]], // 2: type: 0 for pre, 1 for post
           node = row[0], // 0: ID
           count = t[node];
       if (count) t[node] = count + 1;

--- a/django/applications/catmaid/templates/catmaid/exportwidget.html
+++ b/django/applications/catmaid/templates/catmaid/exportwidget.html
@@ -351,6 +351,8 @@
                 });
                 // Parse connector objects
                 json[1].forEach(function (cn) {
+                  // Skip non-synaptic connectors
+                  if (cn[2] !== 0 && cn[2] !== 1) return;
                   var id = cn[1];
                   if (typeof skeleton.connectors[id] === 'undefined') {
                     skeleton.connectors[id] = {};


### PR DESCRIPTION
Attempt to fix issues brought up by @acardona in [#1261](https://github.com/catmaid/CATMAID/pull/1261#issuecomment-172017632): 
1) Adds proper titles to the connector selection table when gap junction connectors are listed.
2) Fixes all places where gap junctions were interpreted erroneously as postsynaptic connections.