### PR TITLE
Stack Grid Viewer: Global zoom and recentre button

### DIFF
--- a/django/applications/catmaid/static/js/widgets/stack-viewer-grid.js
+++ b/django/applications/catmaid/static/js/widgets/stack-viewer-grid.js
@@ -373,10 +373,6 @@
     zoomInput.setAttribute('type', 'text');
     zoomInput.setAttribute('pattern', '^\-?\d?\.?\d*$');
     zoomInput.setAttribute('size', '5');
-    // zoomInput.setAttribute('type', 'number');
-    // zoomInput.setAttribute('step', '0.1');
-    // zoomInput.setAttribute('max', '5');
-    // zoomInput.setAttribute('min', '-2');
     zoomInput.setAttribute('value', self.sourceStackViewer.s);
     zoomInput.onchange = function() {
       if (this.value === '') {
@@ -672,9 +668,9 @@
     var currentCoords = stackViewer.projectCoordinates();
 
     stackViewer.moveToProject(
-      'z' in coords? coords.z : currentCoords.z,
-      'y' in coords? coords.y : currentCoords.y,
-      'x' in coords? coords.x : currentCoords.x,
+      'z' in coords ? coords.z : currentCoords.z,
+      'y' in coords ? coords.y : currentCoords.y,
+      'x' in coords ? coords.x : currentCoords.x,
       's' in coords ? coords.s : this.sourceStackViewer.primaryStack.stackToProjectSX(this.sourceStackViewer.s),
       typeof completionCallback === "function" ? completionCallback : undefined
     );


### PR DESCRIPTION
Two items of issue #1466.

1. Given each redraw has to address many stack viewers, I opted to just have a text box for the zoom - using a slider or spinner gets messy because of the performance.

2. I opted for a single recentre button for all of the mini stack viewers to share because they are starting to get cluttered, but can try to find space to put one in each if required.

Are these sufficient, @acardona ?