### PR TITLE
Requirements: Inherit requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   pip uninstall django-rest-swagger
   pip install -r requirements.txt
 
+- `requirements` files now inherit from each other: `-test.txt` includes
+ the production requirements, `-dev.txt` includes test (and therefore
+ production) and doc.
+
 
 ### Features and enhancements
 

--- a/django/requirements-dev.txt
+++ b/django/requirements-dev.txt
@@ -1,2 +1,4 @@
+-r requirements-test.txt
+-r requirements-doc.txt
 django-devserver==0.8.0
 sh==1.11

--- a/django/requirements-test.txt
+++ b/django/requirements-test.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 django-migration-testcase==0.0.11
 selenium==3.0.2
 git+git://github.com/cgoldberg/sauceclient.git@56fafccf7e941a4d0e98b76cb9082585e79149c7#egg=sauceclient


### PR DESCRIPTION
Resolves #1670 

Previously, requirements files would need to be loaded sequentially to
get all dependencies. Now they inherit from each other in a manner which
should reflect use cases.
  