### PR TITLE
Travis scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,46 +27,16 @@ before_install:
   - mkdir tmp
   - travis_retry sudo apt-get update -y -qq
 install:
-  - travis_retry sudo apt-get install -y -qq $(< packagelist-ubuntu-14.04-apt.txt)
-  - travis_retry python -m pip install -U pip
-  - travis_retry travis_wait 60 pip install -q -r django/requirements.txt
-  - pip list
-  # Install additional dependencies for Travis
-  - pip install -q -r django/requirements-test.txt
+  # Install requirements for running CATMAID and its unit tests
+  - ./scripts/travis/install_requirements.sh
   - pip install coveralls flake8
   - npm install jshint csslint jsdoc karma karma-chrome-launcher karma-qunit karma-sinon qunitjs sinon
   - npm bin
   - export PATH=$(npm bin):$PATH
 before_script:
-  - sudo cp /etc/postgresql/9.5/main/pg_hba.conf /etc/postgresql/9.6/main/pg_hba.conf
-  - sudo /etc/init.d/postgresql restart
-  - psql -c 'CREATE DATABASE catmaid;' -U postgres
-  - psql -c 'CREATE EXTENSION postgis;' -U postgres catmaid
-  - export CATMAID_PATH=$(pwd)
-  - cd django
-  - cp configuration.py.example configuration.py
-  - sed -i -e "s?^\(abs_catmaid_path = \).*?\1'$(echo $CATMAID_PATH)'?g" configuration.py
-  - sed -i -e "s?^\(abs_virtualenv_python_library_path = \).*?\1'$(echo $VIRTUAL_ENV)'?g" configuration.py
-  - sed -i -e "s?^\(catmaid_database_name = \).*?\1'catmaid'?g" configuration.py
-  - sed -i -e "s?^\(catmaid_database_username = \).*?\1'postgres'?g" configuration.py
-  - sed -i -e "s?^\(catmaid_timezone = \).*?\1'America/New_York'?g" configuration.py
-  - sed -i -e "s?^\(catmaid_servername = \).*?\1'localhost:8000'?g" configuration.py
-  - cat configuration.py
-  - python create_configuration.py
-  - sed -i -e "s?^\(ALLOWED_HOSTS = \).*?\1['*']?g" projects/mysite/settings.py
-  # Enable static file serving without DEBUG = True
-  - echo "SERVE_STATIC = True" >> projects/mysite/settings.py
-  # Disable cache-busting for front-end tests
-  - echo "STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'" >> projects/mysite/settings.py
-  # Enable front-end tess
-  - echo "FRONT_END_TESTS_ENABLED = True" >> projects/mysite/settings.py
-  # Enable Selenium GUI tests, this currently works only with non-hash file names.
-  - echo "GUI_TESTS_ENABLED = True" >> projects/mysite/settings.py
-  - echo "GUI_TESTS_REMOTE = True" >> projects/mysite/settings.py
-  # Show full front-end errors by default
-  - echo "EXPAND_FRONTEND_ERRORS = True" >> projects/mysite/settings.py
-  - cat projects/mysite/settings.py
-  - cd ..
+  # Set up and start postgres, create database, write config files
+  - ./scripts/travis/setup_database.sh
+  - ./scripts/travis/configure_catmaid.sh
 script:
   - flake8 --config=.travis.flake8 --statistics --count --exit-zero -q -q django
   - jshint --config=.travis.jshintrc --exclude-path=.travis.jshintignore django/applications
@@ -83,7 +53,7 @@ script:
   - python -Wall manage.py runserver &
   - sleep 5
   - cd ../..
-  # Run QUnit through karma in headless Chrom
+  # Run QUnit through karma in headless Chrome
   - karma start karma.conf.js
 after_success:
   - cd django/projects && coveralls

--- a/scripts/travis/README.md
+++ b/scripts/travis/README.md
@@ -1,15 +1,17 @@
 # Travis CI deployment scripts
 
+## Build scripts
+
 These scripts must be run from the CATMAID root directory.
 
