### PR TITLE
Tag Table: Add skeleton source as constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Miscellaneous:
 - From the Graph Widget exported SVG files preserve now the view of the widget
   (zoom and pan).
 
+- The tag table can now be constrained by a set of skeletons.
+
 ### Bug fixes
 
 - 3D Viewer: custom tag highlighting now also works for tags with upper case


### PR DESCRIPTION
Resolves #1442, closes #1484 

Adds skeleton source controls to a skeleton source which is not registered. When empty, the table behaves just as before. When populated, the table only reflects labels, skeleton counts and label counts which are associated with those skeletons. All of that filtering is done by javascript on the cache populated on the first draw of the table, so it's pretty rapid too.

The ordering and filtering of the table should conserved when the skeleton source is changed (but not when refreshed, yet).

I also tidied up all of the IDs, switched completely to the datatables 1.10 API (it was previously a mixture), and made a few other changes which should make it more robust to future changes.