### PR TITLE
Tag Table: label deduplication and manual cache refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@
 
 ### Features and enhancements
 
+Connector Viewer:
+
+- A new tool used to view the connectors associated with a skeleton set
+  of skeletons.
+
+- Shows a grid of mini stack viewers with their own tracing overlays,
+  focused on connectors associated with the skeleton by a user-selected
+  relation (i.e. outgoing, incoming, gap junction or other).
+
+- Connectors can be sorted by their absolute or proportional depth on
+  their respective skeleton trees, by the connector ID or by the
+  skeleton name.
+
+- Mini stack viewers can inherit settings from a user-defined main stack
+  viewer; users can focus the main stack viewer on any connector by
+  clicking on its ID in the mini stack viewer title bar.
+
+- Users can open a connector table from a connector viewer and vice
+  versa.
+
+- Accessible with Ctrl+Space 'connector-viewer'.
+
+
 Connectivity table:
 
 - Original colors of skeletons added to a Connectivity Table can now optionally
@@ -86,6 +109,12 @@ Miscellaneous:
   down.
 
 - 3D viewer: partner node spheres are now also shown for restricted connectors.
+
+- Multiple stack viewers no longer use the same ID to make requests to
+  the database.
+
+- The connector table can now be used as a skeleton source, where
+  previously an error would be raised.
 
 
 ## 2016.12.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,9 @@ Miscellaneous:
 - The connector table can now be used as a skeleton source, where
   previously an error would be raised.
 
+- The tag table now collapses any tags with identical names, but as a
+  consequence does not show the tag ID (as there may be multiple IDs)
+
 
 ## 2016.12.16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ Miscellaneous:
   Now always only one undo step will be done per single Ctrl-Z click if not hold
   down.
 
+- 3D viewer: partner node spheres are now also shown for restricted connectors.
+
 
 ## 2016.12.16
 

--- a/django/applications/catmaid/static/css/stack.css
+++ b/django/applications/catmaid/static/css/stack.css
@@ -341,6 +341,20 @@ div.stackControlToggle_hidden {
   background-color: #853c00;
 }
 
+.stackViewer p.sort-val {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: auto;
+  border: none;
+  margin: 0;
+  padding: 3px 6px 3px 6px;
+  vertical-align: bottom;
+  z-index: 7;
+  color: #ffffff;
+  background-color: #850084;
+}
+
 .stackViewer p.neuronname:empty {
   display: none;
 }

--- a/django/applications/catmaid/static/css/stack.css
+++ b/django/applications/catmaid/static/css/stack.css
@@ -327,6 +327,20 @@ div.stackControlToggle_hidden {
   background-color: #060;
 }
 
+.stackViewer p.assoc-neuron-name {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: auto;
+  border: none;
+  margin: 0;
+  padding: 3px 6px 3px 6px;
+  vertical-align: bottom;
+  z-index: 7;
+  color: #ffffff;
+  background-color: #853c00;
+}
+
 .stackViewer p.neuronname:empty {
   display: none;
 }

