### PR TITLE
dvid 3d stack group import produces keyword error

### DIFF
--- a/django/applications/catmaid/views/dvid.py
+++ b/django/applications/catmaid/views/dvid.py
@@ -157,7 +157,7 @@ class DVIDImportWizard(SessionWizardView):
                     StackStackGroup.objects.create(
                         group_relation=view_relation,
                         stack=stack,
-                        stackgroup=sg,
+                        stack_group=sg,
                         position=view)
 
         if new_project:


### PR DESCRIPTION
On trying to import a 3d stack group, you get an error in StackStackGroup about an invalid keyword argument `stackgroup`. This fixes the reference to `stack_group` and the import now completes.