### PR TITLE
Settings: Automatically add extensions to apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
  the production requirements, `-dev.txt` includes test (and therefore
  production) and doc.
 
+- CATMAID extensions no longer require users to manually edit their
+  `INSTALLED_APPS` in `settings.py`. Remove if they are already in use.
+
 
 ### Features and enhancements
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -10,6 +10,9 @@ and other administration related changes are listed in order.
 
 - Python 3.6 is now supported.
 
+- CATMAID extensions no longer require users to manually update their
+  `INSTALLED_APPS` in `settings.py`. Remove if they are already in use.
+
 ## 2017.12.07
 
 - PostgreSQL 9.6 and Postgis 2.4 are now required.

--- a/django/projects/mysite/pipelinefiles.py
+++ b/django/projects/mysite/pipelinefiles.py
@@ -187,8 +187,9 @@ javascript_updater = PipelineSpecUpdater(JAVASCRIPT)
 
 for app_name in KNOWN_EXTENSIONS:
     try:
-        app_pipelinefiles = import_module(app_name + '.pipelinefiles')
+        app = import_module(app_name)
         installed_extensions.append(app_name)
+        app_pipelinefiles = import_module(app_name + '.pipelinefiles')
     except ImportError:
         continue
 

--- a/django/projects/mysite/settings.py.example
+++ b/django/projects/mysite/settings.py.example
@@ -93,3 +93,7 @@ IMPORTER_DEFAULT_IMAGE_BASE = 'http://CATMAID_SERVERNAME/CATMAID_SUBDIR/data'
 STATIC_EXTENSION_URL = '/CATMAID_SUBDIR/staticext/'
 # The absolute local path where the static extension files live
 STATIC_EXTENSION_ROOT =  'CATMAIDPATH/django/staticext'
+
+# Gives Django access to installed CATMAID extensions - do not change without good reason.
+# See https://catmaid.readthedocs.io/en/stable/extensions.html for more details
+INSTALLED_APPS += tuple('{}.apps.{}Config'.format(app_name, app_name.title()) for app_name in INSTALLED_EXTENSIONS)

--- a/sphinx-doc/source/extensions.rst
+++ b/sphinx-doc/source/extensions.rst
@@ -13,12 +13,11 @@ which interface with mainline CATMAID without having to change it.
 Overview
 --------
 
-CATMAID extensions are Django apps which form standalone python modules. When that
-module is made available to the python environment and added to ``INSTALLED_APPS``
-in your local ``settings.py``, Django can pick up any database models, API endpoints,
-and static files associated with the app, and code in the app can interact with code
-in mainline CATMAID. This modular approach allows much greater interoperability
-between different versions of CATMAID and the extension.
+CATMAID extensions are python modules which work as Django apps. When that
+module is made available to the python environment, Django can pick up any database
+models, API endpoints, and static files associated with the app, and code in the app
+can interact with code in mainline CATMAID. This modular approach allows much greater
+interoperability between different versions of CATMAID and the extension.
 
 In the documentation below, we use a fictional extension called ``myextension``.
 
@@ -31,10 +30,6 @@ Installing an Extension
     from PyPI, or cloning the repo and using ``pip`` to install from the local \
     ``setup.py``
 
-#. Let Django know you've installed it by adding \
-    ``INSTALLED_APPS += (myextension.apps.MyextensionConfig, )`` (note the capital \
-    M and the comma!) to your ``settings.py`` \
-
 #. Run ``python manage.py migrate`` to update the database as necessary. WARNING: \
     it is possible for a migration to irreversibly change or delete data in your \
     existing database.
@@ -44,8 +39,17 @@ Installing an Extension
 
 API endpoints should be available at ``BASE_URL/ext/myextension/...``
 
+*N.B. CATMAID will only recognise extensions it knows about - i.e. those listed in*
+*``KNOWN_EXTENSIONS`` in ``CATMAID/django/projects/pipelinefiles.py``. Check this if*
+*it doesn't seem to be working.*
+
 Creating an extension
 ---------------------
+
+To quickstart development, you may find this `cookiecutter <https://github.com/audreyr/cookiecutter>`_
+template valuable:
+`clbarnes/CATMAID-ext-cookiecutter <https://github.com/clbarnes/CATMAID-ext-cookiecutter>`_. To do
+it yourself:
 
 #. Decide on a name! We'll use ``myextension`` here.
 
@@ -72,12 +76,7 @@ Creating an extension
 
 #. Develop away! For testing purposes, you will need to `install <extension-install_>`_ \
     the extension in your CATMAID environment - it's convenient to use ``pip install -e`` \
-    to install the module in editable mode and ``python manage.py collectstatic -l``. \
-    Don't forget to add it to ``INSTALLED_APPS``.
-
-To quickstart development, you may find this `cookiecutter <https://github.com/audreyr/cookiecutter>`_
-template valuable:
-`clbarnes/CATMAID-ext-cookiecutter <https://github.com/clbarnes/CATMAID-ext-cookiecutter>`_.
+    to install the module in editable mode and ``python manage.py collectstatic -l``.
 
 Examples
 --------
@@ -88,6 +87,7 @@ Community Standards
 -------------------
 
 - See the :doc:`contributing <contributing>` page.
+- Don't pick an extension name which may clash with other python modules.
 - Don't write any migrations which will change data or database tables in the underlying \
     CATMAID installation.
 - Be aware of CATMAID's namespace - don't add dependencies or tables which could cause \


### PR DESCRIPTION
Previously, users installing extensions would have to manually add their
app config to INSTALLED_APPS. Now, settings.py.example includes a line
which will populate this based on INSTALLED_EXTENSIONS, which is already
populated automatically.

This has been added to `settings.py.example` rather than `settings_base.py` because if extensions depend on other django apps, they will need to be added before this line (and so should be in user-editable space).

Two edge cases which probably don't merit thinking about too hard:

1. The extension's appconfig isn't in the expected module path (it should be if they've used `python manage.py startapp` or the catmaid extension cookiecutter)
2. A django app which isn't a CATMAID extension both depends on a CATMAID extension and is depended upon by another CATMAID extension (and so would need to be inserted into INSTALLED_APPS between them)