### PR TITLE
Tag Table: Fix off-by-one error

### DIFF
--- a/django/applications/catmaid/static/js/widgets/tag-table.js
+++ b/django/applications/catmaid/static/js/widgets/tag-table.js
@@ -209,16 +209,16 @@
 
           if (!(labelName in obj)) {
             obj[labelName] = {
-              'labelIDs': new Set([labelID]),
+              'labelIDs': new Set(),
               'skelIDs': new Set(),
               'nodeIDs': new Set(),
               'checked': false
             };
-          } else {
-            obj[labelName].labelIDs.add(labelID);
-            obj[labelName].skelIDs.add(skelID);
-            obj[labelName].nodeIDs.add(nodeID);
           }
+
+          obj[labelName].labelIDs.add(labelID);
+          obj[labelName].skelIDs.add(skelID);
+          obj[labelName].nodeIDs.add(nodeID);
 
           return obj;
         }, {});


### PR DESCRIPTION
Resolves #1483

Previously, when the data was fetched the first instance of a label would create an empty object; the second would start populating it. Now every label instance populates the data object.