### PR TITLE
Stack viewer: Make scale bar visibility programmatically accessible

### DIFF
--- a/django/applications/catmaid/static/js/layers/layer-control.js
+++ b/django/applications/catmaid/static/js/layers/layer-control.js
@@ -55,12 +55,12 @@
         .append($('<label/>').append(navcb).append('Navigate with project'));
     $view.append(navlabel);
 
-    var benchmark = $view.siblings('.sliceBenchmark');
     var cb = $('<input/>')
         .attr('type', 'checkbox')
-        .prop('checked', benchmark.is(':visible'))
+        .prop('checked', stackViewer.showScaleBar)
         .change(function () {
-          $view.siblings('.sliceBenchmark').toggle();
+          stackViewer.showScaleBar = this.checked;
+          stackViewer.updateScaleBar();
         });
     var label = $('<div/>')
         .addClass('setting')

--- a/django/applications/catmaid/static/js/stack-viewer.js
+++ b/django/applications/catmaid/static/js/stack-viewer.js
@@ -48,6 +48,7 @@
     this.old_scale = this.scale;
 
     this.navigateWithProject = true;
+    this.showScaleBar = true;
 
     this._tool = null;
     this._layers = new Map();
@@ -93,6 +94,7 @@
     this._scaleBar.appendChild( document.createElement( "p" ) );
     this._scaleBar.firstChild.appendChild( document.createElement( "span" ) );
     this._scaleBar.firstChild.firstChild.appendChild( document.createTextNode( "test" ) );
+    this._scaleBar.style.display = this.showScaleBar ? 'initial' : 'none';
     this._view.appendChild( this._scaleBar );
 
     var controlToggle = document.createElement( "div" );
@@ -140,6 +142,7 @@
    * update the scale bar (x-resolution) to a proper size
    */
   StackViewer.prototype.updateScaleBar = function () {
+    this._scaleBar.style.display = this.showScaleBar ? 'initial' : 'none';
     var meter = this.scale / this.primaryStack.resolution.x;
     var width = 0;
     var text = "";


### PR DESCRIPTION
Previously, the scale bar (slice benchmark)'s visibility was not controlled by the stack viewer and was not programmatically accessible. In order for other code to control the scale bar visibility, it had to go digging through the layer control elements and manually trigger the checkbox. This adds a boolean to the stack-viewer which allows other code to manage the visibility.

I had a Ctrl+f and didn't find any other files which needed to access it, so I don't think this should break anything.