### PR TITLE
Tracing overlay node list response caching

### DIFF
--- a/django/applications/catmaid/static/libs/catmaid/lru-cache.js
+++ b/django/applications/catmaid/static/libs/catmaid/lru-cache.js
@@ -1,0 +1,94 @@
+/* -*- mode: espresso; espresso-indent-level: 2; indent-tabs-mode: nil -*- */
+/* vim: set softtabstop=2 shiftwidth=2 tabstop=2 expandtab: */
+
+(function (CATMAID) {
+
+  "use strict";
+
+  /**
+   * A least-recently used, limited lifetime cache of key-value pairs.
+   *
+   * This cache is designed to be simple and generic. Consequently it prefers
+   * clarity over performance and is not suitable for use in tight loops or
+   * with large capacities.
+   *
+   * @param {number}  capacity Size of the cache.
+   * @param {number=} lifetime Lifetime for cache entries in ms (optional).
+   */
+  function LRUCache(capacity, lifetime) {
+    this.capacity = capacity;
+    this.lifetime = lifetime ? lifetime : Infinity;
+    this.resetLifetimeOnHit = false;
+    this._store = [];
+  }
+
+  /**
+   * Get a cached value from the cache by its key.
+   *
+   * @param  {Object} key
+   * @return {Object}     Value if a valid hit was in the cache, else undefined.
+   */
+  LRUCache.prototype.get = function (key) {
+    var now = Date.now();
+    for (var i = 0; i < this._store.length; ++i) {
+      var entry = this._store[i];
+
+      if (entry && entry.key === key) {
+        this._store.splice(i, 1);
+
+        if (now - entry.timestamp <= this.lifetime) {
+          // Value is valid. Move it to top of the cache.
+          if (this.resetLifetimeOnHit) entry.timestamp = now;
+          this._store.unshift(entry);
+          return entry.value;
+        } else {
+          // Value is expired. Leave it out of the cache and return undefined.
+          return;
+        }
+      }
+    }
+  };
+
+  /**
+   * Set a cached value in the cache by its key.
+   *
+   * @param {Object} key
+   * @param {Object} value
+   */
+  LRUCache.prototype.set = function (key, value) {
+    this.delete(key);
+    var entry = {
+      key: key,
+      value: value,
+      timestamp: Date.now()
+    };
+    this._store.unshift(entry);
+    if (this._store.length > this.capacity) this._store.length = this.capacity;
+  };
+
+  /**
+   * Delete a cache entry. If it does not exist, do nothing.
+   *
+   * @param  {Object} key
+   */
+  LRUCache.prototype.delete = function (key) {
+   for (var i = 0; i < this._store.length; ++i) {
+      var entry = this._store[i];
+
+      if (entry && entry.key === key) {
+        this._store.splice(i, 1);
+        return;
+      }
+    }
+  };
+
+  /**
+   * Clear all entries from the cache.
+   */
+  LRUCache.prototype.clear = function () {
+    this._store.length = 0;
+  };
+
+  CATMAID.LRUCache = LRUCache;
+
+})(CATMAID);

--- a/django/applications/catmaid/static/libs/catmaid/models/labels.js
+++ b/django/applications/catmaid/static/libs/catmaid/models/labels.js
@@ -61,6 +61,7 @@
       };
 
       return CATMAID.fetch(url, 'POST', params).then(function(json) {
+        CATMAID.Labels.trigger(CATMAID.Labels.EVENT_NODE_LABELS_CHANGED, nodeId);
         if (json.warning) {
           CATMAID.warn(json.warning);
         }
@@ -86,12 +87,16 @@
     remove: function(projectId, nodeId, nodeType, label) {
       var url = projectId + '/label/' + nodeType + '/' + nodeId + '/remove';
       return CATMAID.fetch(url, 'POST', {tag: label}).then(function(json) {
+        CATMAID.Labels.trigger(CATMAID.Labels.EVENT_NODE_LABELS_CHANGED, nodeId);
         return {
           'deletedLabels': [label],
         };
       });
     },
   };
+
+  Labels.EVENT_NODE_LABELS_CHANGED = "node_labels_changed";
+  CATMAID.asEventSource(Labels);
 
   // Export labels namespace into CATMAID namespace
   CATMAID.Labels = Labels;

--- a/django/applications/catmaid/static/libs/catmaid/models/labels.js
+++ b/django/applications/catmaid/static/libs/catmaid/models/labels.js
@@ -74,7 +74,7 @@
     },
 
     /**
-     * Remoave a label from a specific node.
+     * Remove a label from a specific node.
      *
      * @param {integer} projectId The project the node is part of
      * @param {integer} nodeId    Id of node
@@ -104,7 +104,7 @@
   /**
    * Add a tag to the active treenode. If undo is called the tag set is
    * restored that existed for this node just before the new tag was added.
-   * This information will only be aquired if the command is executed.
+   * This information will only be acquired if the command is executed.
    */
   CATMAID.AddTagsToNodeCommand = CATMAID.makeCommand(function(projectId, nodeId, nodeType,
         tags, deleteExisting) {
@@ -174,7 +174,7 @@
 
       // If the list of added tags is empty, undo will do nothing. This can
       // happen due to multiple reasons, e.g. lack of permissions or the tag
-      // existed before. Othewise, remove all added tags.
+      // existed before. Otherwise, remove all added tags.
       var addLabel = (command._deletedLabels.length === 0) ? Promise.resolve() :
           CATMAID.Labels.update(projectId, nodeId, nodeType, command._deletedLabels);
 

--- a/django/applications/catmaid/static/libs/catmaid/models/nodes.js
+++ b/django/applications/catmaid/static/libs/catmaid/models/nodes.js
@@ -61,6 +61,7 @@
       };
 
       return CATMAID.fetch(url, 'POST', params).then(function(json) {
+        this.trigger(CATMAID.Nodes.EVENT_NODE_RADIUS_CHANGED, json.updated_nodes);
         return {
           // An object mapping node IDs to their old and new radius is returned.
           'updatedNodes': json.updated_nodes,


### PR DESCRIPTION
A dead simple, dumb cache for node queries that is invalidated by any and all modifying actions. Can finally jump back and forth a few sections @ 40 FPS without holding spacebar :tada:

Tiny branch, but submitting as a PR so @tomka can be the second set of eyes on the invalidation events as we discussed.