### PR TITLE
Pipeline files: Each app manages its own static

### DIFF
--- a/django/applications/catmaid/templates/catmaid/index.html
+++ b/django/applications/catmaid/templates/catmaid/index.html
@@ -14,14 +14,20 @@
     </script>
 
     {% stylesheet 'libraries' %}
-    {% stylesheet 'catmaid' %}
+    {% for f in STYLESHEET_IDS %}
+        {% if 'catmaid' in f %}
+            {% stylesheet f %}
+        {% endif %}
+    {% endfor %}
 
-    <!-- Regular CATMAID components -->
+    <!-- Non-CATMAID javascript dependencies -->
     {% for f in COMPRESSED_FILE_IDS %}
-        {% if f != 'catmaid' %}
+        {% if 'catmaid' not in f %}
             {% javascript f %}
         {% endif %}
     {% endfor %}
+
+    {% javascript 'catmaid-lib' %}
 
     <!-- Front end initialization -->
     <script type="text/javascript">
@@ -36,13 +42,19 @@
       CATMAID.expandErrors = {{ EXPAND_FRONTEND_ERRORS|make_js_bool }};
     </script>
 
+    <!-- CATMAID and 3rd-party CATMAID extensions -->
     {% javascript 'catmaid' %}
+    {% for f in COMPRESSED_FILE_IDS %}
+        {% if 'catmaid-ext-' in f %}
+            {% javascript f %}
+        {% endif %}
+    {% endfor %}
 
     {% for f in NON_COMPRESSED_FILES %}
       <script type="application/javascript" src="{{ STATIC_URL }}{{ f }}"></script>
     {% endfor %}
 
-    <!-- Extensions -->
+    <!-- Standalone static extension files -->
     {% for f in STATIC_EXTENSION_FILES %}
       <script type="text/javascript" src="{{ STATIC_EXTENSION_URL }}{{ f }}"></script>
     {% endfor %}

--- a/django/applications/catmaid/views/__init__.py
+++ b/django/applications/catmaid/views/__init__.py
@@ -19,6 +19,7 @@ class CatmaidView(TemplateView):
         context['COOKIE_SUFFIX'] = settings.COOKIE_SUFFIX
         context['COMPRESSED_FILE_IDS'] = settings.COMPRESSED_FILE_IDS
         context['NON_COMPRESSED_FILES'] = settings.NON_COMPRESSED_FILES
+        context['STYLESHEET_IDS'] = settings.STYLESHEET_IDS
         context['STATIC_EXTENSION_URL'] = settings.STATIC_EXTENSION_URL
         context['STATIC_EXTENSION_FILES'] = settings.STATIC_EXTENSION_FILES
         context['HISTORY_TRACKING'] = settings.HISTORY_TRACKING

