### PR TITLE
Feature/1683 move node z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 Reconstruction Sampler:
 
-- 3D previews now allow to use a white background and toggle meta spheres.
+- 3D previews now allow to use a white background.
 
 - To match a given interval length, the Reconstruction Sampler will now create
   new nodes during interval creation. This allows better sampling on long

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 Reconstruction Sampler:
 
-- 3D previews now allow to use a white background.
+- 3D previews now allow to use a white background and toggle meta spheres.
 
 - To match a given interval length, the Reconstruction Sampler will now create
   new nodes during interval creation. This allows better sampling on long

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ Miscellaneous:
   are pressed. This allows to use key combinations like Ctrl + Shift + Space + >
   to browse smoothly through the image stack while hiding the tracing layer.
 
+- The active node can now be moved in Z by holding the `Alt` key and
+  using `,`/`.`. The stack viewer follows the node.
+
 
 ### Bug fixes
 


### PR DESCRIPTION
Resolves #1683 

Holding `Alt` while using `,` and `.` now move the active node in z. The stack viewer then centers on the new node location.

I thought centering on the new location would be better than just moving in Z just to be extra clear on where the node is ending up, as it seems like it would be easy to lose track of nodes using this feature. However, I'm not totally set on it, because it also makes it easier to lose track of everything *else*.

P.S. Sorry for the dirty log, something went weird in my initial rebase on dev.