### PR TITLE
Add Selenium tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - travis_retry travis_wait 60 pip install -q -r django/requirements.txt
   - pip list
   # Install additional dependencies for Travis
+  - pip install -q -r django/requirements-test.txt
   - pip install coveralls flake8
   - npm install jshint qunit-phantomjs-runner csslint jsdoc
 before_script:
@@ -50,6 +51,11 @@ before_script:
   - sed -i -e "s?^\(ALLOWED_HOSTS = \).*?\1['*']?g" projects/mysite/settings.py
   # Enable static file serving without DEBUG = True
   - echo "SERVE_STATIC = True" >> projects/mysite/settings.py
+  # Enable Selenium GUI tests, this currently works only with non-hash file names.
+  - echo "GUI_TESTS_ENABLED = True" >> projects/mysite/settings.py
+  - echo "GUI_TESTS_REMOTE = True" >> projects/mysite/settings.py
+  # Show full front-end errors by default
+  - echo "EXPAND_FRONTEND_ERRORS = True" >> projects/mysite/settings.py
   - cat projects/mysite/settings.py
   - cd ..
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ addons:
     - postgresql-9.5
     - postgresql-contrib-9.5
   postgresql: 9.5
+  sauce_connect:
+    username: catmaid
+  jwt:
+    secure: "hj6rvwzab8ptfMKvRyqCZnWqun2uEv69nLCGxLXiDk9QZOUv/UG8PU060m6DTHtYE8iJw5E6qhTIhLKlpPadYptkxmiOXVGKlU6jam8SLKsSbHbdFsoziIPnU4mpqNgjvZ7Xb7xoTmYcd15G7Du3qgTHc28TeT5F9XnyfyDCH7M="
 before_install:
   - mkdir tmp
   - travis_retry sudo apt-get update -y -qq

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This reflects the status of our tests:
 
 [![Build Status](https://travis-ci.org/catmaid/CATMAID.svg?branch=master)](https://travis-ci.org/catmaid/CATMAID)
 [![Coverage Status](https://coveralls.io/repos/catmaid/CATMAID/badge.svg?branch=master)](https://coveralls.io/r/catmaid/CATMAID)
+[![Sauce Test Status](https://saucelabs.com/open_sauce/build_status/catmaid.svg)](https://saucelabs.com/open_sauce/build_status/catmaid.svg)
 
 ### Releases
 

--- a/django/applications/catmaid/control/data_view.py
+++ b/django/applications/catmaid/control/data_view.py
@@ -90,12 +90,20 @@ def get_available_data_views( request ):
     return HttpResponse(json.dumps(makeJSON_legacy_list(dataviews)), content_type="application/json")
 
 def get_default_properties( request ):
-    """ Return the properies of the default data view.
+    """ Return the properies of the default data view. If no data view is
+    configured as default, the one with the lowest ID will be returned.
     """
-    default = DataView.objects.filter(is_default=True)[0]
-    default = dataview_to_dict( default )
+    default_views = DataView.objects.filter(is_default=True)
+    if len(default_views) > 0:
+        result = dataview_to_dict(default_views[0])
+    else:
+        all_views = DataView.objects.all().order_by('id')
+        if all_views.count() > 0:
+            result = dataview_to_dict(all_views[0])
+        else:
+            result = {}
 
-    return HttpResponse(json.dumps(default), content_type="application/json")
+    return JsonResponse(result)
 
 def get_detail(request, data_view_id):
     """Get details on a particular data view.

--- a/django/applications/catmaid/static/js/widgets/detail-dialog.js
+++ b/django/applications/catmaid/static/js/widgets/detail-dialog.js
@@ -45,7 +45,9 @@
         detail_text.appendChild(document.createTextNode(detail));
         this.dialog.appendChild(detail_text);
         // Hide detail by default and toggle display by click on header
-        $(detail_text).hide();
+        if (!CATMAID.expandErrors) {
+          $(detail_text).hide();
+        }
         $(detail_head).click(function() {
           $(detail_text).toggle();
         });

--- a/django/applications/catmaid/static/js/widgets/ontology_editor.js
+++ b/django/applications/catmaid/static/js/widgets/ontology_editor.js
@@ -1255,7 +1255,9 @@
               Promise.all([
                   self.create_new_class(self.workspace_pid, "classification_root", true),
                   self.create_new_relation(self.workspace_pid, "is_a", true)])
-                .then(function([classJson, relJson]) {
+                .then(function(results) {
+                  var classJson = resuls[0];
+                  var relJson = results[1];
                   self.refresh_trees();
                   if (classJson.already_present && relJson.already_present) {
                     CATMAID.msg("Success", "Classification system alrady initialized");

--- a/django/applications/catmaid/templates/catmaid/index.html
+++ b/django/applications/catmaid/templates/catmaid/index.html
@@ -32,6 +32,7 @@
                 undefined,
                 {{ HISTORY_TRACKING|make_js_bool }});
       CATMAID.CLIENT_VERSION = "{% catmaid_version %}";
+      CATMAID.expandErrors = {{ EXPAND_FRONTEND_ERRORS|make_js_bool }};
     </script>
 
     {% javascript 'catmaid' %}

--- a/django/applications/catmaid/tests/gui/test_basic_gui.py
+++ b/django/applications/catmaid/tests/gui/test_basic_gui.py
@@ -1,0 +1,223 @@
+import os, re
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+import selenium.webdriver.support.expected_conditions as EC
+
+from unittest import skipUnless
+
+from django.conf import settings
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+
+from catmaid.models import User, DataView, DataViewType
+
+from guardian.utils import get_anonymous_user
+
+
+class BasicUITest(StaticLiveServerTestCase):
+    """Test basic front-end elements and workflows, e.g. login/logout. Selenium
+    is used for this. In CATMAID's default configuration, GUI tests are disabled
+    to not interfer too much with console based test runs. They can be enabled
+    by setting GUI_TESTS_ENABLED = True, which is also what is done in our CI
+    tests. Additionally, for CI testing, GUI_TESTS_REMOTE is also set to true,
+    which causes this test case to use a remote Selenium driver. This remote
+    driver uses saucelabs.com to execute GUI tests on a virtual machine.
+    """
+    maxDiff = None
+
+    @classmethod
+    def create_test_data(cls):
+        """Provide some basic model instances to get a running CATMAID front-end
+        without fixtures.
+        """
+        cls.created_models = []
+        cls.anon_user, created = User.objects.get_or_create(
+                username='AnonymousUser', defaults={'email': 'anon@my.mail'})
+        if created:
+            cls.created_models.append(cls.anon_user)
+
+        cls.user, created = User.objects.get_or_create(username='test',
+                defaults={'email': 'test@my.mail'})
+        cls.user.set_password('test')
+        cls.user.save()
+        if created:
+            cls.created_models.append(cls.user)
+
+        dvt, created = DataViewType.objects.get_or_create(
+                code_type='project_list_data_view',
+                defaults={'title': 'Project list'})
+        if created:
+            cls.created_models.append(dvt)
+
+        dv, created = DataView.objects.get_or_create(title='Project list',
+                data_view_type=dvt, is_default=True)
+        if created:
+            cls.created_models.append(dv)
+
+    @classmethod
+    def remove_test_data(cls):
+        """Destroy all created data
+        """
+        for m in cls.created_models:
+            m.delete()
+
+    def setUp(self):
+        """Set up Selenium driver if GUI_TESTS_ENABLED (which will be a remote
+        driver of saucelabs.com if GUI_TESTS_REMOTE is true).
+        """
+        super(BasicUITest, self).setUp()
+        if settings.GUI_TESTS_ENABLED:
+            if settings.GUI_TESTS_REMOTE:
+                # Set up Travis + Sauce Labs configuration
+                username = os.environ["SAUCE_USERNAME"]
+                access_key = os.environ["SAUCE_ACCESS_KEY"]
+                # Saucelab's linux platform only supports Chrome up to v48.
+                # Until this is updated, we have to work with their Windows
+                # platform to use Chrome >= v55.
+                capabilities = {
+                    "platform": "Windows 10",
+                    "browserName": "chrome",
+                    "version": "55.0",
+                    "captureHtml": True,
+                    "webdriverRemoteQuietExceptions": False,
+                    "tunnel-identifier": os.environ["TRAVIS_JOB_NUMBER"],
+                    "name": "Commit {}".format(os.environ["TRAVIS_COMMIT"]),
+                    "build": os.environ["TRAVIS_BUILD_NUMBER"],
+                    "tags": [os.environ["TRAVIS_PYTHON_VERSION"], "CI"]
+                }
+                hub_url = "%s:%s@localhost:4445" % (username, access_key)
+                self.selenium = webdriver.Remote(
+                        desired_capabilities=capabilities,
+                        command_executor="http://%s/wd/hub" % hub_url)
+            else:
+                self.selenium = webdriver.Firefox()
+
+            # Give browser a chance to load elements
+            self.selenium.implicitly_wait(10)
+
+    def tearDown(self):
+        """Figure out if this test case was successful (based on
+        http://stackoverflow.com/questions/4414234). In case of a remote GUI
+        test, saucelabs.com is updated (which otherwise doesn't know if the
+        whole test case was a success).
+        """
+        if hasattr(self, '_outcome'):  # Python 3.4+
+            result = self.defaultTestResult()  # these 2 methods have no side effects
+            self._feedErrorsToResult(result, self._outcome.errors)
+        else:  # Python 3.2 - 3.3 or 2.7
+            result = getattr(self, '_outcomeForDoCleanups', self._resultForDoCleanups)
+        error = self.list2reason(result.errors)
+        failure = self.list2reason(result.failures)
+        ok = not error and not failure
+
+        if settings.GUI_TESTS_ENABLED:
+            if settings.GUI_TESTS_REMOTE:
+                # Let saucelabs.com know about the outcome of this test
+                id = self.selenium.session_id
+                print 'Link to remote Selenium GUI test job: https://saucelabs.com/jobs/%s' % id
+
+                from sauceclient import SauceClient
+                username = os.environ["SAUCE_USERNAME"]
+                access_key = os.environ["SAUCE_ACCESS_KEY"]
+                sauce_client = SauceClient(username, access_key)
+                sauce_client.jobs.update_job(self.selenium.session_id, passed=ok)
+
+            self.selenium.quit()
+
+        super(BasicUITest, self).tearDown()
+
+    @classmethod
+    def setUpClass(cls):
+        """Create some test data that can be used during GUI testing. This is
+        done before all tests are run.
+        """
+        cls.create_test_data()
+        super(BasicUITest, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove created test data after all tests are done.
+        """
+        cls.remove_test_data()
+        super(BasicUITest, cls).tearDownClass()
+
+    def list2reason(self, exc_list):
+        if exc_list and exc_list[-1][0] is self:
+            return exc_list[-1][1]
+
+    def make_url(self, path):
+        """Combine the test server URL with a relative path.
+        """
+        return self.live_server_url + path
+
+    @skipUnless(settings.GUI_TESTS_ENABLED, "GUI tests are disabled")
+    def test_home_page_login_logout(self):
+        """Test if the test server is reachable, the index page can be parsed
+        without syntax errors, has the correct page title and login/logout works
+        as expected.
+        """
+        self.selenium.get(self.make_url("/"))
+
+        # Make sure the browser doesn't see any syntax errors during loading.
+        # These unfortunately fail silently otherwise.
+        browser_log = self.selenium.get_log('browser')
+        for log_entry in browser_log:
+            self.assertIn('message', log_entry)
+            if 'SyntaxError' in log_entry['message']:
+                print("Syntax error: {}".format(log_entry['message']))
+
+                # If there is a syntax error, try to parse the message to load
+                # the respective source file and print the relevant lines.
+                r = re.search('^(.*)\s(\d+):\d+\sUncaught', log_entry['message'])
+                if r:
+                    url = r.group(1)
+                    line = int(r.group(2))
+
+                    if url and line:
+                        self.selenium.get(url)
+                        lines = self.selenium.page_source.splitlines()
+                        print("Relevant source code:")
+                        c = 2
+                        for l in range(max(0, line - c - 1), min(len(lines) - 1, line + c)):
+                            print("{}: {}".format(str(l + 1), lines[l]))
+
+                # Let test fail
+                self.assertNotIn('SyntaxError', log_entry['message'])
+
+            # Fail on any severe errors
+            self.assertIn('level', log_entry)
+            self.assertNotIn('SEVERE', log_entry['level'])
+
+        # Check title
+        self.assertTrue("CATMAID" in self.selenium.title)
+
+        # Login
+        account = WebDriverWait(self.selenium, 10).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, '#account')))
+        password = WebDriverWait(self.selenium, 10).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, '#password')))
+
+        login = WebDriverWait(self.selenium, 10).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, '#login')))
+
+        account.send_keys("test")
+        password.send_keys("test")
+        login.send_keys(Keys.RETURN)
+
+        logout = WebDriverWait(self.selenium, 10).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, 'a#logout')))
+        self.assertTrue(logout.is_displayed(), "Logout button is displayed")
+        login = WebDriverWait(self.selenium, 10).until(
+                EC.invisibility_of_element_located((By.CSS_SELECTOR, 'a#login')))
+        self.assertFalse(login.is_displayed(), "Login button is invisible")
+
+        # Logout
+        logout.send_keys(Keys.RETURN)
+        logout = WebDriverWait(self.selenium, 10).until(
+                EC.invisibility_of_element_located((By.CSS_SELECTOR, 'a#logout')))
+        self.assertFalse(logout.is_displayed(), "Logout button is invisible")
+        login = WebDriverWait(self.selenium, 10).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, 'a#login')))
+        self.assertTrue(login.is_displayed(), "Login button is displayed")

--- a/django/applications/catmaid/views/__init__.py
+++ b/django/applications/catmaid/views/__init__.py
@@ -18,6 +18,7 @@ class CatmaidView(TemplateView):
         context['STATIC_EXTENSION_URL'] = settings.STATIC_EXTENSION_URL
         context['STATIC_EXTENSION_FILES'] = settings.STATIC_EXTENSION_FILES
         context['HISTORY_TRACKING'] = settings.HISTORY_TRACKING
+        context['EXPAND_FRONTEND_ERRORS'] = getattr(settings, 'EXPAND_FRONTEND_ERRORS', False)
         profile_context = self.request.user.userprofile.as_dict()
         return dict(context.items() + profile_context.items())
 

--- a/django/projects/mysite/settings_base.py
+++ b/django/projects/mysite/settings_base.py
@@ -288,6 +288,11 @@ VERSION = utils.get_version()
 # its behavior.
 TEST_RUNNER = 'custom_testrunner.TestSuiteRunner'
 
+# By default GUI tests are disabled. Enable them by setting GUI_TESTS_ENABLED to
+# True (done during CI).
+GUI_TESTS_ENABLED = False
+GUI_TESTS_REMOTE = False
+
 # To simplify configuration for performance test CATMAID instances, the SCM URL
 # used to create commit links is defined here. The {} is used to denote the
 # commit name.

--- a/django/requirements-test.txt
+++ b/django/requirements-test.txt
@@ -1,0 +1,2 @@
+selenium==3.0.2
+git+git://github.com/cgoldberg/sauceclient.git@56fafccf7e941a4d0e98b76cb9082585e79149c7#egg=sauceclient

--- a/sphinx-doc/source/djangounittest.rst
+++ b/sphinx-doc/source/djangounittest.rst
@@ -82,3 +82,13 @@ Then run::
 
 ... to generate HTML output in ``htmlcov/index.html``.
 
+GUI tests
+---------
+
+To make sure some typical workflows work with development and release versions,
+we maintain a small set of Selenium GUI tests. Those are defined as Django unit
+tests and live under ``django/applications/catmaid/tests/gui/``. To run these
+tests locally the ``GUI_TESTS_ENABLED`` setting has to be set to True or
+otherwise all GUI tests are ignored. Our CI test setup activates GUI tests
+automatically and also sets ``GUI_TESTS_REMOTE`` to True, which allows it to run
+Selenium tests on the virtual machines of saucelabs.com automatically.


### PR DESCRIPTION
To make sure some typical workflows work with development and release versions, it seems useful to have a small set of Selenium GUI tests. This branch adds the required infrastructure and integrates it into our Travis CI tests. Selenium tests are defined as Django unit tests and live under ``django/applications/catmaid/tests/gui/``. There is currently only a single small test implemented: load the index page, check for syntax errors, login and logout. A typical output (including screenshots) can be found [here](https://saucelabs.com/jobs/abe748ab718d42d9a93c9dd223c6196d) and there is a new badge in our readme file.

 To run such tests locally the ``GUI_TESTS_ENABLED`` setting has to be set to True or otherwise all GUI tests are ignored. The CI test setup activates GUI tests automatically and also sets ``GUI_TESTS_REMOTE`` to ``True``, which allows it to automatically run Selenium tests on the virtual machines of saucelabs.com.

This PR is more or meant as documentation, but of course I appreciate any concerns or comments. I don't think we need to write a lot of these tests, but a handful of simple tests could already provide some extra robustness: login/logout, open all registered widgets, create a few nodes, etc.