--- a/django/projects/mysite/settings_base.py
+++ b/django/projects/mysite/settings_base.py
@@ -301,10 +301,12 @@ PIPELINE = {
 
 # Make a list of files that should be included directly (bypassing pipeline)
 # and a list of pipeline identifiers for all others.
-NON_COMPRESSED_FILES = list(six.itervalues(pipelinefiles.non_pipeline_js))
-NON_COMPRESSED_FILE_IDS = list(six.iterkeys(pipelinefiles.non_pipeline_js))
-COMPRESSED_FILE_IDS = list(six.moves.filter(lambda f: f not in NON_COMPRESSED_FILE_IDS,
-        pipelinefiles.JAVASCRIPT.keys()))
+NON_COMPRESSED_FILE_IDS = list(pipelinefiles.non_pipeline_js)
+NON_COMPRESSED_FILES = list(pipelinefiles.non_pipeline_js.values())
+STYLESHEET_IDS = list(pipelinefiles.STYLESHEETS)
+COMPRESSED_FILE_IDS = [key for key in pipelinefiles.JAVASCRIPT if key not in NON_COMPRESSED_FILE_IDS]
+
+INSTALLED_EXTENSIONS = tuple(pipelinefiles.installed_extensions)
 
 # Make Git based version of CATMAID available as a settings field
 VERSION = utils.get_version()

--- a/django/projects/mysite/urls.py
+++ b/django/projects/mysite/urls.py
@@ -26,6 +26,12 @@ urlpatterns = [
     url(r'^', include('catmaid.urls')),
 ]
 
+# CATMAID extensions
+urlpatterns += [
+    url(r'^ext/{}/'.format(extension), include('{}.urls'.format(extension)))
+    for extension in settings.INSTALLED_EXTENSIONS
+]
+
 # Admin site
 urlpatterns += [
     url(r'^admin/', include(admin.site.urls))

--- a/sphinx-doc/source/developer.rst
+++ b/sphinx-doc/source/developer.rst
@@ -12,3 +12,4 @@ Developer Documentation
    djangounittest
    models_state_commands
    ami
+   extensions

--- a/sphinx-doc/source/extensions.rst
+++ b/sphinx-doc/source/extensions.rst
@@ -1,0 +1,91 @@
+.. _extensions:
+
+Creating CATMAID extensions
+===========================
+
+In the past, anyone wanting to extend CATMAID for their specific use case
+would need to fork the main repository, making it difficult to take advantage
+of future improvements to mainline CATMAID, and decreasing utility of the
+extension to people who may want to make use of it later. Therefore, we have
+designed the extension system to allow third parties to create external modules
+which interface with mainline CATMAID without having to change it.
+
+Overview
+--------
+
+CATMAID extensions are Django apps which form standalone python modules. When that
+module is made available to the python environment and added to ``INSTALLED_APPS``
+in your local ``settings.py``, Django can pick up any database models, API endpoints,
+and static files associated with the app, and code in the app can interact with code
+in mainline CATMAID. This modular approach allows much greater interoperability
+between different versions of CATMAID and the extension.
+
+In the documentation below, we use a fictional extension called ``myextension``.
+
+.. _extension-install:
+
+Installing an Extension
+-----------------------
+
+#. Install the app into your python environment, either by using ``pip install`` \
+    from PyPI, or cloning the repo and using ``pip`` to install from the local \
+    ``setup.py``
+
+#. Let Django know you've installed it by adding \
+    ``INSTALLED_APPS += (myextension.apps.MyextensionConfig, )`` (note the capital \
+    M and the comma!) to your ``settings.py`` \
+
+#. Run ``python manage.py migrate`` to update the database as necessary. WARNING: \
+    it is possible for a migration to irreversibly change or delete data in your \
+    existing database.
+
+#. Run ``python manage.py collectstatic`` to pick up static files including \
+    stylesheets and frontend widgets.
+
+API endpoints should be available at ``BASE_URL/ext/myextension/...``
+
+Creating an extension
+---------------------
+
+#. Decide on a name! We'll use ``myextension`` here.
+
+#. Make a branch of CATMAID, adding ``"myextension"`` to ``KNOWN_EXTENSIONS`` in \
+    ``CATMAID/django/projects/pipelinefiles.py``. Make a pull request for this to be \
+    included in mainline CATMAID - until then, just use this branch for testing. This \
+    should be the only required change.
+
+#. Create a directory which will hold the module and repository-related cruft (we \
+    recommend naming it something obvious like ``CATMAID-myextension``), navigate to it, \
+    and then create an empty django app with ``django-admin startapp myextension``
+
+#. Add an appropriate ``README``, ``LICENSE``, ``setup.py``, ``MANIFEST.in`` and so on \
+    as laid out in \
+    `Django's documentation <https://docs.djangoproject.com/en/1.11/intro/reusable-apps/>`_, \
+    in ``CATMAID-myextension``. The manifest and setup files are particularly important.
+
+#. If your extension includes javascript and/or stylesheets, create \
+    ``myextension/pipelinefiles.py`` to make Django Pipeline aware of them. See \
+    `synapsesuggestor <https://github.com/clbarnes/CATMAID-synapsesuggestor/pipelinefiles.py>`_ \
+    for an example.
+
+#. Develop away! For testing purposes, you will need to `install <extension-install_>`_ \
+    the extension in your CATMAID environment - it's convenient to use ``pip install -e`` \
+    to install the module in editable mode and ``python manage.py collectstatic -l``. \
+    Don't forget to add it to ``INSTALLED_APPS``. \
+
+Examples
+--------
+
+- `CATMAID-synapsesuggestor <https://github.com/clbarnes/CATMAID-synapsesuggestor>`_
+
+Community Standards
+-------------------
+
+- See the :doc:`contributing <contributing>` page.
+- Don't write any migrations which will change data or database tables in the underlying \
+    CATMAID installation.
+- Be aware of CATMAID's namespace - don't add dependencies or tables which could cause \
+    name collisions.
+- As per Django's guidelines, namespace all static files, templates and so on to your \
+    app - e.g. static files should be in a directory called \
+    ``myextension/static/myextension/<files>``


### PR DESCRIPTION
Resolves #1637 

Previously, any extension apps would require a significant change to the
project's pipelinefiles.py. Now, extension apps can define their own
pipelinefiles, and the project merely collates these entries. CATMAID's
entries are loaded first and are not overloaded.

The only requirement is that the project's pipelinefiles has a list of
all extension apps which could possibly be installed.

Because the appconfigs aren't loaded at the time of pipelinefiles being imported, we can't rely on INSTALLED_APPS to figure out the installed extensions. I don't see a way around this which doesn't involve hard coding the names of possible extensions into this. It could, of course, be split off into a different file, and include links to github repos and so on.