### PR TITLE
Add authentication to HDF5 tile methods

### DIFF
--- a/django/applications/catmaid/control/tile.py
+++ b/django/applications/catmaid/control/tile.py
@@ -6,7 +6,9 @@ import numpy as np
 import base64
 from django.conf import settings
 
+from catmaid.models import UserRole
 from catmaid.control.common import ConfigurationError
+from catmaid.control.authentication import requires_user_role
 
 try:
     from PIL import Image
@@ -26,6 +28,7 @@ except ImportError, e:
 
 from django.http import HttpResponse
 
+@requires_user_role([UserRole.Browse])
 def get_tile(request, project_id=None, stack_id=None):
 
     if not tile_loading_enabled:
@@ -62,7 +65,7 @@ def get_tile(request, project_id=None, stack_id=None):
             pilImage = Image.frombuffer('RGBA',(width,height),data,'raw','L',0,1)
             response = HttpResponse(content_type="image/png")
             pilImage.save(response, "PNG")
-            return response            
+            return response
             # return HttpResponse(json.dumps({'error': 'HDF5 file does not contain scale: {0}'.format(str(int(scale)))}))
         image_data=hfile[hdfpath]
         data=image_data[y:y+height,x:x+width]
@@ -73,6 +76,7 @@ def get_tile(request, project_id=None, stack_id=None):
 
     return response
 
+@requires_user_role([UserRole.Annotate])
 def put_tile(request, project_id=None, stack_id=None):
     """ Store labels to HDF5 """
 

--- a/scripts/neurohdf/create_neurohdf.py
+++ b/scripts/neurohdf/create_neurohdf.py
@@ -1,16 +1,18 @@
 #!/usr/bin/python
 
 # Create a project and stack associated HDF5 file with additional
-# data such as labels, meshes etc. 
+# data such as labels, meshes etc.
 
 import os.path as op
 import h5py
 from contextlib import closing
 import numpy as np
 
+from django.conf import settings
+
 project_id = 3
 stack_id = 4
-filepath = '/home/ottj/CATMAID/django/hdf5'
+filepath = settings.HDF5_STORAGE_PATH
 
 with closing(h5py.File(op.join(filepath, '%s_%s.hdf' % (project_id, stack_id)), 'w')) as hfile:
     mesh=hfile.create_group('meshes')
@@ -28,7 +30,7 @@ with closing(h5py.File(op.join(filepath, '%s_%s.hdf' % (project_id, stack_id)), 
     # the interval defines for a spatial axis the resolution / dimension
     # for scale 0
     image.attrs['axis0__interval'] = 1.0
-    
+
     image.attrs['axis1__label'] = 'y'
     image.attrs['axis1__unit_label'] = 'micrometer'
     image.attrs['axis1__unit_xref'] = 'UO:0000017'
@@ -42,7 +44,7 @@ with closing(h5py.File(op.join(filepath, '%s_%s.hdf' % (project_id, stack_id)), 
     dataset=np.random.random_integers(0,255, (1024,1024,10))
     scale=image.create_group('scale')
     scale.attrs['number_of_scales'] = 3
-    
+
     scale0=scale.create_group('0')
     scale0.attrs['axes_scaling_factor'] = (1.0, 1.0, 1.0)
     scale0.create_dataset('data', data=dataset, dtype = np.uint8)


### PR DESCRIPTION
`tile.py` didn't have any authentication on its API methods, which seemed inadvisable.