-## `install_requirements.sh`
+### `install_requirements.sh`
 
 To be run in the `install` block, this script:
 
 - Installs OS-level dependencies
 - Installs python dependencies for CATMAID and its unit tests
 
-## `setup_database.sh`
+### `setup_database.sh`
 
 To be run in the `before_script` block, this script:
 
@@ -17,10 +19,20 @@ To be run in the `before_script` block, this script:
 - Starts postgres
 - Creates the catmaid database and postgis extension
 
-## `configure_catmaid.sh`
+### `configure_catmaid.sh`
 
 To be run in the `before_script` block, this script:
 
 - Populates `configuration.py`
 - Runs `configuration.py`, creating `settings.py`
 - Modifies `settings.py` to enable serving static files and running tests
+
+## Utilities
+
+### `travis_functions.sh`
+
+To be sourced by scripts requiring the use of `travis_retry` and/or `travis_wait`.
+
+This contains utility functions available to the shell in travis,
+but not to subprocesses. They may need to be updated as the upstream
+implementation changes.

--- a/scripts/travis/README.md
+++ b/scripts/travis/README.md
@@ -1,0 +1,26 @@
+# Travis CI deployment scripts
+
+These scripts must be run from the CATMAID root directory.
+
+## `install_requirements.sh`
+
+To be run in the `install` block, this script:
+
+- Installs OS-level dependencies
+- Installs python dependencies for CATMAID and its unit tests
+
+## `setup_database.sh`
+
+To be run in the `before_script` block, this script:
+
+- Configures postgres
+- Starts postgres
+- Creates the catmaid database and postgis extension
+
+## `configure_catmaid.sh`
+
+To be run in the `before_script` block, this script:
+
+- Populates `configuration.py`
+- Runs `configuration.py`, creating `settings.py`
+- Modifies `settings.py` to enable serving static files and running tests

--- a/scripts/travis/configure_catmaid.sh
+++ b/scripts/travis/configure_catmaid.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Write config files
+set -ex
+
+export CATMAID_PATH=$(pwd)
+cd django
+cp configuration.py.example configuration.py
+sed -i -e "s?^\(abs_catmaid_path = \).*?\1'$(echo $CATMAID_PATH)'?g" configuration.py
+sed -i -e "s?^\(abs_virtualenv_python_library_path = \).*?\1'$(echo $VIRTUAL_ENV)'?g" configuration.py
+sed -i -e "s?^\(catmaid_database_name = \).*?\1'catmaid'?g" configuration.py
+sed -i -e "s?^\(catmaid_database_username = \).*?\1'postgres'?g" configuration.py
+sed -i -e "s?^\(catmaid_timezone = \).*?\1'America/New_York'?g" configuration.py
+sed -i -e "s?^\(catmaid_servername = \).*?\1'localhost:8000'?g" configuration.py
+cat configuration.py
+python create_configuration.py
+sed -i -e "s?^\(ALLOWED_HOSTS = \).*?\1['*']?g" projects/mysite/settings.py
+# Enable static file serving without DEBUG = True
+echo "SERVE_STATIC = True" >> projects/mysite/settings.py
+# Disable cache-busting for front-end tests
+echo "STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'" >> projects/mysite/settings.py
+# Enable front-end tess
+echo "FRONT_END_TESTS_ENABLED = True" >> projects/mysite/settings.py
+# Enable Selenium GUI tests, this currently works only with non-hash file names.
+echo "GUI_TESTS_ENABLED = True" >> projects/mysite/settings.py
+echo "GUI_TESTS_REMOTE = True" >> projects/mysite/settings.py
+# Show full front-end errors by default
+echo "EXPAND_FRONTEND_ERRORS = True" >> projects/mysite/settings.py
+cat projects/mysite/settings.py

--- a/scripts/travis/install_requirements.sh
+++ b/scripts/travis/install_requirements.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# install ubuntu and python requirements
+set -ex
+
+source `dirname ${BASH_SOURCE[0]}`/travis_functions.sh
+
+travis_retry sudo apt-get install -y -qq $(< packagelist-ubuntu-14.04-apt.txt)
+travis_retry python -m pip install -U pip
+travis_retry travis_wait 60 pip install -q -r django/requirements.txt
+pip list
+# Install additional dependencies for Travis
+pip install -q -r django/requirements-test.txt

