### PR TITLE
Tag Table: open node table with selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,9 @@ Miscellaneous:
 - The connector table can now be used as a skeleton source, where
   previously an error would be raised.
 
+- The tag table now collapses any tags with identical names, but as a
+  consequence does not show the tag ID (as there may be multiple IDs)
+
 
 ## 2016.12.16
 

--- a/django/applications/catmaid/static/js/extensions.js
+++ b/django/applications/catmaid/static/js/extensions.js
@@ -53,6 +53,18 @@ Set.prototype.intersection = function(iterable) {
 };
 
 /**
+ * Return a new set of those items which exist in either this set or the given 'of'-able iterable.
+ *
+ * @param iterable
+ * @returns {Set}
+ */
+Set.prototype.union = function(iterable) {
+  var union = new Set(this);
+  union.addAll(iterable);
+  return union;
+};
+
+/**
  * jQuery DataTables extensions
  */
 

--- a/django/applications/catmaid/static/js/widgets/tag-table.js
+++ b/django/applications/catmaid/static/js/widgets/tag-table.js
@@ -5,8 +5,6 @@
 
   "use strict";
 
-  var CACHE_TIMEOUT = 5*60*1000;  // cache invalidation timeout in ms
-
   var TagTable = function() {
     this.widgetID = this.registerInstance();
     this.selectedSkeletons = new CATMAID.BasicSkeletonSource(this.getName());
@@ -19,79 +17,41 @@
     return 'Tag Table ' + this.widgetID;
   };
 
-  var labelSkelMappingCache = {};  // todo - button for enabling/disabling cache?
-
   /**
+   *  {
+   *    labelName1: {
+   *      'labelIDs': Set([labelID1, labelID2, ...]),
+   *      'labelName': labelName1,
+   *      'skelIDs': Set([skelID1, skelID2, ...]),
+   *      'nodeIDs': Set([nodeID1, nodeID2, ...]),
+   *      'checked': isChecked
+   *    },
+   *    labelName2: ...
+   *  }
    *
-   * @param labelIDs - array of label IDs
-   * @param callback - function which takes a list of skelIDs
+   * @type {{}}
    */
