### PR TITLE
fix off by 1 error in user analytics default month

### DIFF
--- a/django/applications/catmaid/templates/catmaid/useranalytics.html
+++ b/django/applications/catmaid/templates/catmaid/useranalytics.html
@@ -125,11 +125,11 @@ End date: <input type="text" id="end_date" />
 
 		var start_date = $("#start_date");
 		start_date.datepicker();
-		start_date.val(back.getMonth() + "/" + back.getDate() + "/" + back.getFullYear());
+		start_date.val((back.getMonth() + 1) + "/" + back.getDate() + "/" + back.getFullYear());
 
 		var end_date = $("#end_date");
 		end_date.datepicker();
-		end_date.val(today.getMonth() + "/" + today.getDate() + "/" + today.getFullYear());
+		end_date.val((today.getMonth() + 1) + "/" + today.getDate() + "/" + today.getFullYear());
   });
 
 </script>


### PR DESCRIPTION
* getMonth() returns a month in the range 0-11 but date picker must be
  expecting 1-12 since the default is always a month off.
* see http://www.w3schools.com/jsref/jsref_getmonth.asp
* same deal with https://github.com/catmaid/CATMAID/blame/5ed4d560218afc62f6b3895b0cdeae984b467e49/django/applications/catmaid/templates/catmaid/userproficiency.html#L156-L160