### PR TITLE
Tracing overlay: Connector nodes now crosshairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ Node filters:
 
 Miscellaneous:
 
+- Users can now choose alternative markers for connector
+nodes, which do not obscure the object being annotated: this encourages
+manually annotating synapses etc. in a manner which is more comparable
+with automated detections
+
 - Exported sub-stacks now include the Z resolution.
 
 - Added table of reviewers vs number of nodes reviewed to the "Summary Info"

--- a/django/applications/catmaid/static/js/widgets/overlay.js
+++ b/django/applications/catmaid/static/js/widgets/overlay.js
@@ -962,6 +962,10 @@ SkeletonAnnotations.TracingOverlay.Settings = new CATMAID.Settings(
           },
           other_rel_color: {
             default: 0x00C800
+          },
+          connector_node_marker: {
+            // enum of 'disc', 'crosshair', 'target', 'bullseye', 'ring'
+            default: 'disc'
           }
         },
         migrations: {

--- a/django/applications/catmaid/static/js/widgets/settings.js
+++ b/django/applications/catmaid/static/js/widgets/settings.js
@@ -823,6 +823,43 @@
           'scale',
           SETTINGS_SCOPE));
 
+      ds.append(wrapSettingsControl(
+        CATMAID.DOM.createSelectSetting(
+          'Connector node marker',
+          {
+            'Disc (classic)': 'disc',
+            'Ring': 'ring',
+            'Target': 'target',
+            'Crosshair': 'crosshair',
+            'Bullseye': 'bullseye'
+          },
+          "Texture to use for connector nodes: classic CATMAID uses 'Disc', but this obscures " +
+          "image data underneath the node.",
+          function() {
+            SkeletonAnnotations.TracingOverlay.Settings
+              .set(
+                'connector_node_marker',
+                this.value,
+                SETTINGS_SCOPE
+              )
+              .then(function() {
+                project.getStackViewers().every(function(stackViewer) {
+                  var overlay = SkeletonAnnotations.getTracingOverlay(stackViewer.getId());
+                  if (overlay) {
+                    overlay.graphics.cache.connectorPool.clear();
+                    overlay.graphics.initTextures(true);
+                    overlay.redraw(true);
+                  }
+                });
+              });
+          },
+          SkeletonAnnotations.TracingOverlay.Settings[SETTINGS_SCOPE].connector_node_marker
+        ),
+        SkeletonAnnotations.TracingOverlay.Settings,
+        'connector_node_marker',
+        SETTINGS_SCOPE
+      ));
+
 
       var dsNodeColors = CATMAID.DOM.addSettingsContainer(ds, "Skeleton colors", true);
       dsNodeColors.append(CATMAID.DOM.createCheckboxSetting(


### PR DESCRIPTION
Resolves #1512

Connector nodes usually label small, biologically interesting features
like synapses. Previously, the solid disc would obscure most of the
morphological detail. This discouraged users from actually labelling
the feature (they instead annotated an area near it). Now, connector
nodes are rendered as a slightly larger ring with a small crosshair
in the middle.

Specifically, automated feature detection algorithms which produce point annotations will much prefer to place them in the object rather than put them somewhere nearby, and if more human annotation had been done on the object itself, associating automatic and ground truth annotation is much easier. 

This is an MVP for #1512, without any of the fancy project-customisable shenanigans @aschampion suggested.

TODO:

- [x] Draw outgoing connector edges from the connector node's exterior rather than its centroid
- [ ] Look into the SVG stuff `wontfix`
- [ ] Account for the line weight when deciding where to stop incoming connector edges `minor: wontfix`