-  var getSkelIDsFromLabelIDs = function(labelIDs) {
-    var remoteLabelIDs = [];
-    var skelIDs = new Set();
-
-    var now = Date.now();
-
-    for (var i = 0; i < labelIDs.length; i++) {
-      var labelID = labelIDs[i];
-      if (labelID in labelSkelMappingCache && now - labelSkelMappingCache[labelID].timestamp <= CACHE_TIMEOUT) {
-        skelIDs.addAll(
-          labelSkelMappingCache[labelID].skelIDs
-        );
-      } else {
-        remoteLabelIDs.push(labelID);
-      }
-    }
-
-    if (remoteLabelIDs.length === 0) {
-      return Promise.resolve(Array.from(skelIDs));
-    }
-
-    return CATMAID.fetch(project.id + '/skeletons/node-labels', 'POST', {
-      'label_ids': remoteLabelIDs
-    }).then(function(json) {
-      now = Date.now();
-
-      for (var i = 0; i < json.length; i++) {
-        var labelSkelTuple = json[i];
-        labelSkelMappingCache[labelSkelTuple[0]].skelIDs = labelSkelTuple[1];
-        labelSkelMappingCache[labelSkelTuple[0]].timestamp = now;
-        skelIDs.addAll(labelSkelTuple[1]);
-      }
-
-      return Array.from(skelIDs);
-    });
-  };
+  var responseCache = {};
 
   /**
    * Set the skeleton source to reflect data in the table
    */
   TagTable.prototype.syncSkeletonSource = function() {
-    var selectedLabelIDs = this.getSelectedLabelIDs();
+    var areInSource = new Set(this.selectedSkeletons.getSelectedSkeletons());
 
-    getSkelIDsFromLabelIDs(selectedLabelIDs).then((function() {
-      var areInSource = new Set(this.selectedSkeletons.getSelectedSkeletons());
-      var shouldBeInSource = this.getSelectedLabelIDs().reduce(function(shouldBeInSource, currentValue) {
-        return shouldBeInSource.addAll(labelSkelMappingCache[currentValue].skelIDs);
-      }, new Set());
-
-      this.addAndSubtractFromSkeletonSource({
-        add: Array.from(shouldBeInSource.difference(areInSource)),
-        subtract: Array.from(areInSource.difference(shouldBeInSource))
-      });
-
-      $("#tag-table" + this.widgetID + '_processing').hide();
-    }).bind(this)).catch(CATMAID.handleError);
-  };
-
-  TagTable.prototype.getSelectedLabelIDs = function () {
-    var selectedLabelIDs = [];
-    for (var key in labelSkelMappingCache) {
-      if (labelSkelMappingCache.hasOwnProperty(key) && labelSkelMappingCache[key].selected) {
-        selectedLabelIDs.push(key);
+    var shouldBeInSource = new Set();
+    for (var skelName of Object.keys(responseCache)) {
+      if (responseCache[skelName].checked) {
+        shouldBeInSource.addAll(responseCache[skelName].skelIDs);
       }
     }
-    return selectedLabelIDs;
+
+    this.addAndSubtractFromSkeletonSource({
+      add: Array.from(shouldBeInSource.difference(areInSource)),
+      subtract: Array.from(areInSource.difference(shouldBeInSource))
+    });
+
+    $("#tag-table" + this.widgetID + '_processing').hide();
   };
 
   TagTable.prototype.getWidgetConfiguration = function() {
@@ -99,24 +59,18 @@
     return {
       // controlsID: 'tag-tableWidgetControls' + this.widgetID,
       // createControls: function(controls) {
-      //   // add buttons - see connectivity-matrix.js
       // },
       contentID: 'tag-table-widget' + this.widgetID,
       createContent: function(container) {
+        var self = this;
+
         container.innerHTML =
-          '<table cellpadding="0" cellspacing="0" border="0" class="display" id="' + "tag-table" + this.widgetID + '">' +
+          '<table cellpadding="0" cellspacing="0" border="0" class="display" id="' + "tag-table" + self.widgetID + '">' +
           '<thead>' +
           '<tr>' +
-          '<th>tag id' +
-            '<input type="number" name="searchInputID" id="tag-table' +
-                this.widgetID +
-                'searchInputID' +
-              '" value=""' +
-            '/>' +
-          '</th>' +
-          '<th>tag name' +
+          '<th>tag' +
             '<input type="text" name="searchInputLabel" id="tag-table' +
-                this.widgetID +
+                self.widgetID +
                 'searchInputLabel' +
               '" value="Search" class="search_init" ' +
             '/>' +
@@ -124,7 +78,7 @@
           '<th>skeletons</th>' +
           '<th>select skeletons' +
           '<input type="checkbox" name="selectAllSkels" id="tag-table' +
-            this.widgetID +
+            self.widgetID +
             'selectAllSkels' +
           '" value="selectAllSkels"' +
           '/>' +
@@ -134,8 +88,7 @@
           '</thead>' +
           '<tfoot>' +
           '<tr>' +
-          '<th>tag id</th>' +
-          '<th>tag name</th>' +
+          '<th>tag</th>' +
           '<th>skeletons</th>' +
           '<th>select skeletons</th>' +
           '<th>nodes</th>' +
@@ -147,20 +100,41 @@
 
         CATMAID.fetch(project.id + '/labels/stats', 'GET')  // ~5s
           .then(function(json) {
-            var rowObjs = json.map(function(arr) {
-              labelSkelMappingCache[arr[0]] = {
-                skelIDs: [],
-                timestamp: -CACHE_TIMEOUT,
-                selected: false
-              };
-              return {
-                id: arr[0],
-                tag: arr[1],
-                skeletons: arr[2],
-                nodes: arr[3],
-                checked: false
-              };
-            });
+            var responseObj = json.reduce(function(obj, arr) {
+              var labelID = arr[0];
+              var labelName = arr[1];
+              var skelID = arr[2];
+              var nodeID = arr[3];
+
+              if (!(labelName in obj)) {
+                obj[labelName] = {
+                  'labelIDs': new Set([labelID]),
+                  'skelIDs': new Set(),
+                  'nodeIDs': new Set(),
+                  'checked': false
+                };
+              } else {
+                obj[labelName].labelIDs.add(labelID);
+                obj[labelName].skelIDs.add(skelID);
+                obj[labelName].nodeIDs.add(nodeID);
+              }
+
+              return obj;
+            }, {});
+
+            responseCache = responseObj;
+
+            var rowObjs = [];
+            for (var key of Object.keys(responseObj)) {
+              if (responseObj[key].nodeIDs.size) {  // only labels applied to nodes
+                rowObjs.push({
+                  'labelName': key,
+                  'skelCount': responseObj[key].skelIDs.size,
+                  'nodeCount': responseObj[key].nodeIDs.size,
+                  'checked': false
+                });
+              }
+            }
 
             var table = $(tableSelector).DataTable();
 
@@ -212,6 +186,7 @@
   };
 
   TagTable.prototype.init = function() {
+    var self = this;
     var widgetID = this.widgetID;
     var tableSelector = "#tag-table" + widgetID;
 
@@ -230,19 +205,13 @@
       "deferRender": true,
       "columns": [
         {
-          "data": 'id',
+          "data": 'labelName',
           "orderable": true,
           "searchable": true,
           "className": "center"
         },
         {
-          "data": 'tag',
-          "orderable": true,
-          "searchable": true,
-          "className": "center"
-        },
-        {
-          "data": 'skeletons',
+          "data": 'skelCount',
           "orderable": true,
           "className": "center"
         },
@@ -254,7 +223,7 @@
           "width": "5%"
         },
         {
-          "data": 'nodes',
+          "data": 'nodeCount',
           "orderable": true,
           "className": "center"
         }
@@ -263,37 +232,39 @@
 
     $(tableSelector + '_processing').show();
 
-    $(this.oTable).on('change', '.skelSelector', (function(event) {
-      var table = this.oTable.DataTable();
+    $(this.oTable).on('change', '.skelSelector', function(event) {
+      var table = self.oTable.DataTable();
       var row = table.row(event.currentTarget.closest('tr'));
       var currentCheckedState = event.currentTarget.checked;
-      row.data().checked = currentCheckedState;
-      labelSkelMappingCache[row.data().id].selected = currentCheckedState;
-      row.invalidate();
-      if (currentCheckedState) {  // if checking box, just add
-        getSkelIDsFromLabelIDs([row.data().id]).then((function() {
-          if (row.data().checked) {
-            this.addAndSubtractFromSkeletonSource({
-              add: labelSkelMappingCache[row.data().id].skelIDs,
-              subtract: []
-            });
-          }
-        }).bind(this)).catch(CATMAID.handleError);
-      } else {  // if unchecking box, run full sync
-        this.syncSkeletonSource();
-      }
-    }).bind(this));
 
-    $(tableSelector + 'selectAllSkels').change((function(event){
+      row.data().checked = currentCheckedState;
+      responseCache[row.data().labelName].checked = currentCheckedState;
+
+      row.invalidate();
+
+      if (currentCheckedState) {  // if checking box, just add
+        self.addAndSubtractFromSkeletonSource({
+          add: Array.from(responseCache[row.data().labelName].skelIDs),
+          subtract: []
+        });
+      } else {  // if unchecking box, run full sync
+        self.syncSkeletonSource();
+      }
+    });
+
+    $(tableSelector + 'selectAllSkels').change(function(event){
       // change all searched-for checkboxes to the same value as the header checkbox
-      var table = this.oTable.DataTable();
+      var table = self.oTable.DataTable();
+
       $(tableSelector + '_processing').show();  // doesn't show up immediately
       table.rows({search: 'applied'}).every(function () {
         // rows().every() may be slow, but is the only way to use search: 'applied'
         // using rows().data() hits call stack limit with large data
         var row = this;
         var currentCheckedState = event.currentTarget.checked;
-        labelSkelMappingCache[row.data().id].selected = currentCheckedState;
+
+        responseCache[row.data().labelName].checked = currentCheckedState;
+
         if (row.data().checked != currentCheckedState) {
           row.data().checked = currentCheckedState;
           row.invalidate();
@@ -301,35 +272,22 @@
       });
 
       table.draw();
-      this.syncSkeletonSource();
-    }).bind(this));
+      self.syncSkeletonSource();
+    });
 
-    $(tableSelector + "searchInputLabel").keydown((function (event) {
+    $(tableSelector + "searchInputLabel").keydown(function (event) {
       // filter table by tag text on hit enter
       if (event.which == 13) {
         event.stopPropagation();
         event.preventDefault();
         // Filter with a regular expression
         var filter_searchtag = event.currentTarget.value;
-        this.oTable.DataTable()
+        self.oTable.DataTable()
           .column(event.currentTarget.closest('th'))
           .search(filter_searchtag, true, false)
           .draw();
       }
-    }).bind(this));
-
-    $(tableSelector + "searchInputID").keydown((function (event) {
-      // filter table by tag text on hit enter
-      if (event.which == 13) {
-        event.stopPropagation();
-        event.preventDefault();
-        var filter_searchid = event.currentTarget.value;
-        this.oTable.DataTable()
-          .column(event.currentTarget.closest('th'))
-          .search(filter_searchid, false, false)
-          .draw();
-      }
-    }).bind(this));
+    });
 
     // prevent sorting the column when focusing on the search field
     $(tableSelector + " thead input").click(function (event) {

--- a/django/applications/catmaid/static/js/widgets/tag-table.js
+++ b/django/applications/catmaid/static/js/widgets/tag-table.js
@@ -54,6 +54,23 @@
     $("#tag-table" + this.widgetID + '_processing').hide();
   };
 
+  var escapeRegexStr = function(text) {
+    return text.replace(/[-[\]{}()*+?.,\\^$|#]/g, "\\$&");
+  };
+
+  var stringListToRegexStr = function(arr) {
+    var escapedStrings = arr.map(function(item) {
+      return '(((\\,\\s)|^)' + escapeRegexStr(item) + '((\\,\\s)|$))';
+    });
+    return escapedStrings.join('|');
+  };
+
+  TagTable.prototype.getSelectedLabelNames = function() {
+    return Object.keys(responseCache).filter(function(item) {
+      return responseCache[item].checked;
+    });
+  };
+
   TagTable.prototype.getWidgetConfiguration = function() {
     var tableSelector = "#tag-table" + this.widgetID;
     return {
@@ -73,6 +90,38 @@
           self.init();
         };
         controls.appendChild(refresh);
+
+        var openTable = document.createElement('input');
+        openTable.setAttribute('type', 'button');
+        openTable.setAttribute('value', 'Open Node Table');
+        openTable.setAttribute('title', 'Open a Treenode Table focused on the selected nodes');
+        openTable.onclick = function() {
+          var selectedModels = self.selectedSkeletons.getSelectedSkeletonModels();
+          var nodeTable = WindowMaker.create('node-table').widget;
+
+          // add skeletons which have the nodes in question
+          nodeTable.append(selectedModels);
+
+          // do not filter on treenode type
+          document.getElementById(nodeTable.idPrefix + 'search-type').value = '';
+
+          // add selected tags as a search string using alternation in regex, and trigger it
+          var searchLabel = document.getElementById(nodeTable.idPrefix + 'search-labels');
+          var regex = stringListToRegexStr(self.getSelectedLabelNames());
+          nodeTable.oTable.DataTable()
+            .column(searchLabel.closest('th'))
+            .search(regex, true, false, false);  // treat as regex, disable smart search, case sensitive
+          // nodeTable.oTable.fnFilter(this.filter_searchtag, columnIdx, true);
+
+          // $(searchLabel).focus();
+          // searchLabel.value = stringListToRegexStr(self.getSelectedLabelNames());
+          // var enterEvent = $.Event('keydown');
+          // enterEvent.which = enterEvent.keyCode = $.ui.keyCode.ENTER;
+          // $(searchLabel).trigger(enterEvent);
+
+          // todo: disable inputs?
+        };
+        controls.appendChild(openTable);
       },
       contentID: 'tag-table-widget' + this.widgetID,
       createContent: function(container) {
@@ -118,6 +167,13 @@
     };
   };
 
+  var skelIDsToModels = function (skelIDs) {
+    return skelIDs.reduce(function (mappingObj, currentID) {
+      mappingObj[currentID] = new CATMAID.SkeletonModel(currentID);
+      return mappingObj;
+    }, {});
+  };
+
   /**
    * Update the skeleton source the widget uses to export skeletons
    *
@@ -127,12 +183,7 @@
    */
   TagTable.prototype.addAndSubtractFromSkeletonSource = function(obj) {
     // Update the skeleton source run by the widget
-    this.selectedSkeletons.append(
-      obj.add.reduce(function (mappingObj, currentID) {
-        mappingObj[currentID] = new CATMAID.SkeletonModel(currentID);
-        return mappingObj;
-      }, {})
-    );
+    this.selectedSkeletons.append(skelIDsToModels(obj.add));
     this.selectedSkeletons.removeSkeletons(obj.subtract);
   };
 

--- a/django/applications/catmaid/static/js/widgets/treenode-table.js
+++ b/django/applications/catmaid/static/js/widgets/treenode-table.js
@@ -9,6 +9,8 @@
     this.widgetID = this.registerInstance();
     CATMAID.SkeletonSource.call(this, true);
 
+    this.idPrefix = 'treenode-table-' + this.widgetID;
+
     this.models = {};
     this.ranges = {};
     this.oTable = null;
@@ -26,9 +28,10 @@
   };
 
   TreenodeTable.prototype.getWidgetConfiguration = function() {
+    var self = this;
     return {
-      controlsID: "treenode_table_buttons" + this.widgetID,
-      contentID: "treenode_table_widget" + this.widgetID,
+      controlsID: this.idPrefix + 'controls',
+      contentID: this.idPrefix + 'content',
       createControls: function(controls) {
         controls.appendChild(document.createTextNode('From'));
         controls.appendChild(CATMAID.skeletonListSources.createSelect(this));
@@ -58,13 +61,15 @@
               '<tr>' +
                 '<th>id</th>' +
                 '<th>type' +
-                  '' +
-                  '<select name="search_type" id="search_type' + this.widgetID + '" class="search_init">' +
-                  '<option value="">Any</option><option value="R">Root</option><option value="L" selected="selected">Leaf</option>' +
-                  '<option value="B">Branch</option><option value="S">Slab</option></select>' +
+                  '<select name="search_type" id="' + self.idPrefix + 'search-type" class="search_init">' +
+                    '<option value="">Any</option>' +
+                    '<option value="R">Root</option>' + '' +
+                    '<option value="L" selected="selected">Leaf</option>' +
+                    '<option value="B">Branch</option>' +
+                    '<option value="S">Slab</option>' + '' +
+                  '</select>' +
                 '</th>' +
-            // <input type="text" name="search_type" value="Search" class="search_init" />
-                '<th>tags<input type="text" name="search_labels" id="search_labels' + this.widgetID + '" value="Search" class="search_init" /></th>' +
+                '<th>tags<input type="text" name="search_labels" id="' + self.idPrefix + 'search-labels' + '" value="Search" class="search_init" /></th>' +
                 '<th>c</th>' +
                 '<th>x</th>' +
                 '<th>y</th>' +
@@ -274,7 +279,7 @@
             }
             // Insert tags
             var tag = tags[row[0]];
-            row.splice(2, 0, tag ? tag.join(', ') : '');
+            row.splice(2, 0, tag ? tag.sort().join(', ') : '');
             // Insert section number
             row.splice(7, 0, (row[6] - stack.translation.z) / stack.resolution.z);
             // Replace user_id with username
@@ -285,8 +290,6 @@
             var reviewers = reviews[row[0]];
             row.push(reviewers ? reviewers.join(', ') : 'None');
           }
-          // david tata
-          // g;[hcbfvged
 
           this.ranges[skid] = {start: n_rows,
                                length: rows.length};
@@ -302,7 +305,7 @@
         }).bind(this),
         (function() {
           this.oTable.fnAddData(all_rows);
-          this.filter_nodetype = $('select#search_type' + this.widgetID).val();
+          this.filter_nodetype = $('select#' + this.idPrefix + 'search-type').val();
           // fnFilter will call fnDraw
           this.oTable.fnFilter(this.filter_nodetype, 1);
         }).bind(this));
@@ -335,7 +338,7 @@
       }, // type
       {
         "bSearchable": true,
-        "bSortable": false,
+        "bSortable": true,
         "sWidth": "150px"
       }, // labels
       {
@@ -380,12 +383,19 @@
     $(tableSelector + " thead input").keydown((function (event) {
       // filter table on hit enter
       if (event.which == 13) {
+        event.stopPropagation();
+        event.preventDefault();
         // Filter with a regular expression
-        this.filter_searchtag = $('#search_labels' + this.widgetID).val();
+        this.filter_searchtag = $('#' + this.idPrefix + 'search-labels').val();
         var columnIdx = this.oTable.DataTable().column(event.currentTarget.closest('th')).index();
         this.oTable.fnFilter(this.filter_searchtag, columnIdx, true);
       }
     }).bind(this));
+
+    // don't sort when clicking on the input
+    $(tableSelector + " thead input").click(function (event) {
+      event.stopPropagation();
+    });
 
     // remove the 'Search' string when first focusing the search box
     $(tableSelector + " thead input").focus(function () {
@@ -395,8 +405,8 @@
       }
     });
 
-    $('select#search_type' + this.widgetID).change((function() {
-      this.filter_nodetype = $('select#search_type' + this.widgetID).val();
+    $('select#' + this.idPrefix + 'search-type').change((function() {
+      this.filter_nodetype = $('select#' + this.idPrefix + 'search-type').val();
       this.oTable.fnFilter(this.filter_nodetype, 1);
     }).bind(this));
 

--- a/django/applications/catmaid/tests/apis/test_labels.py
+++ b/django/applications/catmaid/tests/apis/test_labels.py
@@ -120,8 +120,9 @@ class LabelsApiTests(CatmaidApiTestCase):
 
     def test_stats(self):
         expected_response = [
-            [351, 'TODO', 2, 2],
-            [2342, 'uncertain end', 1, 1],
+            [2342, u'uncertain end', 373, 403],
+            [351, u'TODO', 1, 349],
+            [351, u'TODO', 235, 261]
         ]
 
         response = self.get_successful_stats_response()
@@ -139,4 +140,3 @@ class LabelsApiTests(CatmaidApiTestCase):
 
         for row in response:
             self.assertFalse(row[1] == 'skeleton {}'.format(row[0]) and row[2] == 1, msg=msg.format(row[0], row[1]))
-


### PR DESCRIPTION
NOTE: DO NOT MERGE THIS BEFORE #1469. I *think* it should be fine to merge the other one and then this, as this one is based on #1469 anyway.

However, it may be best to have @acardona check he's happy with it before merging, so it's fine to have this sit around for a bit and I can fix any conflicts which arise.

Resolves #1460 by adding a button to the tag table controls, which opens a treenode table, sets the node type to 'any', and then searches the table based on a regex comprised of the different labels.

Because I had to get a bit saucy with the regex to try to stop it picking up substrings, it wasn't possible to use the 'tags' input directly (as that uses the 'smart search', which can mangle regexes). If we want to make it clear that that treenode table is beholden only to the tag table, we could disable the skeleton source controls and that search box.