### PR TITLE
When updating tiles, check column and row against firstCol and firstR…

### DIFF
--- a/django/applications/catmaid/static/js/layers/tile-layer.js
+++ b/django/applications/catmaid/static/js/layers/tile-layer.js
@@ -415,8 +415,8 @@
 
         nextL = l + effectiveTileWidth;
 
-        if (c >= 0 && c <= tileInfo.lastCol &&
-            r >= 0 && r <= tileInfo.lastRow && showTiles) {
+        if (c >= tileInfo.firstCol && c <= tileInfo.lastCol &&
+            r >= tileInfo.firstRow && r <= tileInfo.lastRow && showTiles) {
           var source = this.tileSource.getTileURL(project, this.stack, slicePixelPosition,
               c, r, tileInfo.zoom);
 


### PR DESCRIPTION
…ow instead of 0 to allow display of stacks with tiles in negative space.