### PR TITLE
Tag table: label deduplication and manual cache refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ Miscellaneous:
 - Synaptic fractions: colors of groups and partners can now be changed through
   legend of graph.
 
+- The tag table now has a refresh button to manually update the cache and
+  redraw the table.
+
 
 ### Bug fixes
 
@@ -118,6 +121,9 @@ Miscellaneous:
 
 - The connector table can now be used as a skeleton source, where
   previously an error would be raised.
+
+- The tag table now collapses any tags with identical names, but as a
+  consequence does not show the tag ID (as there may be multiple IDs)
 
 
 ## 2016.12.16

--- a/django/applications/catmaid/static/js/extensions.js
+++ b/django/applications/catmaid/static/js/extensions.js
@@ -53,6 +53,18 @@ Set.prototype.intersection = function(iterable) {
 };
 
 /**
+ * Return a new set of those items which exist in either this set or the given 'of'-able iterable.
+ *
+ * @param iterable
+ * @returns {Set}
+ */
+Set.prototype.union = function(iterable) {
+  var union = new Set(this);
+  union.addAll(iterable);
+  return union;
+};
+
+/**
  * jQuery DataTables extensions
  */
 

--- a/django/applications/catmaid/static/js/widgets/tag-table.js
+++ b/django/applications/catmaid/static/js/widgets/tag-table.js
@@ -5,8 +5,6 @@
 
   "use strict";
 
-  var CACHE_TIMEOUT = 5*60*1000;  // cache invalidation timeout in ms
-
   var TagTable = function() {
     this.widgetID = this.registerInstance();
     this.selectedSkeletons = new CATMAID.BasicSkeletonSource(this.getName());
@@ -19,79 +17,41 @@
     return 'Tag Table ' + this.widgetID;
   };
 
-  var labelSkelMappingCache = {};  // todo - button for enabling/disabling cache?
-
   /**
+   *  {
+   *    labelName1: {
+   *      'labelIDs': Set([labelID1, labelID2, ...]),
+   *      'labelName': labelName1,
+   *      'skelIDs': Set([skelID1, skelID2, ...]),
+   *      'nodeIDs': Set([nodeID1, nodeID2, ...]),
+   *      'checked': isChecked
+   *    },
+   *    labelName2: ...
+   *  }
    *
-   * @param labelIDs - array of label IDs
-   * @param callback - function which takes a list of skelIDs
+   * @type {{}}
    */
