### PR TITLE
Selection table: Save all skeletons

### DIFF
--- a/django/applications/catmaid/static/js/widgets/selection-table.js
+++ b/django/applications/catmaid/static/js/widgets/selection-table.js
@@ -1693,16 +1693,13 @@
     var filename = prompt('File name', defaultFileName);
     if (!filename) return;
 
-    // Create a list of all skeletons along with their color and opacity
-    var sortedSkeletons = this.gui.datatable.rows({order: 'current'}).data().toArray();
-    var data = sortedSkeletons.map(function(row) {
-      var skeleton = row.skeleton;
+    var data = this.filteredSkeletons().map(function(skeleton) {
       return {
         'skeleton_id': skeleton.id,
         'color': '#' + skeleton.color.getHexString(),
         'opacity': skeleton.opacity
       };
-    }, this);
+    });
 
     saveAs(new Blob([JSON.stringify(data, null, ' ')], {type: 'text/plain'}), filename);
   };


### PR DESCRIPTION
Resolves #1681 

Previously, only the visible skeletons (i.e. the current page) would be saved, probably due to server-side rendering. Now all skeletons in the table will be saved instead.

This should respect name and annotation filters, and current ordering.

UX query: should it also respect whether the skeleton is selected or not (the current implementation doesn't)?