--- a/django/applications/catmaid/static/js/extensions.js
+++ b/django/applications/catmaid/static/js/extensions.js
@@ -17,7 +17,7 @@
  */
 Set.prototype.difference = function(iterable) {
   var difference = new Set(this);
-  for (let item of iterable) {
+  for (var item of iterable) {
     difference.delete(item);
   }
   return difference;
@@ -30,7 +30,7 @@ Set.prototype.difference = function(iterable) {
  * @returns {Set}
  */
 Set.prototype.addAll = function(iterable) {
-  for (let item of iterable) {
+  for (var item of iterable) {
     this.add(item);
   }
   return this;
@@ -44,7 +44,7 @@ Set.prototype.addAll = function(iterable) {
  */
 Set.prototype.intersection = function(iterable) {
   var intersection = new Set();
-  for (let item of iterable) {
+  for (var item of iterable) {
     if (this.has(item)) {
       intersection.add(item);
     }

--- a/django/applications/catmaid/static/js/extensions.js
+++ b/django/applications/catmaid/static/js/extensions.js
@@ -5,6 +5,52 @@
  * This file is a place for small global extensions of libraries used by CATMAID.
  */
 
+/**
+ * Set prototype extensions
+ */
+
+/**
+ * Return a new set of those items which exist in this set, but not in the given 'of'-able iterable.
+ *
+ * @param iterable
+ * @returns {Set}
+ */
+Set.prototype.difference = function(iterable) {
+  var difference = new Set(this);
+  for (let item of iterable) {
+    difference.delete(item);
+  }
+  return difference;
+};
+
+/**
+ * Add all of the items in a given 'of'-able iterable to this set in-place, and return this set (for chaining purposes).
+ *
+ * @param iterable
+ * @returns {Set}
+ */
+Set.prototype.addAll = function(iterable) {
+  for (let item of iterable) {
+    this.add(item);
+  }
+  return this;
+};
+
+/**
+ * Return a new set of those items which exist in both this set and the given 'of'-able iterable.
+ *
+ * @param iterable
+ * @returns {Set}
+ */
+Set.prototype.intersection = function(iterable) {
+  var intersection = new Set();
+  for (let item of iterable) {
+    if (this.has(item)) {
+      intersection.add(item);
+    }
+  }
+  return intersection;
+};
 
 /**
  * jQuery DataTables extensions

--- a/django/applications/catmaid/static/js/extensions.js
+++ b/django/applications/catmaid/static/js/extensions.js
@@ -53,6 +53,18 @@ Set.prototype.intersection = function(iterable) {
 };
 
 /**
+ * Return a new set of those items which exist in either this set or the given 'of'-able iterable.
+ *
+ * @param iterable
+ * @returns {Set}
+ */
+Set.prototype.union = function(iterable) {
+  var union = new Set(this);
+  union.addAll(iterable);
+  return union;
+};
+
+/**
  * jQuery DataTables extensions
  */
 

--- a/django/applications/catmaid/static/js/layers/layer-control.js
+++ b/django/applications/catmaid/static/js/layers/layer-control.js
@@ -55,12 +55,12 @@
         .append($('<label/>').append(navcb).append('Navigate with project'));
     $view.append(navlabel);
 
-    var benchmark = $view.siblings('.sliceBenchmark');
     var cb = $('<input/>')
         .attr('type', 'checkbox')
-        .prop('checked', benchmark.is(':visible'))
+        .prop('checked', stackViewer.showScaleBar)
         .change(function () {
-          $view.siblings('.sliceBenchmark').toggle();
+          stackViewer.showScaleBar = this.checked;
+          stackViewer.updateScaleBar();
         });
     var label = $('<div/>')
         .addClass('setting')

--- a/django/applications/catmaid/static/js/layers/layer-control.js
+++ b/django/applications/catmaid/static/js/layers/layer-control.js
@@ -59,8 +59,7 @@
         .attr('type', 'checkbox')
         .prop('checked', stackViewer.showScaleBar)
         .change(function () {
-          stackViewer.showScaleBar = this.checked;
-          stackViewer.updateScaleBar();
+          stackViewer.updateScaleBar(this.checked);
         });
     var label = $('<div/>')
         .addClass('setting')

--- a/django/applications/catmaid/static/js/project.js
+++ b/django/applications/catmaid/static/js/project.js
@@ -42,12 +42,23 @@
 
       stackViewers.push( stackViewer );
 
-      var rootWindow = CATMAID.rootWindow;
-      if ( rootWindow.getChild() === null ) {
-        rootWindow.replaceChild( stackViewer.getWindow() );
-      } else {
-        rootWindow.replaceChild( new CMWHSplitNode( rootWindow.getChild(),
-             stackViewer.getWindow() ) );
+      var inTree = false;
+      var node = stackViewer.getWindow();
+
+      while (!inTree && node !== null) {
+        node = node.getParent();
+        inTree = node instanceof CMWRootNode;
+      }
+
+      if (!inTree) {
+        var rootWindow = CATMAID.rootWindow;
+
+        if ( rootWindow.getChild() === null ) {
+          rootWindow.replaceChild( stackViewer.getWindow() );
+        } else {
+          rootWindow.replaceChild( new CMWHSplitNode( rootWindow.getChild(),
+            stackViewer.getWindow() ) );
+        }
       }
 
       stackViewer.getWindow().focus();

--- a/django/applications/catmaid/static/js/stack-viewer.js
+++ b/django/applications/catmaid/static/js/stack-viewer.js
@@ -19,7 +19,8 @@
    */
   function StackViewer(
       project,          //!< {CATMAID.Project} reference to the parent project
-      primaryStack
+      primaryStack,
+      catmaidWindow
   ) {
     this._project = project;
     this.primaryStack = primaryStack;
@@ -64,7 +65,7 @@
 
     //-------------------------------------------------------------------------
 
-    this._stackWindow = new CMWWindow( primaryStack.title );
+    this._stackWindow = catmaidWindow || new CMWWindow( primaryStack.title );
     this._view = this._stackWindow.getFrame();
     this._view.classList.add('stackViewer');
     this._layersView = document.createElement("div");

--- a/django/applications/catmaid/static/js/stack-viewer.js
+++ b/django/applications/catmaid/static/js/stack-viewer.js
@@ -140,9 +140,14 @@
 
   /**
    * update the scale bar (x-resolution) to a proper size
+   * @param showScaleBar optional boolean, whether to show the scale bar on update. Default: do not change.
    */
-  StackViewer.prototype.updateScaleBar = function () {
-    this._scaleBar.style.display = this.showScaleBar ? 'initial' : 'none';
+  StackViewer.prototype.updateScaleBar = function (showScaleBar) {
+    if (showScaleBar !== undefined && this.showScaleBar !== showScaleBar) {
+      this.showScaleBar = showScaleBar;
+      this._scaleBar.style.display = showScaleBar ? 'initial' : 'none';
+      this.layercontrol.refresh();
+    }
     var meter = this.scale / this.primaryStack.resolution.x;
     var width = 0;
     var text = "";

--- a/django/applications/catmaid/static/js/stack-viewer.js
+++ b/django/applications/catmaid/static/js/stack-viewer.js
@@ -578,13 +578,7 @@
   StackViewer.prototype._handleWindowSignal = function(callingWindow, signal) {
     switch (signal) {
       case CMWWindow.CLOSE:
-        this._layers.forEach(function (layer) {
-          if (typeof layer.unregister === 'function') {
-            layer.unregister();
-          }
-        });
-        this._layers.clear();
-        this._project.removeStackViewer(this.getId());
+        this.destroy();
         break;
 
       case CMWWindow.RESIZE:
@@ -613,6 +607,17 @@
         break;
     }
     return true;
+  };
+
+  StackViewer.prototype.destroy = function() {
+    this._layers.forEach(function (layer) {
+      if (typeof layer.unregister === 'function') {
+        layer.unregister();
+      }
+    });
+    this._layers.clear();
+    this._layerOrder.length = 0;
+    this._project.removeStackViewer(this.getId());
   };
 
   /**

--- a/django/applications/catmaid/static/js/stack-viewer.js
+++ b/django/applications/catmaid/static/js/stack-viewer.js
@@ -647,6 +647,17 @@
   };
 
   /**
+   * Return an array of layers which are instances of the given type.
+   *
+   * @param type
+   */
+  StackViewer.prototype.getLayersOfType = function(type) {
+    return Array.from(this.getLayers().values()).filter(function(layer) {
+      return layer instanceof type;
+    });
+  };
+
+  /**
    * Look up a layer's key using the layer itself.
    *
    * @param  {Object}  needle The layer object.

--- a/django/applications/catmaid/static/js/stack-viewer.js
+++ b/django/applications/catmaid/static/js/stack-viewer.js
@@ -48,6 +48,7 @@
     this.old_scale = this.scale;
 
     this.navigateWithProject = true;
+    this.showScaleBar = true;
 
     this._tool = null;
     this._layers = new Map();
@@ -93,6 +94,7 @@
     this._scaleBar.appendChild( document.createElement( "p" ) );
     this._scaleBar.firstChild.appendChild( document.createElement( "span" ) );
     this._scaleBar.firstChild.firstChild.appendChild( document.createTextNode( "test" ) );
+    this._scaleBar.style.display = this.showScaleBar ? 'initial' : 'none';
     this._view.appendChild( this._scaleBar );
 
     var controlToggle = document.createElement( "div" );
@@ -140,6 +142,7 @@
    * update the scale bar (x-resolution) to a proper size
    */
   StackViewer.prototype.updateScaleBar = function () {
+    this._scaleBar.style.display = this.showScaleBar ? 'initial' : 'none';
     var meter = this.scale / this.primaryStack.resolution.x;
     var width = 0;
     var text = "";

--- a/django/applications/catmaid/static/js/widgets/3dviewer.js
+++ b/django/applications/catmaid/static/js/widgets/3dviewer.js
@@ -4055,12 +4055,13 @@
     // Used only with restricted connectors
     this.connectoractor = null;
     this.connectorgeometry = {};
+    this.connectorSelection = null;
   };
 
   WebGLApplication.prototype.Space.prototype.Skeleton.prototype.destroy = function(collection) {
     this.removeActorFromScene(collection);
     [this.actor, this.geometry, this.connectorgeometry, this.connectoractor,
-     this.specialTagSpheres, this.synapticSpheres,
+     this.connectorSelection, this.specialTagSpheres, this.synapticSpheres,
      this.radiusVolumes, this.textlabels].forEach(function(ob) {
        if (ob) {
          for (var key in ob) {
@@ -4909,14 +4910,29 @@
     for (var i=0; i < skeletons.length; ++i) {
       var s = skeletons[i];
       // If there is restricted connector geometry displayed, update it, too
-      if (s.connectoractor) {
+      if (s.connectorSelection && s.connectoractor) {
         s.synapticTypes.forEach(function(type) {
           // A reference is fine, the connectoractor material and geometry color
           // aren't modified directly.
-          this.connectoractor[type].material = this.actor[type].material;
-          this.connectoractor[type].material.needsUpdate = true;
-          this.connectorgeometry[type].colors = this.geometry[type].colors;
-          this.connectorgeometry[type].colorsNeedUpdate = true;
+          var ca = this.connectoractor[type];
+          if (ca) {
+            ca.material = this.actor[type].material;
+            ca.material.needsUpdate = true;
+          }
+          var cg = this.connectorgeometry[type];
+          if (cg) {
+            cg.colors = this.geometry[type].colors;
+            cg.colorsNeedUpdate = true;
+          }
+          var cs = this.connectorSelection[type];
+          if (cs) {
+            for (var nodeId in cs.objects) {
+              var originalConnector = this.synapticSpheres[nodeId];
+              if (originalConnector) {
+                cs.objects[nodeId].color = originalConnector.color;
+              }
+            }
+          }
         }, s);
       }
     }
@@ -5191,42 +5207,90 @@
   };
 
   WebGLApplication.prototype.Space.prototype.Skeleton.prototype.remove_connector_selection = function() {
-    if (this.connectoractor) {
-      for (var i=0; i<this.synapticTypes.length; ++i) {
-        var ca = this.connectoractor[this.synapticTypes[i]];
+    for (var i=0; i<this.synapticTypes.length; ++i) {
+      var type = this.synapticTypes[i];
+
+      if (this.connectoractor) {
+        var ca = this.connectoractor[type];
         if (ca) {
           ca.geometry.dispose(); // do not dispose material, it is shared
           this.space.remove(ca);
-          delete this.connectoractor[this.synapticTypes[i]];
+          delete this.connectoractor[type];
         }
       }
-      this.connectoractor = null;
+
+      if (this.connectorSelection) {
+        var cs = this.connectorSelection[type];
+        if (cs) {
+          cs.mesh.geometry.dispose(); // do not dispose material, it is shared
+          this.space.remove(cs.mesh);
+          delete this.connectoractor[type];
+        }
+      }
     }
   };
 
+  /**
+   *
+   */
   WebGLApplication.prototype.Space.prototype.Skeleton.prototype.create_connector_selection = function( common_connector_IDs ) {
+    this.connectorSelection = {};
     this.connectoractor = {};
     this.connectorgeometry = {};
     this.connectorgeometry[this.CTYPES[1]] = new THREE.Geometry();
     this.connectorgeometry[this.CTYPES[2]] = new THREE.Geometry();
     this.connectorgeometry[this.CTYPES[3]] = new THREE.Geometry();
 
+    var scaling = this.space.options.skeleton_node_scaling;
+    var materialType = this.space.options.neuron_material;
+
     this.synapticTypes.forEach(function(type) {
-      // Vertices is an array of Vector3, every two a pair, the first at the connector and the second at the node
+      var material = this.actor[type].material;
+
+      // Vertices is an array of Vector3, every two a pair, the first at the
+      // node and the second at the connector.
       var vertices1 = this.geometry[type].vertices;
       var vertices2 = this.connectorgeometry[type].vertices;
+      var connectors = [];
       for (var i=vertices1.length-2; i>-1; i-=2) {
         var v = vertices1[i];
         if (common_connector_IDs.hasOwnProperty(v.node_id)) {
-          vertices2.push(vertices1[i+1]);
+          var v2 = vertices1[i+1];
+          vertices2.push(v2);
           vertices2.push(v);
+          connectors.push([v2, material, type]);
         }
       }
-      this.connectoractor[type] = new THREE.LineSegments( this.connectorgeometry[type],
-          this.actor[type].material );
-      this.connectorgeometry[type].colors = this.geometry[type].colors;
-      this.connectorgeometry[type].colorsNeedUpdate = true;
-      this.space.add( this.connectoractor[type] );
+
+      if (connectors.length > 0) {
+        this.connectoractor[type] = new THREE.LineSegments(this.connectorgeometry[type],
+            material);
+        this.connectorgeometry[type].colors = this.geometry[type].colors;
+        this.connectorgeometry[type].colorsNeedUpdate = true;
+        this.space.add(this.connectoractor[type]);
+
+        // Create buffer geometry for connector spheres
+        var geometry = new CATMAID.MultiObjectInstancedBufferGeometry({
+          templateGeometry: this.space.staticContent.radiusSphere,
+          nObjects: connectors.length,
+          scaling: scaling
+        });
+
+        var partnerSpheres = {};
+        geometry.createAll(connectors, scaling, null, function(v, m, o, bufferObject) {
+          partnerSpheres[v.node_id] = bufferObject;
+        });
+
+        var sphereMaterial = geometry.createMaterial(materialType);
+
+        var sphereMesh = new THREE.Mesh(geometry, sphereMaterial);
+        this.connectorSelection[type] = {
+          mesh: sphereMesh,
+          objects: partnerSpheres
+        };
+        this.space.add(sphereMesh);
+      }
+
     }, this);
   };
 

--- a/django/applications/catmaid/static/js/widgets/clustering_widget.js
+++ b/django/applications/catmaid/static/js/widgets/clustering_widget.js
@@ -306,7 +306,7 @@
 
     this.patch_clustering_setup = function( container )
     {
-      var form = $("#clustering-setup-form", container);
+      var form = $("form[name=clustering-setup-form]", container);
       var found = form.length !== 0;
       if (found) {
         // Take care of submission on our own
@@ -343,28 +343,28 @@
       }
 
       // additional functionality for the classification selection form
-      var selectAllCb = $("#select-all", container);
+      var selectAllCb = $("input[name=select_all]", container);
       if (selectAllCb.length > 0) {
         selectAllCb.click( function() {
-          var cbSelector = "#clustering-setup-form input[type=checkbox][class=autoselectable]";
+          var cbSelector = "form[name=clustering-setup-form] input[type=checkbox][class=autoselectable]";
           var val = this.checked;
-          var inputGraphCbSelection = $(cbSelector, $(this).closest("#clustering_widget"));
+          var inputGraphCbSelection = $(cbSelector, $(this).closest(".clustering-content"));
           inputGraphCbSelection.prop("checked", val);
         });
 
         $(container).on("change", ".autoselectable", function(e) {
-          var cbSelector = "#clustering-setup-form input[type=checkbox][class=autoselectable]";
+          var cbSelector = "form[name=clustering-setup-form] input[type=checkbox][class=autoselectable]";
           var val = this.checked;
           if (val) {
-            var inputGraphCbSelection = $(cbSelector, $(this).closest("#clustering_widget"));
+            var inputGraphCbSelection = $(cbSelector, $(this).closest(".clustering-content"));
             var allChecked = $.grep(inputGraphCbSelection, function(e) {
               return e.checked;
             }).length == inputGraphCbSelection.length;
             if (allChecked) {
-              $("#select-all", container).prop("checked", true);
+              $("input[name=select_all]", container).prop("checked", true);
             }
           } else {
-            $("#select-all", container).prop("checked", false);
+            $("input[name=select_all]", container).prop("checked", false);
           }
         });
       }

--- a/django/applications/catmaid/static/js/widgets/connector-viewer.js
+++ b/django/applications/catmaid/static/js/widgets/connector-viewer.js
@@ -109,7 +109,7 @@
       this.update();
       return Number(currentPageElement.value) - 1;
     } else if (newPage < 0 || newFirstConnectorIdx >= total) {  // page out of bounds
-      alert('This page does not exist! Returning to page 1.');
+      CATMAID.warn('This page does not exist! Returning to page 1.');
       return this.changePage(0);
     } else {
       this.firstConnectorIdx = newFirstConnectorIdx;
@@ -362,6 +362,7 @@
         var currentPage = document.createElement('input');
         currentPage.setAttribute('type', 'text');
         currentPage.setAttribute('size', '4');
+        currentPage.setAttribute('pattern', '\d+');
         currentPage.style.textAlign = 'right';
         currentPage.setAttribute('id', self.idPrefix + "current-page");
         currentPage.setAttribute('value', '1');
@@ -679,6 +680,9 @@
             panelStackViewer, connector.coords,
             setStackViewerSuspendState.bind(self, panelStackViewer, true)
           );
+          panelStackViewer.getLayersOfType(CATMAID.TracingLayer).forEach(function(tracingLayer) {
+            tracingLayer.forceRedraw();
+          });
 
           hider.style.display = 'none';
         } else {
@@ -698,7 +702,7 @@
   ConnectorViewer.prototype.updateWithSkels = function() {
     var self = this;
     this._updateResultSkelSource();
-    // this.cache.invalidateSort(this.currentConnectorRelation);
+
     return this.updateConnectorOrder().then(function(connectorOrder) {
       var maxPageElement = document.getElementById(self.idPrefix + 'max-page');
       var maxPage = Math.ceil(connectorOrder.length / (self.dimensions[0]*self.dimensions[1]));
@@ -1000,7 +1004,7 @@
    * function(connector1ID, connector2ID, relationType, selectedSkeletons)
    */
   ConnectorViewerCache.prototype.setSortFn = function (sortFnName) {
-      this.sortFn = sortFns[sortFnName].bind(this);  // is the binding necessary here?
+      this.sortFn = sortFns[sortFnName].bind(this);
   };
 
   /**

--- a/django/applications/catmaid/static/js/widgets/connector-viewer.js
+++ b/django/applications/catmaid/static/js/widgets/connector-viewer.js
@@ -1,0 +1,1119 @@
+/* -*- mode: espresso; espresso-indent-level: 2; indent-tabs-mode: nil -*- */
+/* vim: set softtabstop=2 shiftwidth=2 tabstop=2 expandtab: */
+
+(function(CATMAID) {
+
+  "use strict";
+
+  const CACHE_TIMEOUT = 5*60*1000;
+
+  const DEFAULT_WIDTH = 3;
+  const DEFAULT_HEIGHT = 3;
+  const MAX_WIDTH = 5;
+  const MAX_HEIGHT = 5;
+
+  const DEFAULT_CONNECTOR_RELATION = 'presynaptic_to';
+
+  const HIDER_Z_INDEX = 100;
+  const PANEL_PADDING = 1;
+
+  const TRACING_OVERLAY_BUFFER = 64;
+
+  const DEFAULT_SHOW_SCALE_BAR = false;
+
+  const DEFAULT_SORT_FN_TITLE = 'Connector depth (proportion)';
+
+  /**
+   * Create a new connector viewer, optional with a set of initial skeleton
+   * models.
+   */
+  var ConnectorViewer = function(skeletonModels)
+  {
+    this.widgetID = this.registerInstance();
+    this.idPrefix = `connector-viewer${this.widgetID}-`;
+
+    // This skeleton source takes care of internal skeleton management. It is
+    // not registered. It is the input skeleton sink, but the output is handled
+    // with a second source
+    var updateWithSkels = this.updateWithSkels.bind(this);
+    this.skeletonSource = new CATMAID.BasicSkeletonSource(this.getName() + " Input", {
+      register: false,
+      handleAddedModels: updateWithSkels,
+      handleChangedModels: updateWithSkels,
+      handleRemovedModels: updateWithSkels
+    });
+    // A skeleton source to collect results in
+    this.resultSkeletonSource = new CATMAID.BasicSkeletonSource(this.getName());
+
+    this.cache = new ConnectorViewerCache(this.skeletonSource);
+    this.currentConnectorOrder = [];
+    this.firstConnectorIdx = 0;
+
+    this.currentConnectorRelation = DEFAULT_CONNECTOR_RELATION;
+    this.dimensions = [DEFAULT_HEIGHT, DEFAULT_WIDTH];
+
+    this.sourceStackViewer = project.getStackViewers()[0];
+    this.stackViewers = [];
+    this.panelWindows = [];
+    this.showScaleBar = DEFAULT_SHOW_SCALE_BAR;
+
+    if (skeletonModels) {
+      this.skeletonSource.append(skeletonModels);
+    }
+  };
+
+  ConnectorViewer.prototype = {};
+  $.extend(ConnectorViewer.prototype, new InstanceRegistry());
+
+  ConnectorViewer.prototype.getName = function() {
+    return "Connector Viewer " + this.widgetID;
+  };
+
+  ConnectorViewer.prototype.destroy = function() {
+    this.closeStackViewers();
+    this.unregisterInstance();
+  };
+
+  /**
+   * Update the text describing which connectors are shown.
+   */
+  ConnectorViewer.prototype.updateShowingText = function() {
+    var total = this.currentConnectorOrder.length;
+    var start = Math.min(this.firstConnectorIdx + 1, total);
+    var stop = Math.min(this.firstConnectorIdx + this.dimensions[0] * this.dimensions[1], total);
+
+    var showingTextSelector = $(`#${this.idPrefix}showing`);
+    showingTextSelector.find(`.start`).text(start);
+    showingTextSelector.find(`.stop`).text(stop);
+    showingTextSelector.find(`.total`).text(total);
+  };
+
+  /**
+   *
+   * @param newPage zero-indexed
+   */
+  ConnectorViewer.prototype.changePage = function(newPage) {
+    var currentPageElement = document.getElementById(this.idPrefix + 'current-page');
+
+    var total = this.currentConnectorOrder.length;
+
+    if (total === 0) {
+      currentPageElement.value = 1;
+      this.update();
+      return 0;
+    }
+
+    var newFirstConnectorIdx = newPage * this.dimensions[0] * this.dimensions[1];
+
+    if (this.firstConnectorIdx === newFirstConnectorIdx) {  // page may not be changing
+      this.update();
+      return Number(currentPageElement.value) - 1;
+    } else if (newPage < 0 || newFirstConnectorIdx >= total) {  // page out of bounds
+      alert('This page does not exist! Returning to page 1.');
+      return this.changePage(0);
+    } else {
+      this.firstConnectorIdx = newFirstConnectorIdx;
+      currentPageElement.value = newPage + 1;
+      this.update();
+      return newPage;
+    }
+  };
+
+  ConnectorViewer.prototype.clearCache = function() {
+    this.currentConnectorOrder = [];
+    this.firstConnectorIdx = 0;
+    this.cache.clear();
+  };
+
+  ConnectorViewer.prototype.closeStackViewers = function () {
+    for (var stackViewer of this.stackViewers) {
+      stackViewer.destroy();
+    }
+  };
+
+  ConnectorViewer.prototype.getVisibleConnectors = function() {
+    var firstConnIdx = this.firstConnectorIdx;
+
+    return this.currentConnectorOrder.slice(
+      firstConnIdx,
+      firstConnIdx + this.dimensions[0] * this.dimensions[1]
+    );
+  };
+
+  /**
+   * Returns a list of stack windows not inside a connector viewer.
+   *
+   * @returns {Array} of objects {'title': stackViewerWindowTitle, 'stackViewer': stackViewerInstance}
+   */
+  ConnectorViewer.prototype.getOtherStackViewerOptions = function () {
+    return project.getStackViewers()
+      .filter(function(stackViewer) {
+        // only stack viewers not living in a connector-viewer panel window
+        return !stackViewer.getWindow().frame.classList.contains('connector-panel');
+      })
+      .map(function(stackViewer) {
+        return {
+          title: stackViewer.getWindow().title,
+          value: stackViewer
+        };
+      });
+  };
+
+  ConnectorViewer.prototype.updateConnectorOrder = function(){
+    var self = this;
+    return this.cache
+      .updateConnectorOrder(self.currentConnectorRelation)
+      .then(function(connectorOrder) {
+          self.currentConnectorOrder = connectorOrder;
+          return connectorOrder;
+        });
+      };
+
+  ConnectorViewer.prototype.getWidgetConfiguration = function() {
+    return {
+      helpText: "Connector Viewer widget: Quickly view and compare connectors associated with given skeletons",
+      controlsID: this.idPrefix + 'controls',
+      createControls: function(controls) {
+        var self = this;
+
+        // WIDGET SETTINGS CONTROLS
+
+        var sourceStackViewer = CATMAID.DOM.createSelect(
+          self.idPrefix + 'source-stack-viewer',
+          self.getOtherStackViewerOptions(),
+          this.sourceStackViewer._stackWindow.title
+        );
+        sourceStackViewer.onchange = function() {
+          self.sourceStackViewer = this.value;
+          self.redrawPanels();
+          self.updateWithSkels();
+        };
+
+        var sourceStackViewerLabel = document.createElement('label');
+        sourceStackViewerLabel.appendChild(document.createTextNode('Source stack viewer'));
+        sourceStackViewerLabel.appendChild(sourceStackViewer);
+        controls.appendChild(sourceStackViewerLabel);
+
+        var tileCounts = document.createElement('div');
+        tileCounts.style.display = 'inline-block';
+        controls.appendChild(tileCounts);
+
+        var makeTileCountOptions = function(max) {
+          var arr = [];
+          for (var i = 1; i <= max; i++) {
+            arr.push({title: i, value:i});
+          }
+          return arr;
+        };
+
+        var hTileCount = CATMAID.DOM.createSelect(
+          self.idPrefix + "h-tile-count",
+          makeTileCountOptions(MAX_HEIGHT),
+          String(DEFAULT_HEIGHT)
+        );
+        hTileCount.onchange = function() {
+          self.redrawPanels();
+          self.update();
+        };
+
+        var hTileCountLabel = document.createElement('label');
+        hTileCountLabel.appendChild(document.createTextNode('Height'));
+        hTileCountLabel.appendChild(hTileCount);
+        tileCounts.appendChild(hTileCountLabel);
+
+        var wTileCount = CATMAID.DOM.createSelect(
+          self.idPrefix + "w-tile-count",
+          makeTileCountOptions(MAX_WIDTH),
+          String(DEFAULT_WIDTH)
+        );
+        wTileCount.onchange = function() {
+          self.redrawPanels();
+          self.update();
+        };
+
+        var wTileCountLabel = document.createElement('label');
+        wTileCountLabel.appendChild(document.createTextNode('Width'));
+        wTileCountLabel.appendChild(wTileCount);
+        tileCounts.appendChild(wTileCountLabel);
+
+        var scaleBarCb = document.createElement('input');
+        scaleBarCb.setAttribute('type', 'checkbox');
+        scaleBarCb.checked = DEFAULT_SHOW_SCALE_BAR;
+        scaleBarCb.onchange = function() {
+          self.showScaleBar = this.checked;
+          for (var stackViewer of self.stackViewers) {
+            stackViewer.updateScaleBar(self.showScaleBar);
+          }
+        };
+
+        var scaleBarCbLabel = document.createElement('label');
+        scaleBarCbLabel.appendChild(document.createTextNode('Scale bars'));
+        scaleBarCbLabel.appendChild(scaleBarCb);
+        controls.appendChild(scaleBarCbLabel);
+
+        controls.appendChild(document.createElement('br'));
+
+        // CONNECTOR SELECTION CONTROLS
+
+        var sourceSelect = CATMAID.skeletonListSources.createSelect(this.skeletonSource);
+        controls.appendChild(sourceSelect);
+
+        var add = document.createElement('input');
+        add.setAttribute("type", "button");
+        add.setAttribute("value", "Add");
+        add.onclick = function() {
+          self.skeletonSource.loadSource.bind(self.skeletonSource)();
+        };
+        controls.appendChild(add);
+
+        var clear = document.createElement('input');
+        clear.setAttribute("type", "button");
+        clear.setAttribute("value", "Clear");
+        clear.onclick = function() {
+          self.clearCache();
+          self.skeletonSource.clear();
+        };
+        controls.appendChild(clear);
+
+        var refresh = document.createElement('input');
+        refresh.setAttribute("type", "button");
+        refresh.setAttribute("value", "Refresh");
+        refresh.onclick = function() {
+          self.clearCache();
+          self.redrawPanels();
+          self.updateWithSkels();
+        };
+        controls.appendChild(refresh);
+
+        var relation = CATMAID.DOM.createSelect(
+          self.idPrefix + "relation-type",
+          [
+            {title: 'Incoming connectors', value: "postsynaptic_to"},
+            {title: 'Outgoing connectors', value: "presynaptic_to"},
+            {title: 'Gap junction connectors', value: "gapjunction_with"},
+            {title: 'Abutting connectors', value: "abutting"}
+          ],
+          this.currentConnectorRelation
+        );
+        relation.onchange = function() {
+          self.currentConnectorRelation = this.value;
+          self.updateWithSkels();
+        };
+
+        var relationLabel = document.createElement('label');
+        relationLabel.appendChild(document.createTextNode('Type'));
+        relationLabel.appendChild(relation);
+        controls.appendChild(relationLabel);
+
+        var sortingSelect = CATMAID.DOM.createSelect(
+          self.idPrefix + "connector-sorting",
+          [
+            {title: 'Connector depth (proportion)', value: 'depthProportionSort'},
+            {title: 'Connector depth (absolute)', value: 'depthSort'},
+            {title: 'Connector ID', value: 'connIdSort'},
+            {title: 'Skeleton name', value: 'skelNameSort'},
+            {title: 'None', value: 'nullSort'}
+          ],
+          DEFAULT_SORT_FN_TITLE  // might need to be value, not title
+        );
+        sortingSelect.onchange = function() {
+          self.currentConnectorOrder = [];
+          self.cache.setSortFn(this.value);
+          self.updateWithSkels();
+        };
+        self.cache.setSortFn(sortingSelect.value);
+
+        var sortingSelectLabel = document.createElement('label');
+        sortingSelectLabel.appendChild(document.createTextNode('Connector sorting'));
+        sortingSelectLabel.appendChild(sortingSelect);
+        controls.appendChild(sortingSelectLabel);
+
+        var openTable = document.createElement('input');
+        openTable.setAttribute('type', 'button');
+        openTable.setAttribute('value', 'Table');
+        openTable.onclick = function() {
+          var selectedModels = self.resultSkeletonSource.getSelectedSkeletonModels();
+          var connTable = WindowMaker.create('connector-table', selectedModels).widget;
+          document.getElementById(connTable.idPrefix + 'relation-type').value = self.currentConnectorRelation;
+          connTable.update();
+        };
+        controls.appendChild(openTable);
+
+        controls.appendChild(document.createElement('br'));
+
+        // PAGINATION CONTROLS
+
+        var prevButton = document.createElement('input');
+        prevButton.setAttribute('type', 'button');
+        prevButton.setAttribute('id', self.idPrefix + "prev");
+        prevButton.setAttribute('value', 'Previous');
+        prevButton.onclick = function() {
+          var prevPageIdx = Number(document.getElementById(self.idPrefix + "current-page").value) - 2;
+          if (prevPageIdx >= 0) {
+            self.changePage(prevPageIdx);
+          }
+        };
+        controls.appendChild(prevButton);
+
+        var pageCountContainer = document.createElement('div');
+        pageCountContainer.style.display = 'inline-block';
+        controls.appendChild(pageCountContainer);
+
+        var currentPage = document.createElement('input');
+        currentPage.setAttribute('type', 'text');
+        currentPage.setAttribute('size', '4');
+        currentPage.style.textAlign = 'right';
+        currentPage.setAttribute('id', self.idPrefix + "current-page");
+        currentPage.setAttribute('value', '1');
+        currentPage.onchange = function() {
+          self.changePage(Number(this.value) - 1);
+        };
+
+        pageCountContainer.appendChild(currentPage);
+
+        pageCountContainer.appendChild(document.createTextNode(' / '));
+
+        var maxPage = document.createElement('p');
+        maxPage.innerHTML = '1';
+        maxPage.setAttribute('id', self.idPrefix + 'max-page');
+
+        pageCountContainer.appendChild(maxPage);
+
+        var nextButton = document.createElement('input');
+        nextButton.setAttribute('type', 'button');
+        nextButton.setAttribute('id', self.idPrefix + 'next');
+        nextButton.setAttribute('value', 'Next');
+        nextButton.onclick = function() {
+          // going from 1-base to 0-base so no +1 needed
+          var nextPageIdx = Number(document.getElementById(self.idPrefix + 'current-page').value);
+
+          var maxPageIdx = Number(document.getElementById(self.idPrefix + 'max-page').innerHTML) - 1;
+          if (nextPageIdx <= maxPageIdx) {
+            self.changePage(nextPageIdx);
+          }
+        };
+        controls.appendChild(nextButton);
+
+        var showing = document.createElement('p');
+        showing.setAttribute('id', self.idPrefix + 'showing');
+        showing.style.display = 'inline-block';
+        showing.innerHTML = 'Showing <b class="start">0</b>-<b class="stop">0</b> of <b class="total">0</b> connectors';
+        controls.appendChild(showing);
+      },
+      contentID: this.idPrefix + 'content',
+      createContent: function(container) {
+        container.setAttribute('position', 'relative');
+      },
+      init: function() {
+        this.init(project.getId());
+      }
+    };
+  };
+
+  var skelIDsToModels = function(skelIDs) {
+    return skelIDs.reduce(function(obj, skelID) {
+      obj[skelID]  = new CATMAID.SkeletonModel(skelID);
+      return obj;
+    }, {});
+  };
+
+  ConnectorViewer.prototype.init = function() {
+    this.initWidgetWindow();
+    this.redrawPanels();
+    this.updateWithSkels();
+  };
+
+  ConnectorViewer.prototype.initWidgetWindow = function () {
+    var widgetWindow = this.getWidgetWindow();
+    var self = this;
+
+    widgetWindow.getWindows = function() {
+      return [this].concat(self.panelWindows);
+    };
+
+    widgetWindow.redraw = function() {
+      this.callListeners(CMWWindow.RESIZE);
+      self.panelWindows.forEach(function(w) {
+        w.redraw();
+      });
+    };
+  };
+
+  ConnectorViewer.prototype.getWidgetContent = function () {
+    return document.getElementById(this.idPrefix + 'content');
+  };
+
+  ConnectorViewer.prototype.getWidgetWindow = function () {
+    var widgetContent = this.getWidgetContent();
+    var widgetFrame = $(widgetContent).closest('.' + CMWNode.FRAME_CLASS).get(0);
+    return CATMAID.rootWindow.getWindows().find(function(w) {
+      return w.getFrame() === widgetFrame;
+    });
+  };
+
+  /**
+   * Set the suspend state of a stack viewer's tracing layers, and redraw if waking it. Stack viewers set to
+   * navigate with the project cannot be suspended.
+   *
+   * @param stackViewer
+   * @param suspended - new suspend state, 'true' to suspend, 'false' to wake and redraw
+   */
+  var setStackViewerSuspendState = function(stackViewer, suspended) {
+    // do not suspend if the stack viewer is set to navigate with project
+    suspended = stackViewer.navigateWithProject ? false : suspended;
+
+    for (let tracingLayer of stackViewer.getLayersOfType(CATMAID.TracingLayer)) {
+      tracingLayer.tracingOverlay.suspended = suspended;
+      if (!suspended) {
+        tracingLayer.tracingOverlay.redraw(true);
+      }
+    }
+  };
+
+  /**
+   * Return the set of nodes associated with any tracing overlay associated with the given stack viewer.
+   *
+   * @param stackViewer
+   */
+  var getNodeSet = function(stackViewer) {
+    return stackViewer.getLayersOfType(CATMAID.TracingLayer).reduce(function (set, tracingLayer) {
+      return set.addAll(Object.keys(tracingLayer.tracingOverlay.nodes));
+    }, new Set());
+  };
+
+  /**
+   * A listener to add to CMWWindows which will suspend tracing overlays which do not share nodes with the stack
+   * viewer in the focused window.
+   *
+   * EDGE CASE: suspend decisions are made on focus change, so if you trace in one stack viewer, into the field of
+   * view of a stack viewer which had been suspended due to being too far away, the latter will not unsuspend until
+   * focused.
+   *
+   * @param cmwWindow
+   * @param signal
+   */
+  ConnectorViewer.prototype.focusSuspendListener = function(cmwWindow, signal) {
+    if (signal === CMWWindow.FOCUS) {
+      let focusedStackViewer = this.stackViewers[this.panelWindows.indexOf(cmwWindow)];
+      let focusedNodes = getNodeSet(focusedStackViewer);
+
+      for (let stackViewer of this.stackViewers) {
+        if (stackViewer === focusedStackViewer) {
+          // avoid doing unnecessary set operations for the focused stack viewer
+          setStackViewerSuspendState(stackViewer, false);
+        } else {
+          // suspend unless nodes in the focused stack viewer also appear in this stack viewer
+          let otherNodes = getNodeSet(stackViewer);
+          setStackViewerSuspendState(stackViewer, !focusedNodes.intersection(otherNodes).size);
+        }
+      }
+    }
+  };
+
+  /**
+   * Handle the redrawing of stack viewer panels, e.g. in the case of changing dimensions or the first draw.
+   */
+  ConnectorViewer.prototype.redrawPanels = function() {
+    this.dimensions = [$(`#${this.idPrefix}h-tile-count`).val(), $(`#${this.idPrefix}w-tile-count`).val()];
+    var widgetContent = this.getWidgetContent();
+
+    // destroy existing
+    this.closeStackViewers();
+    this.stackViewers.length = 0;
+    this.panelWindows.length = 0;
+    while (widgetContent.lastChild) {
+      widgetContent.removeChild(widgetContent.lastChild);
+    }
+
+    var widgetWindow = this.getWidgetWindow();
+
+    var stack = this.sourceStackViewer.primaryStack;
+    var tileSource = this.sourceStackViewer.getLayer('TileLayer').tileSource;
+
+    var tileLayerConstructor = CATMAID.TileLayer.Settings.session.prefer_webgl ?
+      CATMAID.PixiTileLayer :
+      CATMAID.TileLayer;
+
+    for (var iIdx = 0; iIdx < this.dimensions[0]; iIdx++) {
+      for (var jIdx = 0; jIdx < this.dimensions[1]; jIdx++) {
+        var panelContainer = document.createElement('div');
+        panelContainer.style.position = 'absolute';
+        panelContainer.style.height = `${100 / this.dimensions[0]}%`;
+        panelContainer.style.width = `${100 / this.dimensions[1]}%`;
+        panelContainer.style.top = `${(100 / this.dimensions[0]) * iIdx}%`;
+        panelContainer.style.left = `${(100 / this.dimensions[1]) * jIdx}%`;
+
+        widgetContent.appendChild(panelContainer);
+
+        var panelInnerContainer = document.createElement('div');
+        panelInnerContainer.style.position = 'absolute';
+        panelInnerContainer.style.top = `${PANEL_PADDING}px`;
+        panelInnerContainer.style.bottom = `${iIdx === this.dimensions[0]-1 ? 0 : PANEL_PADDING}px`;
+        panelInnerContainer.style.left = `${jIdx ? PANEL_PADDING: 0}px`;
+        panelInnerContainer.style.right = `${jIdx === this.dimensions[1]-1 ? 0 : PANEL_PADDING}px`;
+
+        panelContainer.appendChild(panelInnerContainer);
+
+        var panelWindow = new CMWWindow('Connector');
+        // prevent dragging
+        $(panelWindow.getFrame()).children('.stackInfo_selected').get(0).onmousedown = function () {return true;};
+        panelWindow.parent = widgetWindow;
+
+        var panel = panelWindow.getFrame();
+        panel.style.position = 'absolute';
+        panel.classList.add('connector-panel', `i${iIdx}`, `j${jIdx}`);
+
+        var panelStackViewer = new CATMAID.StackViewer(project, stack, panelWindow);
+
+        var tileLayer = new tileLayerConstructor(
+          panelStackViewer,
+          "Image data (" + stack.title + ")",
+          stack,
+          tileSource,
+          true,
+          1,
+          false,
+          CATMAID.TileLayer.Settings.session.linear_interpolation
+        );
+
+        panelStackViewer.addLayer("TileLayer", tileLayer);
+
+        panelStackViewer.layercontrol.refresh();
+
+        var stackInfo = panelStackViewer._stackWindow.frame.querySelector('.stackInfo_selected');
+        var assocNeuronNameEl = document.createElement('p');
+        assocNeuronNameEl.classList.add('assoc-neuron-name');
+        stackInfo.appendChild(assocNeuronNameEl);
+
+        this.stackViewers.push(panelStackViewer);
+
+        panelInnerContainer.appendChild(panel);
+        panelStackViewer.resize();
+
+        var panelHider = document.createElement('div');
+        panelHider.style.position = 'absolute';
+        panelHider.style.height = '100%';
+        panelHider.style.width = '100%';
+        panelHider.style.backgroundColor = '#3d3d3d';
+        panelHider.style.zIndex = HIDER_Z_INDEX;
+        panelHider.setAttribute('id', `${this.idPrefix}hider-${iIdx}-${jIdx}`);
+
+        panelInnerContainer.appendChild(panelHider);
+
+        var hiderText = document.createElement('p');
+        hiderText.style.color = 'white';
+        hiderText.style.backgroundColor = 'transparent';
+        hiderText.innerHTML = 'No more connectors to show';
+
+        panelHider.appendChild(hiderText);
+
+        project.addStackViewer(panelStackViewer);
+
+        for (var keyVal of panelStackViewer.getLayers().entries()) {
+          if (keyVal[0].startsWith('TracingLayer')) {
+            keyVal[1].tracingOverlay.padding = TRACING_OVERLAY_BUFFER;
+            break;
+          }
+        }
+
+        panelWindow.redraw();
+
+        panelWindow.addListener(this.focusSuspendListener.bind(this));  // todo: might need some binding here
+
+        setStackViewerSuspendState(panelStackViewer, true);
+      }
+    }
+
+    this.panelWindows = this.stackViewers.map(function(stackViewer) {
+      return stackViewer.getWindow();
+    });
+
+    // todo: do this in the stack viewers rather than here
+    // hide window controls
+    var containerJq = $(widgetContent);
+    containerJq.find('.neuronname').hide();
+    containerJq.find('.stackClose').hide();
+    containerJq.find('.smallMapView_hidden').hide();  // doesn't work anyway
+  };
+
+  ConnectorViewer.prototype.changeAssocNeuronName = function(container, skelNames) {
+    container.querySelector('.assoc-neuron-name').innerHTML = skelNames.join(' | ');
+  };
+
+  ConnectorViewer.prototype.moveStackViewer = function(stackViewer, coords, completionCallback) {
+    stackViewer.moveToProject(
+      coords.z, coords.y, coords.x,
+      this.sourceStackViewer.primaryStack.stackToProjectSX(this.sourceStackViewer.s),
+      typeof completionCallback === "function" ? completionCallback : undefined
+    );
+  };
+
+  /**
+   * Update panel stack viewer state (hidden, title, position etc.) based on current skeleton source content. Used when
+   * dimensions or page changed.
+   */
+  ConnectorViewer.prototype.update = function() {
+    var self = this;
+    this.currentConnectorRelation = $(`#${this.idPrefix}relation-type`).val();
+
+    var visibleConnectors = this.getVisibleConnectors();
+    for (var iIdx = 0; iIdx < self.dimensions[0]; iIdx++) {
+      for (var jIdx = 0; jIdx < self.dimensions[1]; jIdx++) {
+        var panelIdx = jIdx + iIdx*self.dimensions[1];
+        var hider = document.getElementById(`${self.idPrefix}hider-${iIdx}-${jIdx}`);
+
+        var panelStackViewer = self.stackViewers[panelIdx];
+        panelStackViewer.navigateWithProject = false;
+        panelStackViewer.updateScaleBar(self.showScaleBar);
+
+        var connector = visibleConnectors[panelIdx];
+        if (connector) {
+          // change title bar
+          panelStackViewer._stackWindow.setTitle('connector ID: ' + connector.connID);
+          panelStackViewer._stackWindow.frame.querySelector('.stackTitle').onclick = self.moveStackViewer
+            .bind(self, self.sourceStackViewer, connector.coords);
+          self.changeAssocNeuronName(panelStackViewer._stackWindow.frame, connector.skelNames);
+
+          // allow the tracing overlay to update for the move
+          setStackViewerSuspendState(panelStackViewer, false);
+          self.moveStackViewer(
+            panelStackViewer, connector.coords,
+            setStackViewerSuspendState.bind(self, panelStackViewer, true)
+          );
+
+          hider.style.display = 'none';
+        } else {
+          hider.style.display = 'block';
+        }
+      }
+    }
+
+    self.updateShowingText();
+  };
+
+  /**
+   * Update result skeleton source, cache and connector order, and then panel stack viewer state.
+   *
+   * @returns Promise of connector order
+   */
+  ConnectorViewer.prototype.updateWithSkels = function() {
+    var self = this;
+    this._updateResultSkelSource();
+    // this.cache.invalidateSort(this.currentConnectorRelation);
+    return this.updateConnectorOrder().then(function(connectorOrder) {
+      var maxPageElement = document.getElementById(self.idPrefix + 'max-page');
+      var maxPage = Math.ceil(connectorOrder.length / (self.dimensions[0]*self.dimensions[1]));
+      maxPageElement.innerHTML = Math.max(maxPage, 1).toString();
+      self.changePage(0);
+
+      return connectorOrder;
+    });
+  };
+
+  ConnectorViewer.prototype._updateResultSkelSource = function() {
+    this.resultSkeletonSource.clear();
+    // Populate result skeleton source
+    var models = skelIDsToModels(this.skeletonSource.getSelectedSkeletons());
+    this.resultSkeletonSource.append(models);
+  };
+
+  // Export widget
+  CATMAID.ConnectorViewer = ConnectorViewer;
+
+  // Register widget with CATMAID
+  CATMAID.registerWidget({
+    key: 'connector-viewer',
+    creator: ConnectorViewer
+  });
+
+  /**
+   * Acts as a cache and controls database access for the connector viewer.
+   *
+   * EDGE CASES:
+   *  - Doesn't pick up if a treenode and connector lose their association during use
+   *  - Doesn't pick up if a treenode's depth on a skeleton changes
+   *
+   *  All are solved by clearing or refreshing the cache.
+   *
+   * @constructor
+   */
+  var ConnectorViewerCache = function(skeletonSource) {
+    this.relationTypes = {
+      '0': 'presynaptic_to',
+      '1': 'postsynaptic_to',
+      '2': 'gapjunction_with',
+      '-1': 'abutting'
+    };
+
+    /**
+     *  {
+     *    connID1: {
+     *      'coords': {'x': _, 'y': _, 'z': _},
+     *      'relationType': {
+     *        'postsynaptic_to':   Set([treenodeID1, treenodeID2, ...]),
+     *        'presynaptic_to':    Set([treenodeID1, treenodeID2, ...]),
+     *        'gapjunction_with':  Set([treenodeID1, treenodeID2, ...]),
+     *        'abutting':          Set([treenodeID1, treenodeID2, ...])
+     *      }
+     *    },
+     *    connID2...
+     *  }
+     */
+    this.connectors = {};
+
+    /**
+     *  {
+     *    skelID1: {
+     *      'arborTimestamp': _,
+     *      'name': _,
+     *      'nameTimestamp': _,
+     *      'maxDepth': _
+     *    },
+     *    skelID2...
+     *  }
+     */
+    this.skeletons = {};
+
+    /**
+     *  {
+     *    treenodeID1: {
+     *      'skelID': _,
+     *      'depth': _
+     *    },
+     *    treenodeID2: ...
+     *  }
+     */
+    this.treenodes = {};
+
+    this.sortFn = null;
+
+    this.sorting = {
+      'postsynaptic_to':   {sortFn: this.sortFn, order: new Set(), sorted: false},
+      'presynaptic_to':    {sortFn: this.sortFn, order: new Set(), sorted: false},
+      'gapjunction_with':  {sortFn: this.sortFn, order: new Set(), sorted: false},
+      'abutting':          {sortFn: this.sortFn, order: new Set(), sorted: false}
+    };
+
+    this.skeletonSource = skeletonSource;
+  };
+
+  ConnectorViewerCache.prototype = {};
+
+  ConnectorViewerCache.prototype.clear = function() {
+    this.connectors = {};
+    this.skeletons = {};
+    this.sorting = {
+      'postsynaptic_to':   {sortFn: this.sortFn, order: new Set(), sorted: false},
+      'presynaptic_to':    {sortFn: this.sortFn, order: new Set(), sorted: false},
+      'gapjunction_with':  {sortFn: this.sortFn, order: new Set(), sorted: false},
+      'abutting':          {sortFn: this.sortFn, order: new Set(), sorted: false}
+    };
+    this.treenodes = {};
+  };
+
+  ConnectorViewerCache.prototype.refresh = function() {
+    this.clear();
+    return this.ensureValidCache();
+  };
+
+  /**
+   * Return the order of connectors associated with the current selected skeletons by the given relation type, using
+   * the ConnectorViewerCache's stored sorting function.
+   *
+   * @param relationType
+   * @returns Promise of conector order
+   */
+  ConnectorViewerCache.prototype.updateConnectorOrder = function(relationType) {
+    var self = this;
+    var order;
+
+    return this.ensureValidCache().then(function() {
+      var selectedSkeletons = self.skeletonSource.getSelectedSkeletons();
+      var sortInfo = self.sorting[relationType];
+
+      if (sortInfo.sorted && sortInfo.sortFn === self.sortFn) {
+        order = Array.from(sortInfo.order);
+      } else {
+        // re-sort using the stored sort function
+        sortInfo.sortFn = self.sortFn;
+        order = Array.from(sortInfo.order).sort(function(connID1, connID2) {
+          return self.sortFn(connID1, connID2, relationType, selectedSkeletons);
+        });
+
+        // update the sorting cache
+        sortInfo.order = new Set(order);
+        sortInfo.sorted = true;
+      }
+
+      // turn the array of connector IDs into informative objects
+      return order.map(function(connID) {
+        return {
+          connID: connID,
+          coords: self.connectors[connID].coords,
+          skelNames: Array.from(self.connectors[connID].relationType[relationType])
+            .reduce(function(arr, treenodeID) {
+              let skelID = self.treenodes[treenodeID].skelID;
+              let skelName = self.skeletons[skelID].name;
+
+              // only add distinct skeleton IDs, and only skeleton IDs which are in the selected skeletons (they
+              // might just be associated with treenodes which are associated with connectors which are associated
+              // with selected skeletons)
+              if (!arr.includes(skelName) && selectedSkeletons.includes(skelID)) {
+                arr.push(skelName);
+              }
+
+              return arr;
+            }, [])
+            .sort()  // sort alphanumerically to keep it deterministic
+        };
+      });
+    });
+  };
+
+  /**
+   * Ensure that all of the currently selected skeletons have recent representations in the cache.
+   *
+   * @returns {Promise.<*>}
+   */
+  ConnectorViewerCache.prototype.ensureValidCache = function() {
+    var self = this;
+    var promises = this.skeletonSource.getSelectedSkeletons().map(self.ensureValidCacheForSkel.bind(self));
+    return Promise.all(promises);
+  };
+
+  /**
+   * Ensure that a given skeleton has a recent representation in the cache.
+   *
+   * @param skelID
+   * @returns {Promise}
+   */
+  ConnectorViewerCache.prototype.ensureValidCacheForSkel = function(skelID) {
+    var self = this;
+    var now = Date.now();
+
+    if (skelID in this.skeletons && now - this.skeletons[skelID].arborTimestamp < CACHE_TIMEOUT) {
+      return Promise.resolve();  // cache is recent for this skeleton
+    }
+
+    // cache is not recent for this skeleton: fetch it from the database
+    return CATMAID.fetch(`${project.id}/skeletons/${skelID}/compact-detail`, 'GET', {with_connectors: true})
+      .then(function(json) {
+        var arborParser = new CATMAID.ArborParser();
+
+        // this object will calculate treenode depth
+        var arbor = arborParser.init('compact-skeleton', json).arbor;
+
+        if (!(skelID in self.skeletons)) {
+          // name uses a different API endpoint so needs a different timestamp
+          self.skeletons[skelID] = {name: null, nameTimestamp: -CACHE_TIMEOUT};
+        }
+        self.skeletons[skelID].arborTimestamp = now;
+
+        // get the maximum depth of the tree, as a sum of node-to-node euclidean distances, from the root
+        var root = arbor.findRoot();
+        var distancesObj = arbor.nodesDistanceTo(root, self.euclideanDistance.bind(self, arborParser.positions));
+        self.skeletons[skelID].maxLength = distancesObj.max;
+
+        // get all the connectors associated with the given skeleton by any relation type
+        var connectorsResponse = json[1];
+        for (var i = 0; i < connectorsResponse.length; i++) {
+          // turn the array response into more readable objects
+          let connectorResponse = connectorsResponse[i];
+          let treenodeID = connectorResponse[0];
+          let connID = connectorResponse[1];
+          let relationType = self.relationTypes[connectorResponse[2]];
+          let coords = {
+            x: connectorResponse[3],
+            y: connectorResponse[4],
+            z: connectorResponse[5]
+          };
+
+          // insert information from this skeleton into the connectors cache
+          if (!(connID in self.connectors)) {
+            self.connectors[connID] = {
+              coords: null,
+              relationType: {
+                postsynaptic_to: new Set(),
+                presynaptic_to: new Set(),
+                gapjunction_with: new Set(),
+                abutting: new Set()
+              }
+            };
+          }
+          self.connectors[connID].coords = coords;
+          self.connectors[connID].relationType[relationType].add(treenodeID);
+
+          // insert information from this skeleton into the sorting cache if it's not there, and flag it for re-sorting
+          if (!self.sorting[relationType].order.has(connID)) {
+            self.sorting[relationType].order.add(connID);
+            self.sorting[relationType].sorted = false;
+          }
+
+          // insert information from this skeleton into the treenodes cache (only treenodes associated with connectors)
+          self.treenodes[treenodeID] = {
+            skelID: skelID,
+            depth: distancesObj.distances[treenodeID]
+          };
+        }
+      })
+      .then(self.ensureValidCacheForSkelName.bind(self, skelID));  // ensure name is up-to-date
+  };
+
+  /**
+   * Ensure that the given skeleton's name has a recent representation in the cache.
+   *
+   * @param skelID
+   * @returns {*}
+   */
+  ConnectorViewerCache.prototype.ensureValidCacheForSkelName = function(skelID) {
+    var self = this;
+    var now = Date.now();
+
+    if ( this.skeletons[skelID].name && now - this.skeletons[skelID].nameTimestamp < CACHE_TIMEOUT ) {
+      // name is recent
+      return Promise.resolve();
+    } else {
+      // get name from database and add it to the skeletons cache
+      return CATMAID.fetch(project.id + '/skeleton/' + skelID + '/neuronname', 'GET').then(function(json) {
+        self.skeletons[skelID].name = json.neuronname;
+        self.skeletons[skelID].nameTimestamp = now;
+      });
+    }
+  };
+
+  /**
+   * This is bound to the positions property of an initialised Arbor instance.
+   *
+   * @param positions - object of treenode ID : THREE.Vector instances of x y z position, as found in the
+   * 'positions' property of an initialised Arbor instance.
+   * @param child - a treenode ID
+   * @param parent - a treenode ID
+   * @returns {*|number}
+   */
+  ConnectorViewerCache.prototype.euclideanDistance = function(positions, child, parent) {
+    return positions[child].distanceTo(positions[parent]);
+  };
+
+  /**
+   *
+   * @param sortFnName A string which is the property name, in the sortFns object, of a comparator function. The
+   * function will be bound to the ConnectorViewerCache, and should have the signature
+   * function(connector1ID, connector2ID, relationType, selectedSkeletons)
+   */
+  ConnectorViewerCache.prototype.setSortFn = function (sortFnName) {
+      this.sortFn = sortFns[sortFnName].bind(this);  // is the binding necessary here?
+  };
+
+  /**
+   * Get the depth of a given connector on its associated selected skeleton by the given relationType, in absolute
+   * terms or as a proportion of the skeleton's maximum depth.
+   *
+   * As connectors of some relation type can be associated with multiple skeletons, this only counts those which are
+   * in the given selection, and if there are multiple such skeletons, returns the smallest depth.
+   *
+   * @param relationType
+   * @param selectedSkeletons
+   * @param proportional
+   * @param connID
+   * @returns {Number}
+   */
+  ConnectorViewerCache.prototype.getMinDepth = function(relationType, selectedSkeletons, proportional, connID) {
+    var minConnDepth = Infinity;
+
+    for (let treenodeID of this.connectors[connID].relationType[relationType]) {
+      if (selectedSkeletons.includes(this.treenodes[treenodeID].skelID)) {
+        let treenodeInfo = this.treenodes[treenodeID];
+        let depth = proportional ? treenodeInfo.depth / this.skeletons[treenodeInfo.skelID].maxLength : treenodeInfo.depth;
+        minConnDepth = Math.min(minConnDepth, depth);
+      }
+    }
+
+    return minConnDepth;
+  };
+
+  /**
+   * Get a skeleton name associated with a connector by the given relation type.
+   *
+   * As connectors of some relation type can be associated with multiple skeletons, this only counts those which are
+   * in the given selection, and if there are multiple such skeletons, returns the first skeleton by alphanumeric sort.
+   *
+   * @param relationType
+   * @param selectedSkeletons
+   * @param connID
+   * @returns {String}
+   */
+  ConnectorViewerCache.prototype.getFirstSkelName = function(relationType, selectedSkeletons, connID) {
+    var skelNames = [];
+
+    for (let treenodeID of this.connectors[connID].relationType[relationType]) {
+      if (selectedSkeletons.includes(this.treenodes[treenodeID].skelID)) {
+        skelNames.push(this.skeletons[this.treenodes[treenodeID].skelID].name);
+      }
+    }
+
+    return skelNames.sort()[0];
+  };
+
+  /**
+   * Object containing comparator functions to be passed to Array.sort().
+   *
+   * Members will be bound to the ConnectorViewerCache before usage and should have the signature
+   * function(connector1ID, connector2ID, relationType, selectedSkeletons).
+   */
+  const sortFns = {};
+
+  /**
+   * Sort connectors by how far they are from their associated skeleton's root node. Only skeletons which are in
+   * the given array of selected skeletons are counted, and only if they are associated with the connector by the
+   * given relation type. If there are multiple such skeletons, the smallest depth is used.
+   *
+   * @param connID1
+   * @param connID2
+   * @param relationType
+   * @param selectedSkeletons
+   * @returns {number}
+   */
+  sortFns.depthSort = function(connID1, connID2, relationType, selectedSkeletons) {
+    var self = this;
+    var minConnDepths = [connID1, connID2]
+      .map(self.getMinDepth.bind(self, relationType, selectedSkeletons, false));
+
+    return minConnDepths[0] - minConnDepths[1];
+  };
+
+  /**
+   * Similar to sortFns.depthSort, but returns depths as a proportion of the maximum length of the skeleton.
+   *
+   * @param connID1
+   * @param connID2
+   * @param relationType
+   * @param selectedSkeletons
+   * @returns {number}
+   */
+  sortFns.depthProportionSort = function(connID1, connID2, relationType, selectedSkeletons) {
+    var self = this;
+    var minConnDepthPpns = [connID1, connID2]
+      .map(self.getMinDepth.bind(self, relationType, selectedSkeletons, true));
+
+    return minConnDepthPpns[0] - minConnDepthPpns[1];
+  };
+
+  sortFns.connIdSort = function(connID1, connID2) {
+    return connID1 - connID2;
+  };
+
+  /**
+   * Not guaranteed to preserve the current sort order
+   */
+  sortFns.nullSort = function() {
+    return 0;
+  };
+
+  sortFns.skelNameSort = function(connID1, connID2, relationType, selectedSkeletons) {
+    var self = this;
+    var skelNames = [connID1, connID2].map(self.getFirstSkelName.bind(self, relationType, selectedSkeletons));
+
+    return skelNames[0].localeCompare(skelNames[1]);
+  };
+
+})(CATMAID);

--- a/django/applications/catmaid/static/js/widgets/overlay.js
+++ b/django/applications/catmaid/static/js/widgets/overlay.js
@@ -2998,7 +2998,7 @@ SkeletonAnnotations.TracingOverlay.prototype.updateNodes = function (callback,
         true,
         errCallback,
         false,
-        'stack-' + self.stackViewer.primaryStack.id + '-url-' + url);
+        'stack-' + self.stackViewer.getId() + '-url-' + url);
     }
   });
 };

--- a/django/applications/catmaid/static/js/widgets/stats.js
+++ b/django/applications/catmaid/static/js/widgets/stats.js
@@ -33,19 +33,19 @@
 
       var entry = '', points = 0;
       if( data.hasOwnProperty('new_treenodes') && data['new_treenodes'] > 0 ) {
-        entry += wrapWithLink(data['new_treenodes'], 'created') + ' /';
+        entry += wrapWithLink(data['new_treenodes'].toLocaleString(), 'created') + ' /';
         points += data['new_treenodes'];
       } else {
         entry += '0 /';
       }
       if( data.hasOwnProperty('new_connectors') && data['new_connectors'] > 0 ) {
-        entry += ' ' + wrapWithLink(data['new_connectors'], 'connectors') + ' /';
+        entry += ' ' + wrapWithLink(data['new_connectors'].toLocaleString(), 'connectors') + ' /';
         points += data['new_connectors'];
       } else {
         entry += ' 0 /';
       }
       if( data.hasOwnProperty('new_reviewed_nodes') && data['new_reviewed_nodes'] > 0 ) {
-        entry += ' ' + wrapWithLink(data['new_reviewed_nodes'], 'reviewed');
+        entry += ' ' + wrapWithLink(data['new_reviewed_nodes'].toLocaleString(), 'reviewed');
         points += data['new_reviewed_nodes'];
       } else {
         entry += ' 0';
@@ -321,7 +321,7 @@
           }
         });
     };
-    
+
     var parseDate = function(d) {
       var d_s = d.toString();
       var year = d_s.substring(0, 4);
@@ -329,7 +329,7 @@
       var day = d_s.substring(6, 8);
       return new Date(year + '-' + month + '-' + day);
     };
-    
+
     Date.prototype.addDays = function(days){
       var msPerDay = 1000 * 60 * 60 * 24;
       var ms = this.getTime() + (msPerDay * days);
@@ -424,7 +424,7 @@
         .attr("transform", "translate(" + (w - 12) + ", " + (h / 2) + ") rotate(90)")
         .text("Nodes edited");
     };
-    
+
     this.refresh_project_statistics = function() {
       refresh_nodecount();
       this.refresh_history();

--- a/django/applications/catmaid/static/js/widgets/tag-table.js
+++ b/django/applications/catmaid/static/js/widgets/tag-table.js
@@ -195,21 +195,6 @@
     this.selectedSkeletons.removeSkeletons(obj.subtract);
   };
 
-  Set.prototype.difference = function(otherSet) {  // separate function?
-    var difference = new Set(this);
-    otherSet.forEach(function(elem) {
-      difference.delete(elem);
-    });
-    return difference;
-  };
-
-  Set.prototype.addAll = function(array) {  // separate function?
-    for (var i = 0; i < array.length; i++) {
-      this.add(array[i]);
-    }
-    return this;
-  };
-
   var createCheckbox = function(checked, type, row) {
     if (type ==='display') {
       var checkbox = $('<input />', {

--- a/django/applications/catmaid/static/js/widgets/tag-table.js
+++ b/django/applications/catmaid/static/js/widgets/tag-table.js
@@ -5,8 +5,6 @@
 
   "use strict";
 
-  var CACHE_TIMEOUT = 5*60*1000;  // cache invalidation timeout in ms
-
   var TagTable = function() {
     this.widgetID = this.registerInstance();
     this.selectedSkeletons = new CATMAID.BasicSkeletonSource(this.getName());
@@ -19,79 +17,41 @@
     return 'Tag Table ' + this.widgetID;
   };
 
-  var labelSkelMappingCache = {};  // todo - button for enabling/disabling cache?
-
   /**
+   *  {
+   *    labelName1: {
+   *      'labelIDs': Set([labelID1, labelID2, ...]),
+   *      'labelName': labelName1,
+   *      'skelIDs': Set([skelID1, skelID2, ...]),
+   *      'nodeIDs': Set([nodeID1, nodeID2, ...]),
+   *      'checked': isChecked
+   *    },
+   *    labelName2: ...
+   *  }
    *
-   * @param labelIDs - array of label IDs
-   * @param callback - function which takes a list of skelIDs
+   * @type {{}}
    */
-  var getSkelIDsFromLabelIDs = function(labelIDs) {
-    var remoteLabelIDs = [];
-    var skelIDs = new Set();
-
-    var now = Date.now();
-
-    for (var i = 0; i < labelIDs.length; i++) {
-      var labelID = labelIDs[i];
-      if (labelID in labelSkelMappingCache && now - labelSkelMappingCache[labelID].timestamp <= CACHE_TIMEOUT) {
-        skelIDs.addAll(
-          labelSkelMappingCache[labelID].skelIDs
-        );
-      } else {
-        remoteLabelIDs.push(labelID);
-      }
-    }
-
-    if (remoteLabelIDs.length === 0) {
-      return Promise.resolve(Array.from(skelIDs));
-    }
-
-    return CATMAID.fetch(project.id + '/skeletons/node-labels', 'POST', {
-      'label_ids': remoteLabelIDs
-    }).then(function(json) {
-      now = Date.now();
-
-      for (var i = 0; i < json.length; i++) {
-        var labelSkelTuple = json[i];
-        labelSkelMappingCache[labelSkelTuple[0]].skelIDs = labelSkelTuple[1];
-        labelSkelMappingCache[labelSkelTuple[0]].timestamp = now;
-        skelIDs.addAll(labelSkelTuple[1]);
-      }
-
-      return Array.from(skelIDs);
-    });
-  };
+  var responseCache = {};
 
   /**
    * Set the skeleton source to reflect data in the table
    */
   TagTable.prototype.syncSkeletonSource = function() {
-    var selectedLabelIDs = this.getSelectedLabelIDs();
+    var areInSource = new Set(this.selectedSkeletons.getSelectedSkeletons());
 
-    getSkelIDsFromLabelIDs(selectedLabelIDs).then((function() {
-      var areInSource = new Set(this.selectedSkeletons.getSelectedSkeletons());
-      var shouldBeInSource = this.getSelectedLabelIDs().reduce(function(shouldBeInSource, currentValue) {
-        return shouldBeInSource.addAll(labelSkelMappingCache[currentValue].skelIDs);
-      }, new Set());
-
-      this.addAndSubtractFromSkeletonSource({
-        add: Array.from(shouldBeInSource.difference(areInSource)),
-        subtract: Array.from(areInSource.difference(shouldBeInSource))
-      });
-
-      $("#tag-table" + this.widgetID + '_processing').hide();
-    }).bind(this)).catch(CATMAID.handleError);
-  };
-
-  TagTable.prototype.getSelectedLabelIDs = function () {
-    var selectedLabelIDs = [];
-    for (var key in labelSkelMappingCache) {
-      if (labelSkelMappingCache.hasOwnProperty(key) && labelSkelMappingCache[key].selected) {
-        selectedLabelIDs.push(key);
+    var shouldBeInSource = new Set();
+    for (var skelName of Object.keys(responseCache)) {
+      if (responseCache[skelName].checked) {
+        shouldBeInSource.addAll(responseCache[skelName].skelIDs);
       }
     }
-    return selectedLabelIDs;
+
+    this.addAndSubtractFromSkeletonSource({
+      add: Array.from(shouldBeInSource.difference(areInSource)),
+      subtract: Array.from(areInSource.difference(shouldBeInSource))
+    });
+
+    $("#tag-table" + this.widgetID + '_processing').hide();
   };
 
   TagTable.prototype.getWidgetConfiguration = function() {
@@ -99,24 +59,18 @@
     return {
       // controlsID: 'tag-tableWidgetControls' + this.widgetID,
       // createControls: function(controls) {
-      //   // add buttons - see connectivity-matrix.js
       // },
       contentID: 'tag-table-widget' + this.widgetID,
       createContent: function(container) {
+        var self = this;
+
         container.innerHTML =
-          '<table cellpadding="0" cellspacing="0" border="0" class="display" id="' + "tag-table" + this.widgetID + '">' +
+          '<table cellpadding="0" cellspacing="0" border="0" class="display" id="' + "tag-table" + self.widgetID + '">' +
           '<thead>' +
           '<tr>' +
-          '<th>tag id' +
-            '<input type="number" name="searchInputID" id="tag-table' +
-                this.widgetID +
-                'searchInputID' +
-              '" value=""' +
-            '/>' +
-          '</th>' +
-          '<th>tag name' +
+          '<th>tag' +
             '<input type="text" name="searchInputLabel" id="tag-table' +
-                this.widgetID +
+                self.widgetID +
                 'searchInputLabel' +
               '" value="Search" class="search_init" ' +
             '/>' +
@@ -124,7 +78,7 @@
           '<th>skeletons</th>' +
           '<th>select skeletons' +
           '<input type="checkbox" name="selectAllSkels" id="tag-table' +
-            this.widgetID +
+            self.widgetID +
             'selectAllSkels' +
           '" value="selectAllSkels"' +
           '/>' +
@@ -134,8 +88,7 @@
           '</thead>' +
           '<tfoot>' +
           '<tr>' +
-          '<th>tag id</th>' +
-          '<th>tag name</th>' +
+          '<th>tag</th>' +
           '<th>skeletons</th>' +
           '<th>select skeletons</th>' +
           '<th>nodes</th>' +
@@ -147,20 +100,41 @@
 
         CATMAID.fetch(project.id + '/labels/stats', 'GET')  // ~5s
           .then(function(json) {
-            var rowObjs = json.map(function(arr) {
-              labelSkelMappingCache[arr[0]] = {
-                skelIDs: [],
-                timestamp: -CACHE_TIMEOUT,
-                selected: false
-              };
-              return {
-                id: arr[0],
-                tag: arr[1],
-                skeletons: arr[2],
-                nodes: arr[3],
-                checked: false
-              };
-            });
+            var responseObj = json.reduce(function(obj, arr) {
+              var labelID = arr[0];
+              var labelName = arr[1];
+              var skelID = arr[2];
+              var nodeID = arr[3];
+
+              if (!(labelName in obj)) {
+                obj[labelName] = {
+                  'labelIDs': new Set([labelID]),
+                  'skelIDs': new Set(),
+                  'nodeIDs': new Set(),
+                  'checked': false
+                };
+              } else {
+                obj[labelName].labelIDs.add(labelID);
+                obj[labelName].skelIDs.add(skelID);
+                obj[labelName].nodeIDs.add(nodeID);
+              }
+
+              return obj;
+            }, {});
+
+            responseCache = responseObj;
+
+            var rowObjs = [];
+            for (var key of Object.keys(responseObj)) {
+              if (responseObj[key].nodeIDs.size) {  // only labels applied to nodes
+                rowObjs.push({
+                  'labelName': key,
+                  'skelCount': responseObj[key].skelIDs.size,
+                  'nodeCount': responseObj[key].nodeIDs.size,
+                  'checked': false
+                });
+              }
+            }
 
             var table = $(tableSelector).DataTable();
 
@@ -212,6 +186,7 @@
   };
 
   TagTable.prototype.init = function() {
+    var self = this;
     var widgetID = this.widgetID;
     var tableSelector = "#tag-table" + widgetID;
 
@@ -230,19 +205,13 @@
       "deferRender": true,
       "columns": [
         {
-          "data": 'id',
+          "data": 'labelName',
           "orderable": true,
           "searchable": true,
           "className": "center"
         },
         {
-          "data": 'tag',
-          "orderable": true,
-          "searchable": true,
-          "className": "center"
-        },
-        {
-          "data": 'skeletons',
+          "data": 'skelCount',
           "orderable": true,
           "className": "center"
         },
@@ -254,7 +223,7 @@
           "width": "5%"
         },
         {
-          "data": 'nodes',
+          "data": 'nodeCount',
           "orderable": true,
           "className": "center"
         }
@@ -263,37 +232,39 @@
 
     $(tableSelector + '_processing').show();
 
-    $(this.oTable).on('change', '.skelSelector', (function(event) {
-      var table = this.oTable.DataTable();
+    $(this.oTable).on('change', '.skelSelector', function(event) {
+      var table = self.oTable.DataTable();
       var row = table.row(event.currentTarget.closest('tr'));
       var currentCheckedState = event.currentTarget.checked;
-      row.data().checked = currentCheckedState;
-      labelSkelMappingCache[row.data().id].selected = currentCheckedState;
-      row.invalidate();
-      if (currentCheckedState) {  // if checking box, just add
-        getSkelIDsFromLabelIDs([row.data().id]).then((function() {
-          if (row.data().checked) {
-            this.addAndSubtractFromSkeletonSource({
-              add: labelSkelMappingCache[row.data().id].skelIDs,
-              subtract: []
-            });
-          }
-        }).bind(this)).catch(CATMAID.handleError);
-      } else {  // if unchecking box, run full sync
-        this.syncSkeletonSource();
-      }
-    }).bind(this));
 
-    $(tableSelector + 'selectAllSkels').change((function(event){
+      row.data().checked = currentCheckedState;
+      responseCache[row.data().labelName].checked = currentCheckedState;
+
+      row.invalidate();
+
+      if (currentCheckedState) {  // if checking box, just add
+        self.addAndSubtractFromSkeletonSource({
+          add: Array.from(responseCache[row.data().labelName].skelIDs),
+          subtract: []
+        });
+      } else {  // if unchecking box, run full sync
+        self.syncSkeletonSource();
+      }
+    });
+
+    $(tableSelector + 'selectAllSkels').change(function(event){
       // change all searched-for checkboxes to the same value as the header checkbox
-      var table = this.oTable.DataTable();
+      var table = self.oTable.DataTable();
+
       $(tableSelector + '_processing').show();  // doesn't show up immediately
       table.rows({search: 'applied'}).every(function () {
         // rows().every() may be slow, but is the only way to use search: 'applied'
         // using rows().data() hits call stack limit with large data
         var row = this;
         var currentCheckedState = event.currentTarget.checked;
-        labelSkelMappingCache[row.data().id].selected = currentCheckedState;
+
+        responseCache[row.data().labelName].checked = currentCheckedState;
+
         if (row.data().checked != currentCheckedState) {
           row.data().checked = currentCheckedState;
           row.invalidate();
@@ -301,35 +272,22 @@
       });
 
       table.draw();
-      this.syncSkeletonSource();
-    }).bind(this));
+      self.syncSkeletonSource();
+    });
 
-    $(tableSelector + "searchInputLabel").keydown((function (event) {
+    $(tableSelector + "searchInputLabel").keydown(function (event) {
       // filter table by tag text on hit enter
       if (event.which == 13) {
         event.stopPropagation();
         event.preventDefault();
         // Filter with a regular expression
         var filter_searchtag = event.currentTarget.value;
-        this.oTable.DataTable()
+        self.oTable.DataTable()
           .column(event.currentTarget.closest('th'))
           .search(filter_searchtag, true, false)
           .draw();
       }
-    }).bind(this));
-
-    $(tableSelector + "searchInputID").keydown((function (event) {
-      // filter table by tag text on hit enter
-      if (event.which == 13) {
-        event.stopPropagation();
-        event.preventDefault();
-        var filter_searchid = event.currentTarget.value;
-        this.oTable.DataTable()
-          .column(event.currentTarget.closest('th'))
-          .search(filter_searchid, false, false)
-          .draw();
-      }
-    }).bind(this));
+    });
 
     // prevent sorting the column when focusing on the search field
     $(tableSelector + " thead input").click(function (event) {

--- a/django/applications/catmaid/templates/catmaid/clustering/setup.html
+++ b/django/applications/catmaid/templates/catmaid/clustering/setup.html
@@ -7,19 +7,19 @@
 {% if wizard.steps.current == "classifications" %}
     <p>
         <label for="select_all">
-            <input type="checkbox" name="select_all" id="select-all">
+            <input type="checkbox" name="select_all">
             Select all classification graphs
         </label>
     </p>
 {% elif wizard.steps.current == "features" %}
     <p>
         <label for="select_all">
-            <input type="checkbox" name="select_all" id="select-all">
+            <input type="checkbox" name="select_all">
             Select all classification features
         </label>
     </p>
 {% endif %}
-<form method="post" id="clustering-setup-form"
+<form method="post" name="clustering-setup-form"
       action="{% url 'catmaid:clustering_setup' workspace_pid %}">
 {% csrf_token %}
 {{ wizard.management_form }}

--- a/django/applications/catmaid/tests/apis/test_labels.py
+++ b/django/applications/catmaid/tests/apis/test_labels.py
@@ -118,15 +118,25 @@ class LabelsApiTests(CatmaidApiTestCase):
         return response
 
 
+    def assertListOfListsEqualContent(self, ref, test):
+        self.assertEqual(len(ref), len(test))
+
+        ref_set = {tuple(item) for item in ref}
+        test_set = {tuple(item) for item in test}
+
+        self.assertSetEqual(ref_set, test_set)
+
+
     def test_stats(self):
         expected_response = [
-            [351, 'TODO', 2, 2],
-            [2342, 'uncertain end', 1, 1],
+            [2342, u'uncertain end', 373, 403],
+            [351, u'TODO', 1, 349],
+            [351, u'TODO', 235, 261]
         ]
 
         response = self.get_successful_stats_response()
 
-        self.assertJSONEqual(response.content, expected_response)
+        self.assertListOfListsEqualContent(json.loads(response.content), expected_response)
 
 
     def test_stats_does_not_find_all_nodes_of_skeleton(self):
@@ -139,4 +149,3 @@ class LabelsApiTests(CatmaidApiTestCase):
 
         for row in response:
             self.assertFalse(row[1] == 'skeleton {}'.format(row[0]) and row[2] == 1, msg=msg.format(row[0], row[1]))
-


### PR DESCRIPTION
A short-term solution to #1468, duplication of tags in the table (reflecting duplication of tags in the database).

One of the projects I was testing the tag table on had not only labels with unique IDs sharing a name, but also several of these on the same node. This patch changes the API endpoint so that it doesn't do any counting or grouping on the server, but allows the client to do it as appropriate for the application.

As a bonus, this means that we don't need to make separate API calls to get the skeleton IDs from the label IDs (because the first call gets them all), which improves performance when running on my local server with a project with ~3000 skeletons.

Because the table only makes one call to the API, there isn't any cache invalidation - but the user can now refresh manually because this also resolves #1439. As it's a fairly large call, I thought it would be more surprising to have their table lock up for a few seconds every 5 minutes than it would be to just continue using the data as of the time of opening the widget.