### PR TITLE
Non-square dvid YZ tiles display incorrectly

### DIFF
--- a/django/applications/catmaid/static/js/layers/tile-layer.js
+++ b/django/applications/catmaid/static/js/layers/tile-layer.js
@@ -138,6 +138,7 @@
       // the tile layer is responsible for transposing them back to CATMAID's
       // preferred orientation in the client.
       this.tilesContainer.classList.add('transpose');
+      this._transpose = true;
     }
 
     stackViewer.getLayersView().appendChild(this.tilesContainer);
@@ -417,20 +418,31 @@
           tile.style.top = t + 'px';
           tile.style.left = l + 'px';
 
+          var width, height;
+
           // To prevent tile seams when the browser is going to round the
           // edge of the next column up a pixel, grow the width of this
           // column slightly to fill the gap
           if (Math.round(nextL) - nextL > 0) {
-            tile.style.width = Math.ceil(effectiveTileWidth) + 'px';
+            width = Math.ceil(effectiveTileWidth) + 'px';
           } else {
-            tile.style.width = effectiveTileWidth + 'px';
+            width = effectiveTileWidth + 'px';
           }
 
           // As above, prevent tile seams when the next row will round up
           if (seamRow) {
-            tile.style.height = Math.ceil(effectiveTileHeight) + 'px';
+            height = Math.ceil(effectiveTileHeight) + 'px';
           } else {
-            tile.style.height = effectiveTileHeight + 'px';
+            height = effectiveTileHeight + 'px';
+          }
+
+          if (this._transpose) {
+            // CSS dimensions are applied before transforms
+            tile.style.width = height;
+            tile.style.height = width;
+          } else {
+            tile.style.width = width;
+            tile.style.height = height;
           }
 
           if (tile.src === source) {


### PR DESCRIPTION
When tiles are not square, YZ (ZY) dvid tiles display with seams and gaps.  This appears to be because the width and height styles are set to the final width and height, rather than those of the source image.

With this patch, if you set the tile size to the transposed viewable (YZ) size (not the DVID ZY size), they should display correctly. (Alternatively, you could let users enter the original DVID ZY tile size and flip width and height everywhere else. Regardless, might be worth documenting.)

This fixes the display for non-square transposed tiles, at least for me on firefox (Mozilla/5.0 (X11; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0).  This may need to be fixed in other viewers as well.

Even with this patch, I still see 1-pixel seams in some cases, but I suspect that's more a browser CSS transform issue.