-  var getSkelIDsFromLabelIDs = function(labelIDs) {
-    var remoteLabelIDs = [];
-    var skelIDs = new Set();
-
-    var now = Date.now();
-
-    for (var i = 0; i < labelIDs.length; i++) {
-      var labelID = labelIDs[i];
-      if (labelID in labelSkelMappingCache && now - labelSkelMappingCache[labelID].timestamp <= CACHE_TIMEOUT) {
-        skelIDs.addAll(
-          labelSkelMappingCache[labelID].skelIDs
-        );
-      } else {
-        remoteLabelIDs.push(labelID);
-      }
-    }
-
-    if (remoteLabelIDs.length === 0) {
-      return Promise.resolve(Array.from(skelIDs));
-    }
-
-    return CATMAID.fetch(project.id + '/skeletons/node-labels', 'POST', {
-      'label_ids': remoteLabelIDs
-    }).then(function(json) {
-      now = Date.now();
-
-      for (var i = 0; i < json.length; i++) {
-        var labelSkelTuple = json[i];
-        labelSkelMappingCache[labelSkelTuple[0]].skelIDs = labelSkelTuple[1];
-        labelSkelMappingCache[labelSkelTuple[0]].timestamp = now;
-        skelIDs.addAll(labelSkelTuple[1]);
-      }
-
-      return Array.from(skelIDs);
-    });
-  };
+  var responseCache = {};
 
   /**
    * Set the skeleton source to reflect data in the table
    */
   TagTable.prototype.syncSkeletonSource = function() {
-    var selectedLabelIDs = this.getSelectedLabelIDs();
+    var areInSource = new Set(this.selectedSkeletons.getSelectedSkeletons());
 
-    getSkelIDsFromLabelIDs(selectedLabelIDs).then((function() {
-      var areInSource = new Set(this.selectedSkeletons.getSelectedSkeletons());
-      var shouldBeInSource = this.getSelectedLabelIDs().reduce(function(shouldBeInSource, currentValue) {
-        return shouldBeInSource.addAll(labelSkelMappingCache[currentValue].skelIDs);
-      }, new Set());
-
-      this.addAndSubtractFromSkeletonSource({
-        add: Array.from(shouldBeInSource.difference(areInSource)),
-        subtract: Array.from(areInSource.difference(shouldBeInSource))
-      });
-
-      $("#tag-table" + this.widgetID + '_processing').hide();
-    }).bind(this)).catch(CATMAID.handleError);
-  };
-
-  TagTable.prototype.getSelectedLabelIDs = function () {
-    var selectedLabelIDs = [];
-    for (var key in labelSkelMappingCache) {
-      if (labelSkelMappingCache.hasOwnProperty(key) && labelSkelMappingCache[key].selected) {
-        selectedLabelIDs.push(key);
+    var shouldBeInSource = new Set();
+    for (var skelName of Object.keys(responseCache)) {
+      if (responseCache[skelName].checked) {
+        shouldBeInSource.addAll(responseCache[skelName].skelIDs);
       }
     }
-    return selectedLabelIDs;
+
+    this.addAndSubtractFromSkeletonSource({
+      add: Array.from(shouldBeInSource.difference(areInSource)),
+      subtract: Array.from(areInSource.difference(shouldBeInSource))
+    });
+
+    $("#tag-table" + this.widgetID + '_processing').hide();
   };
 
   TagTable.prototype.getWidgetConfiguration = function() {
@@ -99,24 +59,18 @@
     return {
       // controlsID: 'tag-tableWidgetControls' + this.widgetID,
       // createControls: function(controls) {
-      //   // add buttons - see connectivity-matrix.js
       // },
       contentID: 'tag-table-widget' + this.widgetID,
       createContent: function(container) {
+        var self = this;
+
         container.innerHTML =
-          '<table cellpadding="0" cellspacing="0" border="0" class="display" id="' + "tag-table" + this.widgetID + '">' +
+          '<table cellpadding="0" cellspacing="0" border="0" class="display" id="' + "tag-table" + self.widgetID + '">' +
           '<thead>' +
           '<tr>' +
-          '<th>tag id' +
-            '<input type="number" name="searchInputID" id="tag-table' +
-                this.widgetID +
-                'searchInputID' +
-              '" value=""' +
-            '/>' +
-          '</th>' +
-          '<th>tag name' +
+          '<th>tag' +
             '<input type="text" name="searchInputLabel" id="tag-table' +
-                this.widgetID +
+                self.widgetID +
                 'searchInputLabel' +
               '" value="Search" class="search_init" ' +
             '/>' +
@@ -124,7 +78,7 @@
           '<th>skeletons</th>' +
           '<th>select skeletons' +
           '<input type="checkbox" name="selectAllSkels" id="tag-table' +
-            this.widgetID +
+            self.widgetID +
             'selectAllSkels' +
           '" value="selectAllSkels"' +
           '/>' +
@@ -134,8 +88,7 @@
           '</thead>' +
           '<tfoot>' +
           '<tr>' +
-          '<th>tag id</th>' +
-          '<th>tag name</th>' +
+          '<th>tag</th>' +
           '<th>skeletons</th>' +
           '<th>select skeletons</th>' +
           '<th>nodes</th>' +
@@ -147,20 +100,41 @@
 
         CATMAID.fetch(project.id + '/labels/stats', 'GET')  // ~5s
           .then(function(json) {
-            var rowObjs = json.map(function(arr) {
-              labelSkelMappingCache[arr[0]] = {
-                skelIDs: [],
-                timestamp: -CACHE_TIMEOUT,
-                selected: false
-              };
-              return {
-                id: arr[0],
-                tag: arr[1],
-                skeletons: arr[2],
-                nodes: arr[3],
-                checked: false
-              };
-            });
+            var responseObj = json.reduce(function(obj, arr) {
+              var labelID = arr[0];
+              var labelName = arr[1];
+              var skelID = arr[2];
+              var nodeID = arr[3];
+
+              if (!(labelName in obj)) {
+                obj[labelName] = {
+                  'labelIDs': new Set([labelID]),
+                  'skelIDs': new Set(),
+                  'nodeIDs': new Set(),
+                  'checked': false
+                };
+              } else {
+                obj[labelName].labelIDs.add(labelID);
+                obj[labelName].skelIDs.add(skelID);
+                obj[labelName].nodeIDs.add(nodeID);
+              }
+
+              return obj;
+            }, {});
+
+            responseCache = responseObj;
+
+            var rowObjs = [];
+            for (var key of Object.keys(responseObj)) {
+              if (responseObj[key].nodeIDs.size) {  // only labels applied to nodes
+                rowObjs.push({
+                  'labelName': key,
+                  'skelCount': responseObj[key].skelIDs.size,
+                  'nodeCount': responseObj[key].nodeIDs.size,
+                  'checked': false
+                });
+              }
+            }
 
             var table = $(tableSelector).DataTable();
 
@@ -212,6 +186,7 @@
   };
 
   TagTable.prototype.init = function() {
+    var self = this;
     var widgetID = this.widgetID;
     var tableSelector = "#tag-table" + widgetID;
 
@@ -230,19 +205,13 @@
       "deferRender": true,
       "columns": [
         {
-          "data": 'id',
+          "data": 'labelName',
           "orderable": true,
           "searchable": true,
           "className": "center"
         },
         {
-          "data": 'tag',
-          "orderable": true,
-          "searchable": true,
-          "className": "center"
-        },
-        {
-          "data": 'skeletons',
+          "data": 'skelCount',
           "orderable": true,
           "className": "center"
         },
@@ -254,7 +223,7 @@
           "width": "5%"
         },
         {
-          "data": 'nodes',
+          "data": 'nodeCount',
           "orderable": true,
           "className": "center"
         }
@@ -263,37 +232,39 @@
 
     $(tableSelector + '_processing').show();
 
-    $(this.oTable).on('change', '.skelSelector', (function(event) {
-      var table = this.oTable.DataTable();
+    $(this.oTable).on('change', '.skelSelector', function(event) {
+      var table = self.oTable.DataTable();
       var row = table.row(event.currentTarget.closest('tr'));
       var currentCheckedState = event.currentTarget.checked;
-      row.data().checked = currentCheckedState;
-      labelSkelMappingCache[row.data().id].selected = currentCheckedState;
-      row.invalidate();
-      if (currentCheckedState) {  // if checking box, just add
-        getSkelIDsFromLabelIDs([row.data().id]).then((function() {
-          if (row.data().checked) {
-            this.addAndSubtractFromSkeletonSource({
-              add: labelSkelMappingCache[row.data().id].skelIDs,
-              subtract: []
-            });
-          }
-        }).bind(this)).catch(CATMAID.handleError);
-      } else {  // if unchecking box, run full sync
-        this.syncSkeletonSource();
-      }
-    }).bind(this));
 
-    $(tableSelector + 'selectAllSkels').change((function(event){
+      row.data().checked = currentCheckedState;
+      responseCache[row.data().labelName].checked = currentCheckedState;
+
+      row.invalidate();
+
+      if (currentCheckedState) {  // if checking box, just add
+        self.addAndSubtractFromSkeletonSource({
+          add: Array.from(responseCache[row.data().labelName].skelIDs),
+          subtract: []
+        });
+      } else {  // if unchecking box, run full sync
+        self.syncSkeletonSource();
+      }
+    });
+
+    $(tableSelector + 'selectAllSkels').change(function(event){
       // change all searched-for checkboxes to the same value as the header checkbox
-      var table = this.oTable.DataTable();
+      var table = self.oTable.DataTable();
+
       $(tableSelector + '_processing').show();  // doesn't show up immediately
       table.rows({search: 'applied'}).every(function () {
         // rows().every() may be slow, but is the only way to use search: 'applied'
         // using rows().data() hits call stack limit with large data
         var row = this;
         var currentCheckedState = event.currentTarget.checked;
-        labelSkelMappingCache[row.data().id].selected = currentCheckedState;
+
+        responseCache[row.data().labelName].checked = currentCheckedState;
+
         if (row.data().checked != currentCheckedState) {
           row.data().checked = currentCheckedState;
           row.invalidate();
@@ -301,35 +272,22 @@
       });
 
       table.draw();
-      this.syncSkeletonSource();
-    }).bind(this));
+      self.syncSkeletonSource();
+    });
 
-    $(tableSelector + "searchInputLabel").keydown((function (event) {
+    $(tableSelector + "searchInputLabel").keydown(function (event) {
       // filter table by tag text on hit enter
       if (event.which == 13) {
         event.stopPropagation();
         event.preventDefault();
         // Filter with a regular expression
         var filter_searchtag = event.currentTarget.value;
-        this.oTable.DataTable()
+        self.oTable.DataTable()
           .column(event.currentTarget.closest('th'))
           .search(filter_searchtag, true, false)
           .draw();
       }
-    }).bind(this));
-
-    $(tableSelector + "searchInputID").keydown((function (event) {
-      // filter table by tag text on hit enter
-      if (event.which == 13) {
-        event.stopPropagation();
-        event.preventDefault();
-        var filter_searchid = event.currentTarget.value;
-        this.oTable.DataTable()
-          .column(event.currentTarget.closest('th'))
-          .search(filter_searchid, false, false)
-          .draw();
-      }
-    }).bind(this));
+    });
 
     // prevent sorting the column when focusing on the search field
     $(tableSelector + " thead input").click(function (event) {

--- a/django/applications/catmaid/tests/apis/test_labels.py
+++ b/django/applications/catmaid/tests/apis/test_labels.py
@@ -118,15 +118,25 @@ class LabelsApiTests(CatmaidApiTestCase):
         return response
 
 
+    def assertListOfListsEqualContent(self, ref, test):
+        self.assertEqual(len(ref), len(test))
+
+        ref_set = {tuple(item) for item in ref}
+        test_set = {tuple(item) for item in test}
+
+        self.assertSetEqual(ref_set, test_set)
+
+
     def test_stats(self):
         expected_response = [
-            [351, 'TODO', 2, 2],
-            [2342, 'uncertain end', 1, 1],
+            [2342, u'uncertain end', 373, 403],
+            [351, u'TODO', 1, 349],
+            [351, u'TODO', 235, 261]
         ]
 
         response = self.get_successful_stats_response()
 
-        self.assertJSONEqual(response.content, expected_response)
+        self.assertListOfListsEqualContent(json.loads(response.content), expected_response)
 
 
     def test_stats_does_not_find_all_nodes_of_skeleton(self):
@@ -139,4 +149,3 @@ class LabelsApiTests(CatmaidApiTestCase):
 
         for row in response:
             self.assertFalse(row[1] == 'skeleton {}'.format(row[0]) and row[2] == 1, msg=msg.format(row[0], row[1]))
-


### PR DESCRIPTION
A short-term solution to #1468, duplication of tags in the table (reflecting duplication of tags in the database). Also resolves #1439.

One of the projects I was testing the tag table on had not only labels with unique IDs sharing a name, but also several of these on the same node. This patch changes the API endpoint so that it doesn't do any counting or grouping on the server, but allows the client to do it as appropriate for the application.

As a bonus, this means that we don't need to make separate API calls to get the skeleton IDs from the label IDs (because the first call gets them all), which improves performance when running on my local server with a project with ~3000 skeletons.

Because the table only makes one call to the API, there isn't any cache invalidation - but the user can now refresh manually because this also resolves #1439. As it's a fairly large call, I thought it would be more surprising to have their table lock up for a few seconds every 5 minutes than it would be to just continue using the data as of the time of opening the widget.