### PR TITLE
Minor synapse overlay features

### DIFF
--- a/django/applications/catmaid/control/project.py
+++ b/django/applications/catmaid/control/project.py
@@ -17,6 +17,7 @@ from rest_framework.decorators import api_view
 # descriptions.
 needed_classes = {
     'annotation': "An arbitrary annotation",
+    'stack_property': 'A property which a stack has',
 }
 
 # All relations needed by the tracing system alongside their
@@ -25,6 +26,7 @@ needed_relations = {
     'is_a': "A generic is-a relationship",
     'part_of': "One thing is part of something else.",
     'annotated_with': "Something is annotated by something else.",
+    'has_property': 'A thing which has an arbitrary property',
 }
 
 # All client datastores needed by the tracing system along their descriptions.

--- a/django/applications/catmaid/static/js/tile-source.js
+++ b/django/applications/catmaid/static/js/tile-source.js
@@ -63,7 +63,7 @@
     });
 
     var beforeCorsLoad = performance.now();
-    var corsReq = fetch(new Request(url, {mode: 'cors'}))
+    var corsReq = fetch(new Request(url, {mode: 'cors', credentials: 'same-origin'}))
       .then(function (response) {
         var contentHeader = response.headers.get('Content-Type');
         return [contentHeader && contentHeader.startsWith('image'),


### PR DESCRIPTION
Some minor changes towards enabling HDF5 label stack viewing.

I assume d57445d is fine to go into production - sending normal CORS headers for a same-origin request (e.g. if the HDF5 stack is served directly by CATMAID)

6d63612 adds a Class for stack properties, and a relation for it - although I'm not doing anything with them yet, I've just hardcoded `tile.py` to get the HDF5 I want. This doesn't need to go in right now.

18fb228 is the main meat of the PR; it adds a color picker and a number field (which will only accept uint24, for... reasons) to the filter control options, and the Object Label Color Map filter, which is pretty much like the old LabelColorMap, but it allows you to reserve two labels ('unknown' for un-segmented pixels and 'background') and assign them specific colours. All other labels are assigned a colour based on the hash of that label, and a user-specified alpha. I've renamed the old LabelColorMap to RandomLabelColorMap, for clarity.

~~One remaining issue is that the background and unknown colours multiply the image stack colours - i.e. even if the 'unknown' alpha is set to 0, everything under it will still be slightly red. This is true for all blend modes. I suspect it's something to do with the way the color picker returns its RGB values - maybe they're not premultiplied and want to be, which is confusing webGL.~~ Fixed

Welcome to come by my desk for a demo next week (as it depends on some changes I haven't pushed).