### PR TITLE
Bugs/1661 node corners

### DIFF
--- a/django/applications/catmaid/static/js/layers/pixi-layer.js
+++ b/django/applications/catmaid/static/js/layers/pixi-layer.js
@@ -415,7 +415,7 @@
    * @return {string[]} Names of supported blend modes.
    */
   PixiLayer.prototype.getAvailableBlendModes = function () {
-    var glBlendModes = this._context.renderer.state.blendModes;
+    var glBlendModes = this._context.renderer.blendModes;
     var normBlendFuncs = glBlendModes[PIXI.BLEND_MODES.NORMAL];
     return Object.keys(PIXI.BLEND_MODES)
         .filter(function (modeKey) { // Filter modes that are not different from normal.

--- a/django/applications/catmaid/static/js/widgets/overlay-node.js
+++ b/django/applications/catmaid/static/js/widgets/overlay-node.js
@@ -1360,9 +1360,7 @@
        * @param force
        */
       this.initTextures = function(force) {
-        var oldMarkerType = this.markerType;
         this.markerType = SkeletonAnnotations.TracingOverlay.Settings.session.connector_node_marker;
-        force = force && (oldMarkerType === 'disc' ^ this.markerType === 'disc');
         this.NODE_RADIUS = this.markerType === 'disc' ? 8 : 15;
         var g = this.makeMarker();
 
@@ -1374,7 +1372,10 @@
           this.NODE_TEXTURE.baseTexture = texture.baseTexture;
           oldBaseTexture.destroy();
         } else {
-          if (this.NODE_TEXTURE) console.log('Warning: Possible connector node texture leak');
+          if (this.NODE_TEXTURE) {
+            console.log('Warning: Possible connector node texture leak');
+            this.NODE_TEXTURE.destroy(true);
+          }
           this.NODE_TEXTURE = texture;
         }
       };

--- a/django/applications/catmaid/static/js/widgets/overlay-node.js
+++ b/django/applications/catmaid/static/js/widgets/overlay-node.js
@@ -58,7 +58,7 @@
   var makeDisc = function(radius) {
     return new PIXI.Graphics()
       .beginFill(0xFFFFFF)
-      .drawCircle(0, 0, radius)
+      .drawCircle(radius, radius, radius)
       .endFill();
   };
 
@@ -69,9 +69,11 @@
    * @param ringWeight
    */
   var makeRing = function(radius, ringWeight) {
+    let center = radius + ringWeight/2;
+
     return new PIXI.Graphics()
       .lineStyle(ringWeight, 0xFFFFFF)
-      .drawCircle(0, 0, radius);
+      .drawCircle(center, center, radius);
   };
 
   /**
@@ -83,9 +85,11 @@
    */
   var makeTarget = function(radius, ringWeight, innerRingPpn) {
     innerRingPpn = innerRingPpn || 0.5;
+    let center = radius + ringWeight/2;
+
 
     return makeRing(radius, ringWeight)
-      .drawCircle(0, 0, radius * innerRingPpn);
+      .drawCircle(center, center, radius * innerRingPpn);
   };
 
   /**
@@ -98,12 +102,15 @@
    */
   var makeCrosshair = function(radius, ringWeight, crossWeight, crossRadius) {
     crossRadius = crossRadius || radius;
+
+    let center = radius + ringWeight/2;
+
     return makeRing(radius, ringWeight)
       .lineStyle(crossWeight, 0xFFFFFF)
-      .moveTo(-crossRadius, 0)
-      .lineTo(crossRadius, 0)
-      .moveTo(0, -crossRadius)
-      .lineTo(0, crossRadius);
+      .moveTo(center - crossRadius, center)
+      .lineTo(center + crossRadius, center)
+      .moveTo(center, center - crossRadius)
+      .lineTo(center, center + crossRadius);
   };
 
   /**
@@ -114,9 +121,11 @@
    * @param bullseyeRadius
    */
   var makeBullseye = function(radius, ringWeight, bullseyeRadius) {
+    let center = radius + ringWeight/2;
+
     return makeRing(radius, ringWeight)
       .beginFill(0xFFFFFF)
-      .drawCircle(0, 0, bullseyeRadius)
+      .drawCircle(center, center, bullseyeRadius)
       .endFill();
   };
 


### PR DESCRIPTION
Includes the changes from PR #1660 

Fixes the major part of #1661 by recentering the textures so they're not around (0, 0), which used to work fine but apparently... doesn't any more? See discussion on the issue.

On the subject of things which used to work fine but don't any more, switching between ring-based node markers is currently achieved by hot-switching the basetextures. This was fine previously but no longer works (can't find any change in our code which should have broken that, though) - the switch still takes place, as far as I can tell. The easy alternative is to just switch out the textures themselves, but this may leak a texture - I can call `oldTexture.destroy()` but I seem to recall that not being entirely water-tight last time I worked on it. The textures are very small, and this task is likely to be rare, so it's not the end of the world, but a bit gross nonetheless. This leaky approach is currently used for switching between markers of different size (i.e. discs vs ring-based): see https://github.com/catmaid/CATMAID/blob/dev/django/applications/catmaid/static/js/widgets/overlay-node.js#L1353