### PR TITLE
Pixi layer: Fix blend mode undefined bug

### DIFF
--- a/django/applications/catmaid/static/js/layers/pixi-layer.js
+++ b/django/applications/catmaid/static/js/layers/pixi-layer.js
@@ -415,7 +415,7 @@
    * @return {string[]} Names of supported blend modes.
    */
   PixiLayer.prototype.getAvailableBlendModes = function () {
-    var glBlendModes = this._context.renderer.state.blendModes;
+    var glBlendModes = this._context.renderer.blendModes;
     var normBlendFuncs = glBlendModes[PIXI.BLEND_MODES.NORMAL];
     return Object.keys(PIXI.BLEND_MODES)
         .filter(function (modeKey) { // Filter modes that are not different from normal.


### PR DESCRIPTION
Resolves #1659

Previously, the getAvailableBlendModes method looked for the GL blend
modes in `renderer.state.blendModes`, and returned undefined. Now it
looks for them at `rendered.blendModes` and finds them.

This seems like the sort of thing which would have been noticed earlier, so it's a bit odd to have come across it. If nobody else is hitting this problem, let me know.