### PR TITLE
Tag table improvements

### DIFF
--- a/django/applications/catmaid/static/js/widgets/tag-table.js
+++ b/django/applications/catmaid/static/js/widgets/tag-table.js
@@ -52,6 +52,12 @@
    */
   var responseCache = {};
 
+  TagTable.prototype.setConstrainText = function() {
+    var count = this.filterSkeletons.getNumberOfSkeletons();
+    var element = document.getElementById(this.idPrefix + 'constrain-text');
+    element.innerText = `Constraining by ${count} skeleton${count === 1 ? '' : 's'}`;
+  };
+
   /**
    * Clear the table and repopulate it using only data relating to the selected skeletons. If no skeletons are
    * selected, show the data for the whole project.
@@ -62,17 +68,10 @@
   TagTable.prototype.constrainSkelsAndRedraw = function() {
     this.oTable.clear();
 
-    var newOrder;
-    var currentOrder = this.oTable.order();
-    if (currentOrder.length >= 1 && currentOrder[0][0] !== 0 && currentOrder[0][1] !== 'desc') {
-      newOrder = [[0, 'desc']].concat(currentOrder);
-    } else {
-      newOrder = currentOrder;
-    }
-
     var filterSkels = this.filterSkeletons.getSelectedSkeletons();
     var rowObjs = [];
-    for (var key of Object.keys(responseCache)) {
+    for (var key of Object.keys(responseCache).sort(function(a, b) {return a.localeCompare(b);} )) {
+      // look at rows in lexicographic order
 
       var skelIntersection = filterSkels.length ?  // if there are no selected skeletons, show everything in the project
         responseCache[key].skelIDs.intersection(filterSkels) : responseCache[key].skelIDs;
@@ -95,7 +94,7 @@
     }
 
     this.oTable.rows.add(rowObjs);
-    this.oTable.order(newOrder).draw();
+    this.oTable.draw();
 
     this.syncResultSkeletonSource();
   };
@@ -112,6 +111,8 @@
         shouldBeInSource.addAll(responseCache[labelName].skelIDs);
       }
     }
+
+    shouldBeInSource = shouldBeInSource.intersection(this.filterSkeletons.getSelectedSkeletons());
 
     this.addAndSubtractFromResultSkeletonSource({
       add: Array.from(shouldBeInSource.difference(areInSource)),
@@ -170,6 +171,7 @@
         add.setAttribute("value", "Add");
         add.onclick = function() {
           self.filterSkeletons.loadSource.bind(self.filterSkeletons)();
+          self.setConstrainText();
         };
         controls.appendChild(add);
 
@@ -178,13 +180,20 @@
         clear.setAttribute("value", "Clear");
         clear.onclick = function() {
           self.filterSkeletons.clear();
+          self.setConstrainText();
         };
         controls.appendChild(clear);
+
+        var constrainText = document.createElement('p');
+        constrainText.setAttribute('id', self.idPrefix + 'constrain-text');
+        constrainText.innerText = 'Constraining by 0 skeletons';
+
+        controls.appendChild(constrainText);
 
         var refresh = document.createElement('input');
         refresh.setAttribute("type", "button");
         refresh.setAttribute("value", "Refresh");
-        refresh.onclick = self.refreshDataAndRedraw.bind(self)
+        refresh.onclick = self.refreshDataAndRedraw.bind(self);
         controls.appendChild(refresh);
 
         var openTable = document.createElement('input');
@@ -209,6 +218,12 @@
             .search(regex, true, false, false);  // treat as regex, disable smart search, case sensitive
         };
         controls.appendChild(openTable);
+
+        controls.append(document.createElement('br'));
+        var showingText = document.createElement('p');
+        showingText.setAttribute('id', self.idPrefix + 'selected-text');
+
+        controls.append(showingText);
       },
       contentID: this.idPrefix + 'content',
       createContent: function(container) {
@@ -231,9 +246,9 @@
           '</thead>' +
           '<tfoot>' +
           '<tr>' +
+          '<th>select</th>' +
           '<th>tag</th>' +
           '<th>skeletons</th>' +
-          '<th>select skeletons</th>' +
           '<th>nodes</th>' +
           '</tr>' +
           '</tfoot>' +
@@ -245,6 +260,31 @@
         this.init(project.getId());
       }
     };
+  };
+
+  TagTable.prototype.setSelectedText = function() {
+    var selectedLabels = new Set();
+    var selectedSkels = new Set();
+    var selectedNodes = new Set();
+
+    var constrainSkels = new Set(this.filterSkeletons.getSelectedSkeletons());
+
+    for (var labelID of Object.keys(responseCache)) {
+      if (responseCache[labelID].checked) {
+        selectedLabels.add(labelID);
+        selectedSkels.addAll(responseCache[labelID].skelIDs.intersection(constrainSkels));
+        for (var [nodeID, skelID] of responseCache[labelID].nodeIDs.entries()) {
+          if (constrainSkels.has(skelID)) {
+            selectedNodes.add(nodeID);
+          }
+        }
+      }
+    }
+
+    document.getElementById(this.idPrefix + 'selected-text').innerText = '' +
+      `Selected ${selectedLabels.size} label${selectedLabels.size === 1 ? '' : 's'}, ` +
+      `${selectedSkels.size} skeleton${selectedSkels.size === 1 ? '' : 's'}, ` +
+      `${selectedNodes.size} node${selectedNodes.size === 1 ? '' : 's'}`;
   };
 
   var skelIDsToModels = function (skelIDs) {
@@ -265,11 +305,13 @@
     // Update the skeleton source run by the widget
     this.resultSkeletons.append(skelIDsToModels(obj.add));
     this.resultSkeletons.removeSkeletons(obj.subtract);
+
+    this.setSelectedText();
   };
 
   TagTable.prototype.createCheckbox = function(checked, type, row) {
     if (type ==='display') {
-      var checkbox = $('<input />', {
+      var $checkbox = $('<input />', {
         type:'checkbox',
         class:'skelSelector',
         id: this.idPrefix + 'skelselector' + row.id,
@@ -277,7 +319,7 @@
         checked: checked
       });
 
-      return checkbox.prop('outerHTML');
+      return $checkbox.prop('outerHTML');
     } else {
       return checked ? 1 : 0;
     }
@@ -287,9 +329,9 @@
     var self = this;
     var tableID = this.idPrefix + 'datatable';
 
-    var tableSelector = $('#' + tableID);
+    var $table = $('#' + tableID);
 
-    this.oTable = tableSelector.DataTable({
+    this.oTable = $table.DataTable({
       // http://www.datatables.net/usage/options
       "destroy": true,
       "dom": '<"H"lrp>t<"F"ip>',
@@ -331,7 +373,7 @@
 
     this.refreshDataAndRedraw();
 
-    tableSelector.on('change', '.skelSelector', function(event) {
+    $table.on('change', '.skelSelector', function(event) {
       var row = self.oTable.row(event.currentTarget.closest('tr'));
       var currentCheckedState = event.currentTarget.checked;
 
@@ -340,14 +382,7 @@
 
       row.invalidate();
 
-      if (currentCheckedState) {  // if checking box, just add
-        self.addAndSubtractFromResultSkeletonSource({
-          add: Array.from(responseCache[row.data().labelName].skelIDs),
-          subtract: []
-        });
-      } else {  // if unchecking box, run full sync
-        self.syncResultSkeletonSource();
-      }
+      self.syncResultSkeletonSource();
     });
 
     $(`#${self.idPrefix}select-all`).change(function(event){
@@ -386,15 +421,15 @@
       }
     });
 
-    var headerInputSelector = tableSelector.find('thead input');
+    var $headerInput = $table.find('thead input');
 
     // prevent sorting the column when focusing on the search field
-    headerInputSelector.click(function (event) {
+    $headerInput.click(function (event) {
       event.stopPropagation();
     });
 
     // remove the 'Search' string when first focusing the search box
-    headerInputSelector.focus(function () {
+    $headerInput.focus(function () {
       if (this.className === "search_init") {
         this.className = "";
         this.value = "";
@@ -403,9 +438,9 @@
   };
 
   TagTable.prototype.refreshDataAndRedraw = function() {
-    var procSelector = $(`#${this.idPrefix}datatable_processing`);
+    var $processing = $(`#${this.idPrefix}datatable_processing`);
 
-    procSelector.show();
+    $processing.show();
 
     for (var key of Object.keys(responseCache)) {
       delete responseCache[key];
@@ -440,9 +475,13 @@
 
         self.constrainSkelsAndRedraw();
 
-        procSelector.hide();
+        $processing.hide();
       }
-    );
+    )
+    .catch(function(error) {
+      $processing.hide();
+      CATMAID.handleError(error);
+    });
   };
 
   TagTable.prototype.destroy = function() {


### PR DESCRIPTION
Partially resolves #1482.

Fixes a couple of bugs relating to selecting skeletons which aren't in the constraint set, and the incorrect table footers. Also ensures that labels are inserted into the table in lexicographic order.

In my opinion, because you can't guarantee that you pull the same labels every time you refresh the table, it's best to go back to the first page (rather than a bunch of new labels appearing somewhere on an earlier page and having you miss them). Similarly, all rows get unchecked on refresh. Filters remain intact.

Datatables only stores the last ordering step, so if you sort (for example) by reverse name, and then skeleton count, on refresh it will keep the skeleton count sorting but the total order will change because it doesn't sort by the name first. I think we'd need to extend datatables to accomplish this, or intercept clicks on the headers - it would be a bit gross. 