### PR TITLE
Move manage.py script one folder level up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,15 +71,15 @@ script:
   - cd django/applications/catmaid/static/css
   - $TRAVIS_BUILD_DIR/node_modules/.bin/csslint .
   - cd $TRAVIS_BUILD_DIR
-  - cd django/projects/mysite
+  - cd django/projects
   - python manage.py migrate --noinput
   - python manage.py collectstatic --link --noinput
   - coverage run manage.py test catmaid.tests
   # Remove login requirement from QUnit test page
-  - sed -i 's/login_required(\([^)]*\))/\1/g' ../../applications/catmaid/urls.py
+  - sed -i 's/login_required(\([^)]*\))/\1/g' ../applications/catmaid/urls.py
   - python manage.py runserver &
   - sleep 5
-  - cd ../../..
+  - cd ../..
   # Run QUnit tests through SlimerJS with Firefox
   - wget https://github.com/laurentj/slimerjs/releases/download/0.10.0/slimerjs-0.10.0.zip
   - unzip -qq slimerjs-0.10.0.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@
 
 ### Notes
 
+- The location of the `manage.py` script changed: it moved a level up into
+  `django/projects`. All other configuration files remain where they are. Make
+  sure to update your `settings.py` file by replacing the line
+  `from settings_base import *` with `from mysite.settings_base import *`.
+
 - Python 3.5 is now experimentally supported. Most functionality should work
-  without problems. To test, make sure to update `settings.py` by 1. replacing
-  `from settings_base import *` with `from mysite.settings_base import *` and 2.
-  replace the fragment `hashlib.md5(CATMAID_URL)` with
+  without problems. To test, make sure to update `settings.py` by replacing
+  the fragment `hashlib.md5(CATMAID_URL)` with
   'hashlib.md5(CATMAID_URL.encode('utf-8'))'.
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN cp /home/django/configuration.py.example /home/django/configuration.py \
 RUN service postgresql start \
     && /bin/bash -c "source /usr/share/virtualenvwrapper/virtualenvwrapper.sh \
     && workon catmaid \
-    && cd /home/django/projects/mysite \
+    && cd /home/django/projects \
     && python manage.py migrate --noinput \
     && python manage.py collectstatic --clear --link --noinput \
     && cat /home/scripts/docker/create_superuser.py | python manage.py shell \

--- a/django/projects/manage.py
+++ b/django/projects/manage.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import os, sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
 
     from django.core.management import execute_from_command_line
 

--- a/django/projects/mysite/settings.py.example
+++ b/django/projects/mysite/settings.py.example
@@ -1,7 +1,7 @@
 # If you don't have settings.py in this directory, you should copy
 # this file to settings.py and customize it.
 
-from settings_base import *
+from mysite.settings_base import *
 import hashlib
 import djcelery
 

--- a/django/projects/mysite/settings_base.py
+++ b/django/projects/mysite/settings_base.py
@@ -6,9 +6,9 @@ from __future__ import unicode_literals
 import os
 import sys
 import django.conf.global_settings as DEFAULT_SETTINGS
-import utils
 import logging
-import pipelinefiles
+import mysite.pipelinefiles as pipelinefiles
+import mysite.utils as utils
 import six
 
 try:

--- a/django/projects/run-gevent.py
+++ b/django/projects/run-gevent.py
@@ -10,9 +10,9 @@ monkey.patch_all()
 from django.core.wsgi import get_wsgi_application
 from gevent.wsgi import WSGIServer
 import os, sys
-import settings
+import mysite.settings as settings
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
 
 # Configure host and port for the WSGI server
 host = getattr(settings, 'WSGI_HOST', '127.0.0.1')

--- a/sphinx-doc/source/administration.rst
+++ b/sphinx-doc/source/administration.rst
@@ -45,11 +45,11 @@ Update Python packages::
 
 Synchronize the Django environment with the database::
 
-   ./projects/mysite/manage.py migrate
+   ./projects/manage.py migrate
 
 Collect new and changed static files::
 
-   ./projects/mysite/manage.py collectstatic -l
+   ./projects/manage.py collectstatic -l
 
 Finally, open the web-frontend of your CATMAID instance in a browser to
 start the database migration. If you don't need it anymore, you can also

--- a/sphinx-doc/source/celeryinstall.rst
+++ b/sphinx-doc/source/celeryinstall.rst
@@ -219,7 +219,7 @@ script that can be used with the example provided there would look like this
   export PYTHONPATH=$DJANGODIR:$PYTHONPATH
 
   # Run Celery
-  exec ./mysite/manage.py celery worker -l info -E
+  exec ./manage.py celery worker -l info -E
 
 Init
 ^^^^
@@ -242,7 +242,7 @@ the Celery documentation)::
   #CELERYD_NODES="w1 w2 w3"
 
   # Where to chdir at start. (CATMAID Django project dir.)
-  CELERYD_CHDIR="/path/to/CATMAID/django/projects/mysite/"
+  CELERYD_CHDIR="/path/to/CATMAID/django/projects/"
 
   # Python interpreter from environment. (in CATMAID Django dir)
   ENV_PYTHON="/path/to/CATMAID/django/env/bin/python"

--- a/sphinx-doc/source/contributing.rst
+++ b/sphinx-doc/source/contributing.rst
@@ -343,7 +343,7 @@ these checks are easy to run locally.
 
 Django tests are run through Django's admin commands::
 
-        cd /<path_to_catmaid_install>/django/projects/mysite
+        cd /<path_to_catmaid_install>/django/projects
         ./manage.py test catmaid.tests
 
 JSHint can be `installed from NPM or your platform's package manager

--- a/sphinx-doc/source/importing_data.rst
+++ b/sphinx-doc/source/importing_data.rst
@@ -13,7 +13,7 @@ Two management commands for Django's ``manage.py`` tool are available in CATMAID
 that allow exporting and importing neuron tracing data. They are called
 ``catmaid_export_data`` and ``catmaid_import_data``. To use them, you have to be
 in the ``virtualenv`` and it is probably easiest to work from the
-``django/projects/mysite/`` directory.
+``django/projects/`` directory.
 
 Exporting data
 ^^^^^^^^^^^^^^

--- a/sphinx-doc/source/installation.rst
+++ b/sphinx-doc/source/installation.rst
@@ -239,12 +239,11 @@ in ``/home/alice/catmaid/django/projects/mysite``.
 5. Create the database tables
 #############################
 
-The commands in the following sections are all based on the
-Django site's admin script ``manage.py``, which would be in
-``/home/alice/catmaid/django/projects/mysite``, so these
-instructions assume that you've changed into that directory::
+The commands in the following sections are all based on the Django site's admin
+script ``manage.py``, which would be in ``/home/alice/catmaid/django/projects``,
+so these instructions assume that you've changed into that directory::
 
-    cd /home/alice/catmaid/django/projects/mysite
+    cd /home/alice/catmaid/django/projects
 
 Now create all required tables and bring the database schema up to date
 for applications that mange changes to their tables with South::


### PR DESCRIPTION
Django changed the default manage.py location already multiple versions ago. This has been done do prevent duplicate imports under different names, which caused some log entries to appear twice. This was so far no big problem, but with Python 3.5 the relative imports used in `settings.py` and `settings_base.py` had to be replaced to work both in a module and non-module environment (e.g. uwsgi vs. manage.py). To make this easier and more consistent with recent Django versions, the manage.py script was moved up a level. This way, the Django settings module is consistently available as `mysite.settings`, duplicate imports are prevented, and our settings configuration works with Python 3.5.

I am putting this into a pull request mainly for documentation purposes and for comments or concerns in case I overlooked something.