--- a/scripts/travis/setup_database.sh
+++ b/scripts/travis/setup_database.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Configure and start postgres, create database
+set -ex
+
+sudo cp /etc/postgresql/9.5/main/pg_hba.conf /etc/postgresql/9.6/main/pg_hba.conf
+sudo /etc/init.d/postgresql restart
+psql -c 'CREATE DATABASE catmaid;' -U postgres
+psql -c 'CREATE EXTENSION postgis;' -U postgres catmaid

--- a/scripts/travis/travis_functions.sh
+++ b/scripts/travis/travis_functions.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# As advised by https://twitter.com/plexus/status/499194992632811520?lang=en
+# Based on https://github.com/travis-ci/travis-build/blob/20903aad38a9db0717827275b70c8a2c53820f85/lib/travis/build/templates/header.sh
+
+# MIT LICENSE
+#
+# Copyright (c) 2016 Travis CI GmbH <contact@travis-ci.org>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+ANSI_RED="\033[31;1m"
+ANSI_GREEN="\033[32;1m"
+ANSI_RESET="\033[0m"
+
+travis_retry() {
+  local result=0
+  local count=1
+  while [ $count -le 3 ]; do
+    [ $result -ne 0 ] && {
+      echo -e "\n${ANSI_RED}The command \"$@\" failed. Retrying, $count of 3.${ANSI_RESET}\n" >&2
+    }
+    "$@" && { result=0 && break; } || result=$?
+    count=$(($count + 1))
+    sleep 1
+  done
+  [ $count -gt 3 ] && {
+    echo -e "\n${ANSI_RED}The command \"$@\" failed 3 times.${ANSI_RESET}\n" >&2
+  }
+  return $result
+}
+
+travis_jigger() {
+  local cmd_pid=$1
+  shift
+  local timeout=$1
+  shift
+  local count=0
+  echo -e "\n"
+  while [ $count -lt $timeout ]; do
+    count=$(($count + 1))
+    echo -ne "Still running ($count of $timeout): $@\r"
+    sleep 60
+  done
+  echo -e "\n${ANSI_RED}Timeout (${timeout} minutes) reached. Terminating \"$@\"${ANSI_RESET}\n"
+  kill -9 $cmd_pid
+}
+
+travis_wait() {
+  local timeout=$1
+  if [[ $timeout =~ ^[0-9]+$ ]]; then
+    shift
+  else
+    timeout=20
+  fi
+  local cmd="$@"
+  local log_file=travis_wait_$$.log
+  $cmd &>$log_file &
+  local cmd_pid=$!
+  travis_jigger $! $timeout $cmd &
+  local jigger_pid=$!
+  local result
+  {
+    wait $cmd_pid 2>/dev/null
+    result=$?
+    ps -p$jigger_pid &>/dev/null && kill $jigger_pid
+  }
+  if [ $result -eq 0 ]; then
+    echo -e "\n${ANSI_GREEN}The command $cmd exited with $result.${ANSI_RESET}"
+  else
+    echo -e "\n${ANSI_RED}The command $cmd exited with $result.${ANSI_RESET}"
+  fi
+  echo -e "\n${ANSI_GREEN}Log:${ANSI_RESET}\n"
+  cat $log_file
+  return $result
+}


### PR DESCRIPTION
Currently, a lot of setup is done in the `.travis.yml` directly, where the same logic would also be useful for downstream projects like `catpy` and CATMAID extensions, which may want to stand up minimal CATMAID instances for testing purposes. These downstream projects would need to manually edit their own travis configuration every time the CATMAID setup process changes.

By factoring some of this setup into standalone scripts, the complexity of CATMAID's travis config is reduced and the pipeline for downstream projects is made less brittle.

On the downside, which logic to include in those scripts and how to divide them is somewhat arbitrary and may be biased towards my own use case for `synapsesuggestor`. It also makes the travis config slightly more opaque. Feedback welcome.