### PR TITLE
Fix titles in connector table for pre/post neurons

### DIFF
--- a/django/applications/catmaid/static/js/widgets/connectorselection.js
+++ b/django/applications/catmaid/static/js/widgets/connectorselection.js
@@ -24,9 +24,9 @@
           }
           var text;
           if ('presynaptic_to' === relation) {
-            text = 'Synapses presynaptic to';
-          } else if ('postsynaptic_to' === relation) {
             text = 'Synapses postsynaptic to';
+          } else if ('postsynaptic_to' === relation) {
+            text = 'Synapses presynaptic to';
           } else if ('gapjunction_with' === relation) {
             text = 'Gap junctions with';
           }


### PR DESCRIPTION
* see https://github.com/catmaid/CATMAID/commit/bcc7ee4901adf752bcc160c4adbcf6600b678296#commitcomment-19687097 for the origin of the switch.