### PR TITLE
Travis scripts: Reduce logging

### DIFF
--- a/scripts/travis/configure_catmaid.sh
+++ b/scripts/travis/configure_catmaid.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Write config files
-set -ex
+set -ev
 
 export CATMAID_PATH=$(pwd)
 cd django

--- a/scripts/travis/install_requirements.sh
+++ b/scripts/travis/install_requirements.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # install ubuntu and python requirements
-set -ex
+set -ev
 
 source `dirname ${BASH_SOURCE[0]}`/travis_functions.sh
 

--- a/scripts/travis/setup_database.sh
+++ b/scripts/travis/setup_database.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Configure and start postgres, create database
-set -ex
+set -ev
 
 sudo cp /etc/postgresql/9.5/main/pg_hba.conf /etc/postgresql/9.6/main/pg_hba.conf
 sudo /etc/init.d/postgresql restart

--- a/scripts/travis/travis_functions.sh
+++ b/scripts/travis/travis_functions.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 # As advised by https://twitter.com/plexus/status/499194992632811520?lang=en
 # Based on https://github.com/travis-ci/travis-build/blob/20903aad38a9db0717827275b70c8a2c53820f85/lib/travis/build/templates/header.sh
 


### PR DESCRIPTION
Previously, set -x would log every line of the travis functions'
execution as well as the commands of interest. Now set -v is used, which
only logs the function definition, not the call.

I'll need to check the build logs to see whether this actually helps legibility.