### PR TITLE
Use event key values instead of key codes for key handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ Miscellaneous:
 - Review widget: it is possible again to use Q/W to move along already reviewed
   segments (re-review of nodes).
 
+- Fix some accidental key mapping collisions of some special keys and media
+  keys.
+
 
 ## 2017.04.20
 

--- a/django/applications/catmaid/static/js/action.js
+++ b/django/applications/catmaid/static/js/action.js
@@ -53,16 +53,16 @@
 
   /**
    * Add a new key shortcut for this action. For example, you might call:
-   *    action.addKey( "+", [107, 61, 187] );
+   *    action.addKey( "+", ['+'] );
    *
-   * @param {string}   name     Display string of the bound key.
-   * @param {number[]} keyCodes Array of key codes that will trigger this action.
+   * @param {string}   name   Display string of the bound key.
+   * @param {number[]} keys   Array of key names that will trigger this action.
    */
-  Action.prototype.addKey = function (name, keyCodes) {
+  Action.prototype.addKey = function (name, keys) {
     if (this.keyShortcuts.hasOwnProperty(name)) {
-      alert("BUG: replacing the keyCodes for " + name + " with Action.addKey");
+      CATMAID.warn("Replacing the key for " + name + " with Action.addKey");
     }
-    this.keyShortcuts[name] = keyCodes;
+    this.keyShortcuts[name] = keys;
   };
 
   Action.prototype.hasButton = function () {
@@ -120,26 +120,25 @@
   };
 
 
-  var getKeyCodeToActionMap = function( actionArray ) {
-    var i, j, keyCodeToKeyAction = {}, action;
-    var keyShortcuts, keyCodes, keyCode;
-    for (i = 0; i < actionArray.length; ++i) {
-      action = actionArray[i];
-      keyShortcuts = action.getKeys();
+  var getKeyToActionMap = function( actionArray ) {
+    var keyToKeyAction = {};
+    for (var i = 0; i < actionArray.length; ++i) {
+      var action = actionArray[i];
+      var keyShortcuts = action.getKeys();
       for (var name in keyShortcuts) {
         if (keyShortcuts.hasOwnProperty(name)) {
-          keyCodes = keyShortcuts[name];
-          for( j = 0; j < keyCodes.length; ++j ) {
-            keyCode = keyCodes[j];
-            if (keyCodeToKeyAction[keyCode]) {
-              alert("BUG: overwriting action for keyCode " + keyCode + " (via '" + name + "')");
+          var keys = keyShortcuts[name];
+          for(var j = 0; j < keys.length; ++j) {
+            var key = CATMAID.UI.normalizeKeyCombo(keys[j]);
+            if (keyToKeyAction[key]) {
+              CATMAID.warn("Overriding action for key " + key + " (via '" + name + "')");
             }
-            keyCodeToKeyAction[keyCode] = action;
+            keyToKeyAction[key] = action;
           }
         }
       }
     }
-    return keyCodeToKeyAction;
+    return keyToKeyAction;
   };
 
   /** Updates the 'alt' and 'title' attributes on the toolbar
@@ -230,7 +229,7 @@
       buttonID: 'key_help_button',
       buttonName: "help",
       keyShortcuts: {
-        'F1': [ 112 ]
+        'F1': [ 'F1' ]
       },
       run: function (e) {
         WindowMaker.show('keyboard-shortcuts');
@@ -241,7 +240,7 @@
 
   // Make Action available in CATMAID namespace
   CATMAID.Action = Action;
-  CATMAID.getKeyCodeToActionMap = getKeyCodeToActionMap;
+  CATMAID.getKeyToActionMap = getKeyToActionMap;
   CATMAID.createButtonsFromActions = createButtonsFromActions;
 
 })(CATMAID);

--- a/django/applications/catmaid/static/js/init.js
+++ b/django/applications/catmaid/static/js/init.js
@@ -755,11 +755,12 @@ var project;
    * @return {boolean}   False if enter was pressed, true otherwise.
    */
   function login_oninputreturn(e) {
-    if (CATMAID.ui.getKey(e) == 13) {
+    if (e.key === 'Enter') {
       CATMAID.client.login(document.getElementById("account").value, document.getElementById("password").value);
       return false;
-    } else
-    return true;
+    } else {
+      return true;
+    }
   }
 
   /**

--- a/django/applications/catmaid/static/js/project.js
+++ b/django/applications/catmaid/static/js/project.js
@@ -434,7 +434,7 @@
       linked to the key code, or false otherwise. */
 
     this.handleKeyPress = function( e ) {
-      var keyAction = keyCodeToAction[e.keyCode];
+      var keyAction = CATMAID.UI.getMappedKeyAction(keyToAction, e);
       if (keyAction) {
         return keyAction.run(e);
       } else {
@@ -487,7 +487,7 @@
       return actions;
     };
 
-    var keyCodeToAction = CATMAID.getKeyCodeToActionMap(actions);
+    var keyToAction = CATMAID.getKeyToActionMap(actions);
   }
 
   /**

--- a/django/applications/catmaid/static/js/tests/test_ui.js
+++ b/django/applications/catmaid/static/js/tests/test_ui.js
@@ -1,0 +1,28 @@
+/* -*- mode: espresso; espresso-indent-level: 2; indent-tabs-mode: nil -*- */
+/* vim: set softtabstop=2 shiftwidth=2 tabstop=2 expandtab: */
+
+QUnit.test('UI test', function( assert ) {
+
+  // Test CATMAID.UI.getKeyValue
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Shift + a'), 'Shift + A');
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Shift + Shift + z'), 'Shift + Z');
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Shift + Z'), 'Shift + Z');
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Shift + Shift + A'), 'Shift + A');
+
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Alt + a'), 'Alt + a');
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Alt + Alt + z'), 'Alt + z');
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Alt + Z'), 'Alt + Z');
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Alt + Alt + A'), 'Alt + A');
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Alt + z'), 'Alt + z');
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Alt + Alt + a'), 'Alt + a');
+
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Ctrl + a'), 'Ctrl + a');
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Ctrl + Ctrl + z'), 'Ctrl + z');
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Ctrl + Z'), 'Ctrl + Z');
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Ctrl + Ctrl + A'), 'Ctrl + A');
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Ctrl + z'), 'Ctrl + z');
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Ctrl + Ctrl + a'), 'Ctrl + a');
+
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Ctrl + Alt + a'), 'Alt + Ctrl + a');
+  assert.ok(CATMAID.UI.normalizeKeyCombo('Ctrl + Alt + Shift + a'), 'Alt + Ctrl + Shift + A');
+});

--- a/django/applications/catmaid/static/js/tools/edit-tool.js
+++ b/django/applications/catmaid/static/js/tools/edit-tool.js
@@ -70,8 +70,6 @@
            helpText: "Segmentation Tool",
            buttonID: 'edit_button_segmentation',
            buttonName: 'canvas',
-           keyShortcuts: {
-           },
            run: function (e) {
               project.setTool( new CATMAID.SegmentationTool() );
            }

--- a/django/applications/catmaid/static/js/tools/navigator.js
+++ b/django/applications/catmaid/static/js/tools/navigator.js
@@ -325,19 +325,12 @@
       return actions;
     };
 
-    var arrowKeyCodes = {
-      left: 37,
-      up: 38,
-      right: 39,
-      down: 40
-    };
-
     var actions = [
 
       new CATMAID.Action({
         helpText: "Zoom in (smaller increments with <kbd>Shift</kbd> held)",
         keyShortcuts: {
-          '+': [ 43, 107, 61, 187 ]
+          '+': [ '+', 'Shift + +' ]
         },
         run: function (e) {
           self.slider_s.move(1, !e.shiftKey);
@@ -348,7 +341,7 @@
       new CATMAID.Action({
         helpText: "Zoom out (smaller increments with <kbd>Shift</kbd> held)",
         keyShortcuts: {
-          '-': [ 45, 109, 173, 189 ]
+          '-': [ '-', 'Shift + -' ]
         },
         run: function (e) {
           self.slider_s.move(-1, !e.shiftKey);
@@ -359,7 +352,7 @@
       new CATMAID.Action({
         helpText: "Move up 1 slice in z (or 10 with <kbd>Shift</kbd> held; hold with <kbd>Ctrl</kbd> to animate)",
         keyShortcuts: {
-          ',': [ 44, 188 ]
+          ',': [ ',', 'Ctrl + ,', 'Ctrl + Shift + ,', 'Shift + ,' ]
         },
         run: function (e) {
           var step = e.shiftKey ? (-1 * Navigator.Settings.session.major_section_step) : -1;
@@ -375,7 +368,7 @@
       new CATMAID.Action({
         helpText: "Move down 1 slice in z (or 10 with <kbd>Shift</kbd> held; hold with <kbd>Ctrl</kbd> to animate)",
         keyShortcuts: {
-          '.': [ 190 ]
+          '.': [ '.', 'Ctrl + .', 'Ctrl + Shift + .', 'Shift + .' ]
         },
         run: function (e) {
           var step = e.shiftKey ? Navigator.Settings.session.major_section_step : 1;
@@ -391,7 +384,7 @@
       new CATMAID.Action({
         helpText: "Move left (towards negative x, faster with <kbd>Shift</kbd> held)",
         keyShortcuts: {
-          "\u2190": [ arrowKeyCodes.left ]
+          "\u2190": [ 'ArrowLeft', 'Alt + ArrowLeft', 'Alt + Shift + ArrowLeft', 'Shift + ArrowLeft' ]
         },
         run: function (e) {
           self.input_x.value = parseInt(self.input_x.value, 10) - (e.shiftKey ? 100 : (e.altKey ? 1 : 10));
@@ -403,7 +396,7 @@
       new CATMAID.Action({
         helpText: "Move right (towards positive x, faster with <kbd>Shift</kbd> held)",
         keyShortcuts: {
-          "\u2192": [ arrowKeyCodes.right ]
+          "\u2192": [ 'ArrowRight', 'Alt + ArrowRight', 'Alt + Shift + ArrowRight', 'Shift + ArrowRight' ]
         },
         run: function (e) {
           self.input_x.value = parseInt(self.input_x.value, 10) + (e.shiftKey ? 100 : (e.altKey ? 1 : 10));
@@ -415,7 +408,7 @@
       new CATMAID.Action({
         helpText: "Move up (towards negative y, faster with <kbd>Shift</kbd> held)",
         keyShortcuts: {
-          "\u2191": [ arrowKeyCodes.up ]
+          "\u2191": [ 'ArrowUp', 'Alt + ArrowUp', 'Alt + Shift + ArrowUp', 'Shift + ArrowUp' ]
         },
         run: function (e) {
           self.input_y.value = parseInt(self.input_y.value, 10) - (e.shiftKey ? 100 : (e.altKey ? 1 : 10));
@@ -427,7 +420,7 @@
       new CATMAID.Action({
         helpText: "Move down (towards positive y, faster with <kbd>Shift</kbd> held)",
         keyShortcuts: {
-          "\u2193": [ arrowKeyCodes.down ]
+          "\u2193": [ 'ArrowDown', 'Alt + ArrowDown', 'Alt + Shift + ArrowDown', 'Shift + ArrowDown' ]
         },
         run: function (e) {
           self.input_y.value = parseInt(self.input_y.value, 10) + (e.shiftKey ? 100 : (e.altKey ? 1 : 10));
@@ -439,7 +432,7 @@
       new CATMAID.Action({
         helpText: "Hide all layers except image tile layers (while held)",
         keyShortcuts: {
-          "SPACE": [ 32 ]
+          "SPACE": [ ' ' ]
         },
         run: function (e) {
           // Avoid repeated onkeydown events in some browsers, but still
@@ -468,7 +461,7 @@
           var target = e.target;
           var oldListener = target.onkeyup;
           target.onkeyup = function (e) {
-            if (e.keyCode == 32) {
+            if (e.key === ' ') {
               stackLayers.forEach(function (layers, ind) {
                 Object.keys(layerOpacities[ind]).forEach(function (k) {
                   layers.get(k).setOpacity(layerOpacities[ind][k]);
@@ -487,13 +480,9 @@
       new CATMAID.Action({
         helpText: "Change major section step size",
         keyShortcuts: {
-          '#': [ 51 ]
+          '#': [ 'Shift + #' ]
         },
         run: function (e) {
-          // Don't handle "3" key presses without shift
-          if (!e.shiftKey) {
-            return false;
-          }
           // Show dialog to update major section step size
           var dialog = new CATMAID.OptionsDialog("Update major section step");
           dialog.appendMessage("Please provide a new majtor section step size.");
@@ -513,7 +502,7 @@
       }),
     ];
 
-    var keyCodeToAction = CATMAID.getKeyCodeToActionMap(actions);
+    var keyToAction = CATMAID.getKeyToActionMap(actions);
 
     /**
      * install this tool in a stackViewer.
@@ -621,7 +610,7 @@
       linked to the key code, or false otherwise. */
 
     this.handleKeyPress = function( e ) {
-      var keyAction = keyCodeToAction[e.keyCode];
+      var keyAction = CATMAID.UI.getMappedKeyAction(keyToAction, e);
       if (keyAction) {
         keyAction.run(e);
         return true;

--- a/django/applications/catmaid/static/js/tools/ontology-tool.js
+++ b/django/applications/catmaid/static/js/tools/ontology-tool.js
@@ -138,7 +138,7 @@
           // nothing to do here currently
     };
 
-      var keyCodeToAction = CATMAID.getKeyCodeToActionMap(actions);
+      var keyToAction = CATMAID.getKeyToActionMap(actions);
 
       /**
        * This function should return true if there was any action
@@ -146,7 +146,7 @@
        */
       this.handleKeyPress = function( e )
       {
-          var keyAction = keyCodeToAction[e.keyCode];
+          var keyAction = CATMAID.UI.getMappedKeyAction(keyToAction, e);
           if (keyAction) {
             return keyAction.run(e);
           } else {

--- a/django/applications/catmaid/static/js/tools/segmentation-tool.js
+++ b/django/applications/catmaid/static/js/tools/segmentation-tool.js
@@ -184,7 +184,7 @@
       this.addAction( new CATMAID.Action({
           helpText: "Move up 1 slice in z (or 10 with Shift held)",
           keyShortcuts: {
-              ',': [ 44, 188 ]
+              ',': [ ',' ]
           },
           run: function (e) {
               self.move_up( e );
@@ -195,7 +195,7 @@
       this.addAction( new CATMAID.Action({
           helpText: "Move down 1 slice in z (or 10 with Shift held)",
           keyShortcuts: {
-              '.': [ 46, 190 ]
+              '.': [ '.' ]
           },
           run: function (e) {
               self.move_down( e );
@@ -203,13 +203,13 @@
           }
       }) );
 
-      var keyCodeToAction = CATMAID.getKeyCodeToActionMap(actions);
+      var keyToAction = CATMAID.getKeyToActionMap(actions);
 
       /** This function should return true if there was any action
           linked to the key code, or false otherwise. */
       this.handleKeyPress = function( e )
       {
-          var keyAction = keyCodeToAction[e.keyCode];
+          var keyAction = CATMAID.UI.getMappedKeyAction(keyToAction, e);
           if (keyAction) {
             return keyAction.run(e);
           } else {

--- a/django/applications/catmaid/static/js/tools/tracing-tool.js
+++ b/django/applications/catmaid/static/js/tools/tracing-tool.js
@@ -534,31 +534,31 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Add 'ends' tag (<kbd>Shift</kbd>: Remove) for the active node",
-      keyShortcuts: { "K": [ 75 ] },
+      keyShortcuts: { "K": [ "k", "Shift + k" ] },
       run: tagFn('ends')
     }));
 
     this.addAction(new CATMAID.Action({
       helpText: "Add 'uncertain end' tag (<kbd>Shift</kbd>: Remove) for the active node",
-      keyShortcuts: { "U": [ 85 ] },
+      keyShortcuts: { "U": [ "u", "Shift + u" ] },
       run: tagFn('uncertain end')
     }));
 
     this.addAction(new CATMAID.Action({
       helpText: "Add 'uncertain continuation' tag (<kbd>Shift</kbd>: Remove) for the active node",
-      keyShortcuts: { "C": [ 67 ] },
+      keyShortcuts: { "C": [ "c", "Shift + c" ] },
       run: tagFn('uncertain continuation')
     }));
 
     this.addAction(new CATMAID.Action({
       helpText: "Add 'not a branch' tag (<kbd>Shift</kbd>: Remove) for the active node",
-      keyShortcuts: { "N": [ 78 ] },
+      keyShortcuts: { "N": [ "n", "Shift + n" ] },
       run: tagFn('not a branch')
     }));
 
     this.addAction(new CATMAID.Action({
       helpText: "Add 'soma' tag (<kbd>Shift</kbd>: Remove) for the active node",
-      keyShortcuts: { "M": [ 77 ] },
+      keyShortcuts: { "M": [ "m", "Shift + m" ] },
       run: tagFn('soma')
     }));
 
@@ -566,7 +566,7 @@
       helpText: "Go to active node (<kbd>Shift</kbd>: refresh active skeleton in 3D viewer)",
       buttonName: "goactive",
       buttonID: 'trace_button_goactive',
-      keyShortcuts: { "A": [ 65 ] },
+      keyShortcuts: { "A": [ "a", "Shift + a" ] },
       run: function (e) {
         if (!CATMAID.mayView())
           return false;
@@ -582,7 +582,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Go to nearest open leaf node (subsequent <kbd>Shift</kbd>+<kbd>R</kbd>: cycle through other open leaves; with <kbd>Alt</kbd>: most recent rather than nearest)",
-      keyShortcuts: { "R": [ 82 ] },
+      keyShortcuts: { "R": [ "r", "Alt + r", "Alt + Shift + r", "Shift + r" ] },
       run: function (e) {
         if (!CATMAID.mayView())
           return false;
@@ -593,7 +593,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Go to next branch or end point (with <kbd>Alt</kbd>: stop earlier at node with tag, synapse or low confidence; subsequent <kbd>Shift</kbd>+<kbd>V</kbd>: cycle through other branches)",
-      keyShortcuts: { "V": [ 86 ] },
+      keyShortcuts: { "V": [ "v", "Alt + v", "Alt + Shift + v", "Shift + v" ] },
       run: function (e) {
         if (!CATMAID.mayView())
           return false;
@@ -604,7 +604,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Go to previous branch or end node (with <kbd>Alt</kbd>: stop earlier at node with tag, synapse or low confidence)",
-      keyShortcuts: { "B": [ 66 ] },
+      keyShortcuts: { "B": [ "b", "Alt + b" ] },
       run: function (e) {
         if (!CATMAID.mayView())
           return false;
@@ -616,7 +616,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Deselect the active node",
-      keyShortcuts: { "D": [ 68 ] },
+      keyShortcuts: { "D": [ "d" ] },
       run: function (e) {
         if (!CATMAID.mayView())
           return false;
@@ -627,7 +627,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Go to the parent of the active node (<kbd>Ctrl</kbd>: ignore virtual nodes)",
-      keyShortcuts: { "[": [ 219, 56 ] },
+      keyShortcuts: { "[": [ "[", "Ctrl + [", "Meta + [" ] },
       run: (function() {
         var updateInProgress = false;
         return function (e) {
@@ -660,7 +660,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Go to the child of the active node (<kbd>Ctrl</kbd>: ignore virtual nodes; Subsequent <kbd>Shift</kbd>+<kbd>]</kbd>: cycle through children)",
-      keyShortcuts: { "]": [ 221, 57 ] },
+      keyShortcuts: { "]": [ "]", "Ctrl + ]" , "Meta + ]", "Shift + ]", "Ctrl + Shift + ]", "Meta + Shift + ]" ] },
       run: (function() {
         var updateInProgress = false;
         return function (e) {
@@ -693,7 +693,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Edit the radius of the active node (<kbd>Shift</kbd>: without measurment tool; <kbd>Ctrl</kbd>: without confirmation dialog)",
-      keyShortcuts: { "O": [ 79 ] },
+      keyShortcuts: { "O": [ "o", "Ctrl + o", "Ctrl + Shift + o", "Shift + o" ] },
       run: function (e) {
         if (!CATMAID.mayView())
           return false;
@@ -705,7 +705,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Measure the distance between the cursor and a clicked point",
-      keyShortcuts: { "X": [ 88 ] },
+      keyShortcuts: { "X": [ "x" ] },
       run: function (e) {
         if (!CATMAID.mayView())
           return false;
@@ -716,7 +716,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Go to last node edited by you in this skeleton (<kbd>Shift</kbd>: in any skeleton)",
-      keyShortcuts: { "H": [ 72 ] },
+      keyShortcuts: { "H": [ "h", "Shift + h" ] },
       run: function (e) {
         if (!CATMAID.mayView())
           return false;
@@ -732,7 +732,7 @@
           "<kbd>Shift</kbd>: select by radius; " +
           "<kbd>Alt</kbd>: create a new selection widget)",
       keyShortcuts: {
-        "Y": [ 89 ]
+        "Y": [ "y", "Ctrl + y", "Meta + y", "Shift + y", "Ctrl + Shift + y", "Meta + Shift + y" ]
       },
       run: function (e) {
         if (e.shiftKey) { // Select skeletons by radius.
@@ -792,7 +792,7 @@
       helpText: "Re-root this skeleton at the active node",
       buttonName: "skelrerooting",
       buttonID: 'trace_button_skelrerooting',
-      keyShortcuts: { "6": [ 54 ] },
+      keyShortcuts: { "6": [ "6" ] },
       run: function (e) {
         if (!CATMAID.mayEdit())
           return false;
@@ -805,7 +805,7 @@
       helpText: "Toggle the display of labels",
       buttonName: "togglelabels",
       buttonID: 'trace_button_togglelabels',
-      keyShortcuts: { "7": [ 55 ] },
+      keyShortcuts: { "7": [ "7" ] },
       run: function (e) {
         if (!CATMAID.mayView())
           return false;
@@ -827,7 +827,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Switch between a terminal and its connector",
-      keyShortcuts: { "S": [ 83 ] },
+      keyShortcuts: { "S": [ "s" ] },
       run: function (e) {
         if (!CATMAID.mayView())
           return false;
@@ -838,7 +838,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Tag the active node (<kbd>Shift</kbd>: Remove all tags; <kbd>Alt</kbd>: Tag with personal tag set)",
-      keyShortcuts: { "T": [ 84 ] },
+      keyShortcuts: { "T": [ "t", "Alt + t", "Shift + t", "Alt + Shift + t" ] },
       run: function (e) {
         if (!CATMAID.mayEdit())
           return false;
@@ -881,21 +881,21 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Add TODO Tag (<kbd>Shift</kbd>: Remove) to the active node",
-      keyShortcuts: { "L": [ 76 ] },
+      keyShortcuts: { "L": [ "l", "Shift + l" ] },
       run: tagFn('TODO')
     }));
 
     this.addAction(new CATMAID.Action({
       helpText: "Add 'microtubules end' tag (<kbd>Shift</kbd>: Remove) to the active node",
       keyShortcuts: {
-        "F": [ 70 ]
+        "F": [ "f", "Shift + f" ]
       },
       run: tagFn('microtubules end')
     }));
 
     this.addAction(new CATMAID.Action({
       helpText: "Select the nearest node to the mouse cursor",
-      keyShortcuts: { "G": [ 71 ] },
+      keyShortcuts: { "G": [ "g" ] },
       run: function (e) {
         if (!CATMAID.mayView())
           return false;
@@ -937,7 +937,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Create treenode (<kbd>Shift</kbd> on another node: join), behavior like mouse click",
-      keyShortcuts: { 'Z': [ 90 ] },
+      keyShortcuts: { 'Z': [ "z", "Alt + z", "Shift + z", "Alt + Shift + z" ] },
       run: function (e) {
         if (!CATMAID.mayEdit())
           return false;
@@ -951,7 +951,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Delete the active node (or suppress it if it is virtual)",
-      keyShortcuts: { 'DEL': [ 46 ] },
+      keyShortcuts: { 'DEL': [ "Delete" ] },
       run: function (e) {
         if (!CATMAID.mayEdit())
           return false;
@@ -962,7 +962,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Retrieve information about the active node.",
-      keyShortcuts: { 'I': [ 73 ] },
+      keyShortcuts: { 'I': [ 'i' ] },
       run: function (e) {
         if (!CATMAID.mayView())
           return false;
@@ -973,7 +973,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Set confidence in node link to 1 (Alt: with a connector)",
-      keyShortcuts: { '1': [ 49 ] },
+      keyShortcuts: { '1': [ '1', 'Alt + 1' ] },
       run: function (e) {
         if (!CATMAID.mayEdit())
           return false;
@@ -987,7 +987,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Set confidence in node link to 2 (Alt: with a connector)",
-      keyShortcuts: { '2': [ 50 ] },
+      keyShortcuts: { '2': [ '2', 'Alt + 2' ] },
       run: function (e) {
         if (!CATMAID.mayEdit())
           return false;
@@ -1001,7 +1001,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Set confidence in node link to 3 (Alt: with a connector)",
-      keyShortcuts: { '3': [ 51 ] },
+      keyShortcuts: { '3': [ '3', 'Alt + 3' ] },
       run: function (e) {
         if (!CATMAID.mayEdit())
           return false;
@@ -1015,7 +1015,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Set confidence in node link to 4 (Alt: with a connector)",
-      keyShortcuts: { '4': [ 52 ] },
+      keyShortcuts: { '4': [ '4', 'Alt + 4' ] },
       run: function (e) {
         if (!CATMAID.mayEdit())
           return false;
@@ -1029,7 +1029,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Set confidence in node link to 5 (Alt: with a connector)",
-      keyShortcuts: { '5': [ 53 ] },
+      keyShortcuts: { '5': [ '5', 'Alt + 5' ] },
       run: function (e) {
         if (!CATMAID.mayEdit())
           return false;
@@ -1043,7 +1043,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Move to previous node in segment for review. At an end node, moves one section beyond for you to check that it really ends.",
-      keyShortcuts: { 'Q': [ 81 ] },
+      keyShortcuts: { 'Q': [ 'q' ] },
       run: function (e) {
         if (!CATMAID.mayEdit())
           return false;
@@ -1059,7 +1059,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Move to next node in segment for review (with <kbd>Shift</kbd>: move to next unreviewed node in the segment)",
-      keyShortcuts: { 'W': [ 87 ] },
+      keyShortcuts: { 'W': [ 'w', 'Shift + w' ] },
       run: function (e) {
         if (!CATMAID.mayEdit())
           return false;
@@ -1075,7 +1075,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Start reviewing the next skeleton segment.",
-      keyShortcuts: { 'E': [ 69 ] },
+      keyShortcuts: { 'E': [ 'e' ] },
       run: function (e) {
         if (!CATMAID.mayEdit())
           return false;
@@ -1091,7 +1091,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Rename active neuron",
-      keyShortcuts: { 'F2': [ 113 ] },
+      keyShortcuts: { 'F2': [ 'F2' ] },
       run: function (e) {
         if (!CATMAID.mayEdit()) {
           return false;
@@ -1103,7 +1103,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Annotate active neuron",
-      keyShortcuts: { 'F3': [ 114 ] },
+      keyShortcuts: { 'F3': [ 'F3' ] },
       run: function (e) {
         if (!CATMAID.mayEdit()) {
           return false;
@@ -1117,7 +1117,7 @@
     this.addAction(new CATMAID.Action({
       helpText: "Neuron dendrogram",
       keyShortcuts: {
-        'F4': [ 115 ]
+        'F4': [ 'F4' ]
       },
       run: function (e) {
         WindowMaker.create('neuron-dendrogram');
@@ -1128,7 +1128,7 @@
     this.addAction(new CATMAID.Action({
       helpText: "Command history",
       keyShortcuts: {
-        'F9': [ 120 ]
+        'F9': [ 'F9' ]
       },
       run: function (e) {
         var dialog = new CATMAID.HistoryDialog();
@@ -1140,7 +1140,7 @@
     this.addAction(new CATMAID.Action({
       helpText: "Toggle skeleton projection layer",
       keyShortcuts: {
-        'F10': [ 121 ]
+        'F10': [ 'F10' ]
       },
       run: function (e) {
         toggleSkeletonProjectionLayers();
@@ -1150,7 +1150,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Open the neuron/annotation search widget (with <kbd>Shift</kbd>: activate next selected neuron in search results after active skeleton)",
-      keyShortcuts: { '/': [ 191 ] },
+      keyShortcuts: { '/': [ '/', 'Shift + /' ] },
       run: function (e) {
         if (e.shiftKey) {
           var nextSkid = CATMAID.NeuronSearch.prototype.getFirstInstance()
@@ -1167,7 +1167,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Find the nearest matching tagged node (<kbd>Ctrl</kbd>: repeat last tag query; Subsequent <kbd>Shift</kbd>+<kbd>\\</kbd>: cycle to next nearest)",
-      keyShortcuts: { '\\': [ 220 ] },
+      keyShortcuts: { '\\': [ '\\', 'Ctrl + \\', 'Shift + \\', 'Ctrl + Shift + \\' ] },
       run: function (e) {
         activeTracingLayer.tracingOverlay.goToNearestMatchingTag(e.shiftKey, e.ctrlKey);
         return true;
@@ -1176,7 +1176,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Bookmark the active node or current location",
-      keyShortcuts: { ';': [ 186 ] },
+      keyShortcuts: { ';': [ ';' ] },
       run: function (e) {
           var dialog = new CATMAID.Bookmarks.Dialog(CATMAID.Bookmarks.MODES.MARK);
           dialog.show();
@@ -1186,7 +1186,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Go to a bookmarked skeleton",
-      keyShortcuts: { '\'': [ 222 ] },
+      keyShortcuts: { '\'': [ '\'' ] },
       run: function (e) {
           var dialog = new CATMAID.Bookmarks.Dialog(CATMAID.Bookmarks.MODES.SKELETON);
           dialog.show();
@@ -1196,7 +1196,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Go to a bookmarked node",
-      keyShortcuts: { '`': [ 192 ] },
+      keyShortcuts: { '`': [ '`' ] },
       run: function (e) {
           var dialog = new CATMAID.Bookmarks.Dialog(CATMAID.Bookmarks.MODES.NODE);
           dialog.show();
@@ -1206,7 +1206,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Toggle display of skeletons in visibility group 1 (<kbd>Shift</kbd>: visibility group 2)",
-      keyShortcuts: { 'HOME': [ 36 ] },
+      keyShortcuts: { 'HOME': [ 'Home', 'Shift + Home' ] },
       run: function (e) {
         if (e.shiftKey) {
           SkeletonAnnotations.VisibilityGroups.toggle(SkeletonAnnotations.VisibilityGroups.GROUP_IDS.GROUP_2);
@@ -1219,7 +1219,7 @@
 
     this.addAction(new CATMAID.Action({
       helpText: "Peek: show the active skeleton in all open 3D viewers (while held)",
-      keyShortcuts: { 'P': [ 80 ] },
+      keyShortcuts: { 'P': [ 'p' ] },
       run: function (e) {
         if (self.peekingSkeleton) return;
         var skid = SkeletonAnnotations.getActiveSkeletonId();
@@ -1253,7 +1253,7 @@
         var target = e.target;
         var oldListener = target.onkeyup;
         target.onkeyup = function (e) {
-          if (e.keyCode == 80) {
+          if (e.key === 'p') {
             target.onkeyup = oldListener;
             removePeekingSkeleton();
           } else if (oldListener) oldListener(e);
@@ -1264,7 +1264,7 @@
     }));
 
 
-    var keyCodeToAction = CATMAID.getKeyCodeToActionMap(actions);
+    var keyToAction = CATMAID.getKeyToActionMap(actions);
 
     /**
      * This function should return true if there was any action linked to the key
@@ -1272,7 +1272,7 @@
      */
     this.handleKeyPress = function(e) {
       var result = false;
-      var keyAction = keyCodeToAction[e.keyCode];
+      var keyAction = CATMAID.UI.getMappedKeyAction(keyToAction, e);
       if (keyAction) {
         activeTracingLayer.tracingOverlay.ensureFocused();
         result = keyAction.run(e);

--- a/django/applications/catmaid/static/js/widgets/compartment_graph_widget.js
+++ b/django/applications/catmaid/static/js/widgets/compartment_graph_widget.js
@@ -401,7 +401,7 @@
   GroupGraph.prototype.handleKeyPress = function(event) {
     // In case shift is pressed, the mousewheel sensitivity will be changed so
     // that zooming happens in smaller steps.
-    if (event.keyCode === 16 && this.cy) {
+    if (event.key === 'Shift' && this.cy) {
       this.cy._private.renderer.wheelSensitivity = 0.5;
     }
   };
@@ -409,9 +409,9 @@
   GroupGraph.prototype.handleKeyUp = function(event) {
     // In case shift is pressed, the mousewheel sensitivity will be set back to
     // normal.
-    if (event.keyCode === 16 && this.cy) {
+    if (event.key === 'Shift' && this.cy) {
       this.cy._private.renderer.wheelSensitivity = 1;
-    } else if (event.keyCode === 74) {
+    } else if (event.key === 'j') {
       // Letter 'J' (would prefer shift+G)
       this.group();
     }

--- a/django/applications/catmaid/static/js/widgets/connectivity.js
+++ b/django/applications/catmaid/static/js/widgets/connectivity.js
@@ -1338,7 +1338,7 @@
         changeThresholdDelayedTimer = window.setTimeout(changePartnerThreshold.bind(undefined, value), 400);
       };
       hidePartnerThresholdInput.oninput = function (e) {
-        if (13 === e.keyCode) {
+        if ('Enter' === e.key) {
           widget.createConnectivityTable();
         } else {
           widget.hidePartnerThreshold = parseInt(this.value, 10);

--- a/django/applications/catmaid/static/js/widgets/context-menu.js
+++ b/django/applications/catmaid/static/js/widgets/context-menu.js
@@ -130,7 +130,7 @@
       // Attach a handler for the ESC key to cancel context menu
       var self = this;
       $('body').on('keydown.catmaidContextMenu', function(event) {
-        if (27 === event.keyCode) {
+        if ('Escape' === event.key) {
           self.hide();
           return true;
         }

--- a/django/applications/catmaid/static/js/widgets/neuron_dendrogram.js
+++ b/django/applications/catmaid/static/js/widgets/neuron_dendrogram.js
@@ -114,7 +114,7 @@
             self.update();
         };
         minStrahlerInput.oninput = function(e) {
-          if (13 === e.keyCode) {
+          if ('Enter' === e.key) {
             self.update();
           } else {
             self.setMinStrahler(parseInt(this.value, 10));
@@ -211,7 +211,7 @@
             self.update();
         };
         hSpacingFactorInput.oninput = function(e) {
-          if (13 === e.keyCode) {
+          if ('Enter' === e.key) {
             self.update();
           } else {
             self.setHSpaceFactor(parseFloat(this.value));
@@ -251,7 +251,7 @@
             self.update();
         };
         vSpacingFactorInput.oninput = function(e) {
-          if (13 === e.keyCode) {
+          if ('Enter' === e.key) {
             self.update();
           } else {
             self.setVSpaceFactor(parseFloat(this.value));
@@ -290,7 +290,7 @@
             self.update();
         };
         lineWidthFactorInput.oninput = function(e) {
-          if (13 === e.keyCode) {
+          if ('Enter' === e.key) {
             self.update();
           } else {
             self.lineWidthFactor = parseFloat(this.value);

--- a/django/applications/catmaid/static/js/widgets/options-dialog.js
+++ b/django/applications/catmaid/static/js/widgets/options-dialog.js
@@ -108,7 +108,7 @@
     // Make this field press okay on Enter, if wanted
     if (submitOnEnter) {
       $(input).keypress((function(e) {
-        if (e.keyCode == $.ui.keyCode.ENTER) {
+        if (e.key == 'Enter') {
           $(this.dialog).parent().find(
               '.ui-dialog-buttonpane button:last').click();
           return false;

--- a/django/applications/catmaid/static/js/widgets/overlay.js
+++ b/django/applications/catmaid/static/js/widgets/overlay.js
@@ -3313,7 +3313,7 @@ SkeletonAnnotations.TracingOverlay.prototype.selectRadius = function(treenode_id
           hideCircleAndCallback);
       // Attach a handler for the ESC key to cancel selection
       $('body').on('keydown.catmaidRadiusSelect', function(event) {
-        if (27 === event.keyCode) {
+        if ('Escape'  === event.key) {
           // Allow location changes again
           self.pixiLayer.blockLocationChange = false;
           // Unbind key handler and remove circle
@@ -3477,7 +3477,7 @@ SkeletonAnnotations.TracingOverlay.prototype.measureRadius = function () {
         hideCircleAndCallback);
     // Attach a handler for the ESC key to cancel selection
     $('body').on('keydown.catmaidRadiusSelect', function(event) {
-      if (27 === event.keyCode) {
+      if ('Escape' === event.key) {
         // Unbind key handler and remove circle
         $('body').off('keydown.catmaidRadiusSelect');
         fakeNode.removeSurroundingCircle();
@@ -4766,7 +4766,7 @@ SkeletonAnnotations.Tag = new (function() {
         })
 
         .keydown(function (event) {
-          if (13 === event.keyCode) { // ENTER
+          if ('Enter' === event.key) {
             event.stopPropagation();
             var val = input.val().trim();
             if ("" === val) {
@@ -4780,7 +4780,7 @@ SkeletonAnnotations.Tag = new (function() {
         })
 
         .keyup(function (event) {
-          if (27 === event.keyCode) { // ESC
+          if ('Escape' === event.key) {
             event.stopPropagation();
             SkeletonAnnotations.Tag.removeTagbox();
           }

--- a/django/applications/catmaid/static/js/widgets/selection-table.js
+++ b/django/applications/catmaid/static/js/widgets/selection-table.js
@@ -233,7 +233,7 @@
             });
         $('th input[type=button].filter', tab).on("click", filterNeuronList);
         $('th input[type=text].filter', tab).on("keyup", function(e) {
-          if (13 === e.keyCode) filterNeuronList();
+          if ('Enter' === e.key) filterNeuronList();
         });
         $('th', tab).on("click", this, function(e) {
           // Prevent sorting if order is locked

--- a/django/applications/catmaid/static/js/widgets/settings.js
+++ b/django/applications/catmaid/static/js/widgets/settings.js
@@ -796,7 +796,7 @@
 
       // Allow color confirmation with enter
       dsNodeColors.find('input').on('keyup', function(e) {
-        if (13 === e.keyCode) {
+        if ('Enter' === e.key) {
           setColorOfTracingFields();
         }
       });
@@ -906,7 +906,7 @@
       // Allow color confirmation with enter
       skpDownstreamColor.find('input').add(skpUpstreamColor.find('input'))
         .on('keyup', function(e) {
-          if (13 === e.keyCode) updateSkeletonProjectionDisplay();
+          if ('Enter' === e.key) updateSkeletonProjectionDisplay();
         });
 
       // Get all relevant skeleton projection options

--- a/django/applications/catmaid/static/js/widgets/textlabel.js
+++ b/django/applications/catmaid/static/js/widgets/textlabel.js
@@ -203,20 +203,13 @@ function TextlabelTool()
     return actions;
   };
 
-  var arrowKeyCodes = {
-    left: 37,
-    up: 38,
-    right: 39,
-    down: 40
-  };
-
-  var keyCodeToAction = CATMAID.getKeyCodeToActionMap(actions);
+  var keyToAction = CATMAID.getKeyToActionMap(actions);
 
   /** This function should return true if there was any action
       linked to the key code, or false otherwise. */
 
   this.handleKeyPress = function( e ) {
-    var keyAction = keyCodeToAction[e.keyCode];
+    var keyAction = CATMAID.UI.getMappedKeyAction(keyToAction, e);
     if (keyAction) {
       return keyAction.run(e);
     } else {

--- a/django/applications/catmaid/templates/catmaid/tests.html
+++ b/django/applications/catmaid/templates/catmaid/tests.html
@@ -29,6 +29,7 @@
 
     <script src="{{ STATIC_URL }}js/tests/test_basicskeletonsource.js"></script>
     <script src="{{ STATIC_URL }}js/tests/test_misc.js"></script>
+    <script src="{{ STATIC_URL }}js/tests/test_ui.js"></script>
     <script src="{{ STATIC_URL }}js/tests/test_neuronnameservice.js"></script>
     <script src="{{ STATIC_URL }}js/tests/test_arbor.js"></script>
     <script src="{{ STATIC_URL }}js/tests/test_events.js"></script>


### PR DESCRIPTION
I post this as a pull request, because this makes quite a few (small) changes and I wonder if anyone thinks this got more complicated than necessary and you'd rather stick to key codes. Otherwise, I'd like to merge this, because it fixes a few minor problems (like surprising media key mappings and collisions). Most changes are simple, but I want to make sure everyone is okay with specifying *all* handled key combinations from now on explicitly for each action (e.g. `Ctrl + Shift + ,`).

Using the `keyCode` property of an event is deprecated and the key field should be used instead. The key field contains key values that are described here:

  https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values

This is more readable and needs less exceptions. While this was not a big problem with the key code based implementation, it fixes some problems users reported where media keys (e.g. mute) generated key codes that CATMAID listened to. It also provides a good opportunity to add cleaner and more robust differentiation between key combinations, e.g. lower case and upper case letters as key shortcuts for actions. So far actions had to explicitly exclude modifier key combinations they didn't want to run for. This changes so that actions aren't run anymore if the current key combination isn't explicitly listed. Given that we are almost out of options for new keys, we should make it easier to add new ones.

Depending on the use case, 'Shift + 3' or '#' (US layout) is more useful. To support both (and also e.g. "Shift + A"), supported key combination had to be made explicit. So to be able to register different actions for e.g. "Shift + g" and "g", it is now required that all actions list their supported actions explicitly. An action that lists only "Shift + g" won't be called anymore if only "g" is pressed. While this is more restrictive and makes a few actions have key lists of five or more elements, it makes it easier to list used key combinations and find unused key combinations. Plus it is makes calling accidentally wrong actions for multi-use keys less likely.

Since the Bookmark Widget uses key codes to store bookmarks in the data store, it is left untouched for now. It manages events completely separate from CATMAID's general key event handling.