### PR TITLE
Tracing overlay: change type of internal `nodes` field to Map

### DIFF
--- a/django/applications/catmaid/static/js/tests/test_overlay.js
+++ b/django/applications/catmaid/static/js/tests/test_overlay.js
@@ -47,23 +47,22 @@ QUnit.test('Tracing overlay test', function( assert ) {
     // Mock SVG overlay
     var nodeID = 42;
     var FakeOverlay = function() {
-      this.nodes = {
-        '41': {
+      this.nodes = new Map([[
+        41, {
           id: 41,
           canEdit: function () { return true; },
           type: SkeletonAnnotations.TYPE_NODE,
           obliterate: function() {},
           drawEdges: function() {}
-        },
-        '42': {
+        }], [
+        42, {
           id: 42,
           canEdit: function () { return true; },
           type: SkeletonAnnotations.TYPE_NODE,
           obliterate: function() {},
           drawEdges: function() {},
           x: 0, y:0, z:0
-        }
-      };
+        }]]);
       this.nodeIDsNeedingSync = new Set([41, 42]);
       this.state = new CATMAID.GenericState({
         getNode: function(nodeId) {

--- a/django/applications/catmaid/static/js/tests/test_skeleton_annotations.js
+++ b/django/applications/catmaid/static/js/tests/test_skeleton_annotations.js
@@ -38,7 +38,7 @@ QUnit.test('Skeleton annotations test', function( assert ) {
   // Test SkeletonAnnotations.getChildOfVirtualNode
   (function() {
     var vnID = "vn:123:456:8.1:-12.2:1";
-    assert.strictEqual(SkeletonAnnotations.getChildOfVirtualNode(vnID), "123",
+    assert.strictEqual(SkeletonAnnotations.getChildOfVirtualNode(vnID), 123,
         "SkeletonAnnotations.getChildOfVirtualNode correctly identifies 123 as child of " + vnID);
     assert.strictEqual(SkeletonAnnotations.getChildOfVirtualNode(123), null,
         "SkeletonAnnotations.getChildOfVirtualNode correctly returns null for ID 123");
@@ -47,7 +47,7 @@ QUnit.test('Skeleton annotations test', function( assert ) {
   // Test SkeletonAnnotations.getParentOfVirtualNode
   (function() {
     var vnID = "vn:123:456:8.1:-12.2:1";
-    assert.strictEqual(SkeletonAnnotations.getParentOfVirtualNode(vnID), "456",
+    assert.strictEqual(SkeletonAnnotations.getParentOfVirtualNode(vnID), 456,
         "SkeletonAnnotations.getParentOfVirtualNode correctly identifies 456 as parent of " + vnID);
     assert.strictEqual(SkeletonAnnotations.getParentOfVirtualNode(123), null,
         "SkeletonAnnotations.getParentOfVirtualNode correctly returns null for ID 123");

--- a/django/applications/catmaid/static/js/tools/tracing-tool.js
+++ b/django/applications/catmaid/static/js/tools/tracing-tool.js
@@ -847,12 +847,12 @@
                 if (typeof radius === 'undefined') return;
 
                 var respectVirtualNodes = true;
-                var node = activeTracingLayer.tracingOverlay.nodes[atnID];
+                var node = activeTracingLayer.tracingOverlay.nodes.get(atnID);
                 var selectedIDs = activeTracingLayer.tracingOverlay.findAllNodesWithinRadius(
                     node.x, node.y, node.z,
                     radius, respectVirtualNodes, true);
                 selectedIDs = selectedIDs.map(function (nodeID) {
-                    return activeTracingLayer.tracingOverlay.nodes[nodeID].skeleton_id;
+                    return activeTracingLayer.tracingOverlay.nodes.get(nodeID).skeleton_id;
                 }).filter(function (s) { return !isNaN(s); });
 
                 selectionCallback(selectedIDs);
@@ -1408,7 +1408,7 @@
         const tracingOverlay = activeStackViewer.getLayersOfType(CATMAID.TracingLayer)[0].tracingOverlay;
 
         // force SkeletonAnnotation.atn's attributes (x and y coords) to update
-        tracingOverlay.activateNode(tracingOverlay.nodes[SkeletonAnnotations.getActiveNodeId()]);
+        tracingOverlay.activateNode(tracingOverlay.nodes.get(SkeletonAnnotations.getActiveNodeId()));
         const activeNode = SkeletonAnnotations.atn;
 
         if (!CATMAID.mayEdit()) {

--- a/django/applications/catmaid/static/js/widgets/3dviewer.js
+++ b/django/applications/catmaid/static/js/widgets/3dviewer.js
@@ -710,7 +710,7 @@
       let hasParent = i < (partition.length - 1);
       let isNotRoot = hasParent || this.arbor.root != p;
       // Make sure we have an integer
-      let id = parseInt(p);
+      let id = parseInt(p, 10);
       let nodeSphere = this.nodes.get(id);
       if (!nodeSphere) {
         let r = isNotRoot ? radius : (3 * radius);

--- a/django/applications/catmaid/static/js/widgets/overlay-node.js
+++ b/django/applications/catmaid/static/js/widgets/overlay-node.js
@@ -1637,13 +1637,10 @@
         // approach of iterating through all nodes is sufficiently fast.
         // TODO: A two-way map would be ergonomic and speed up ops like this.
         if (node.type === SkeletonAnnotations.TYPE_NODE) {
-          for (var connID in catmaidTracingOverlay.nodes) {
-            if (catmaidTracingOverlay.nodes.hasOwnProperty(connID)) {
-              var conn = catmaidTracingOverlay.nodes[connID];
-              if (conn.type === SkeletonAnnotations.TYPE_CONNECTORNODE) {
-                if (conn.links.some(linkedToNode, node)) {
-                  conn.drawEdges(true);
-                }
+          for (var conn of catmaidTracingOverlay.nodes.values()) {
+            if (conn.type === SkeletonAnnotations.TYPE_CONNECTORNODE) {
+              if (conn.links.some(linkedToNode, node)) {
+                conn.drawEdges(true);
               }
             }
           }

--- a/django/applications/catmaid/static/js/widgets/stack-viewer-grid.js
+++ b/django/applications/catmaid/static/js/widgets/stack-viewer-grid.js
@@ -509,7 +509,7 @@
    */
   var getNodeSet = function(stackViewer) {
     return stackViewer.getLayersOfType(CATMAID.TracingLayer).reduce(function (set, tracingLayer) {
-      return set.addAll(Object.keys(tracingLayer.tracingOverlay.nodes));
+      return set.addAll(tracingLayer.tracingOverlay.nodes.keys());
     }, new Set());
   };
 


### PR DESCRIPTION
This replaces the data type of the internal node directory of `TracingOverlay` from `Object` to `Map`. This enforces proper typing of node IDs when referencing into the dictionary, which will make ID types more predictable and reduces other type enforcing code.

Iterating maps is in many scenarios faster than iterating objects and some useful helper fields and  methods like `.size` are provided. This doesn't seem to make a big difference though for common node query sizes. For ~20,000 nodes, using the Map implementation saves  about ~20ms in average, but in general it seems to come with about the same performance as before. Memory use however is much better with the Map based implementation. It seems that the Tracing Overlay needs about one third less memory when using the Map implementation and garbage collection happens more quickly.  Individual element access might be slightly slower due to the `.get()` function call, but this only happens with low frequency for only a few nodes at a time, plus it runs in about the same time as before anyway.

I file this as a pull request for documentation purposes (it is a very central data structure in the tracing data display) and to allow others to provide arguments why this may not be such a good idea. I believe I checked all uses. All tracing actions seems to work normally. 