### PR TITLE
Treenode viewer and treenode table improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Features and enhancements
 
+Treenode Viewer:
+
+- A new tool similar to the connector viewer, which allows users to
+  quickly view the nodes in a treenode table.
+
+- The viewer is opened from the treenode table.
+
+- Nodes are shown only if they are filtered in the table, and appear in
+  the order that they appear in the table.
+
+- When the sorting and filtering in the table is changed, users can
+  refresh the viewer from the table to reflect these changes.
+
+
 Miscellaneous:
 
 - Bookmarks are now persistent for each project.
@@ -12,6 +26,10 @@ Miscellaneous:
   (zoom and pan).
 
 - The tag table can now be constrained by a set of skeletons.
+
+- The treenode table can now be filtered by node confidence, creator and
+  reviewer.
+
 
 ### Bug fixes
 

--- a/django/applications/catmaid/static/js/widgets/treenode-viewer.js
+++ b/django/applications/catmaid/static/js/widgets/treenode-viewer.js
@@ -1,0 +1,68 @@
+/* -*- mode: espresso; espresso-indent-level: 2; indent-tabs-mode: nil -*- */
+/* vim: set softtabstop=2 shiftwidth=2 tabstop=2 expandtab: */
+
+(function(CATMAID) {
+
+  "use strict";
+
+  /**
+   * Create a new treenode viewer. It must be coupled to a treenode table: that's where it gets its nodes, sort
+   * order and so on from.
+   *
+   * @param treenodeTable - the treenode table to which the viewer is coupled.
+   * @constructor
+   */
+  var TreenodeViewer = function(treenodeTable)
+  {
+    this.widgetID = this.registerInstance();
+    this.idPrefix = `treenode-viewer${this.widgetID}-`;
+
+    this.treenodeTable = treenodeTable;
+    this.MIN_WEBGL_CONTEXTS = 1;
+
+    this.stackViewerGrid = null;  // instantiated in init()
+  };
+
+  TreenodeViewer.prototype = {};
+  $.extend(TreenodeViewer.prototype, new InstanceRegistry());
+
+  TreenodeViewer.prototype.getName = function() {
+    return "Treenode Viewer " + this.widgetID;
+  };
+
+  TreenodeViewer.prototype.destroy = function() {
+    this.stackViewerGrid.closeStackViewers();
+    this.treenodeTable.treenodeViewer = null;
+    document.getElementById(this.treenodeTable.idPrefix + 'viewer-button').value = 'Open Viewer';
+    this.unregisterInstance();
+  };
+
+  TreenodeViewer.prototype.getWidgetConfiguration = function() {
+    var self = this;
+    return {
+      helpText: "Treenode Viewer widget: Quickly view and compare treenodes selected in a treenode table",
+      controlsID: this.idPrefix + 'controls',
+      createControls: function(controls) {
+        var nodeSource = document.createElement('p');
+        nodeSource.innerText = 'Treenode source: ' + self.treenodeTable.getName();
+        controls.append(nodeSource);
+      },
+      contentID: this.idPrefix + 'content',
+      createContent: function(container) {
+        // container.style.position = 'absolute';
+      },
+      init: function() {
+        this.stackViewerGrid = new CATMAID.StackViewerGrid(self.idPrefix);
+      }
+    };
+  };
+
+  // Export widget
+  CATMAID.TreenodeViewer = TreenodeViewer;
+
+  // Register widget with CATMAID
+  CATMAID.registerWidget({
+    key: 'treenode-viewer',
+    creator: TreenodeViewer
+  });
+})(CATMAID);

--- a/django/applications/catmaid/static/js/widgets/treenode-viewer.js
+++ b/django/applications/catmaid/static/js/widgets/treenode-viewer.js
@@ -32,8 +32,15 @@
 
   TreenodeViewer.prototype.destroy = function() {
     this.stackViewerGrid.closeStackViewers();
-    this.treenodeTable.treenodeViewer = null;
-    document.getElementById(this.treenodeTable.idPrefix + 'viewer-button').value = 'Open Viewer';
+
+    if (this.treenodeTable) {
+      var tableViewerButton = document.getElementById(this.treenodeTable.idPrefix + 'viewer-button');
+      if (tableViewerButton) {
+        tableViewerButton.value = 'Open Viewer';
+      }
+      this.treenodeTable.treenodeViewer = null;
+    }
+
     this.unregisterInstance();
   };
 
@@ -44,6 +51,7 @@
       controlsID: this.idPrefix + 'controls',
       createControls: function(controls) {
         var nodeSource = document.createElement('p');
+        nodeSource.setAttribute('id', self.idPrefix + 'node-source');
         nodeSource.innerText = 'Treenode source: ' + self.treenodeTable.getName();
         controls.append(nodeSource);
       },


### PR DESCRIPTION
Resolves #1475 

Thanks to #1476, the treenode viewer was all of 72 lines...

The changes to the treenode table were a bit more significant, although that's largely because I took the opportunity to port it over to the datatables 1.10 API and tidy up some jQuery. I also added the ability to filter on node confidence, creator and reviewer - valuable for checking a beginner's unreviewed ends, for example.