### PR TITLE
Fix z slider text size

### DIFF
--- a/django/applications/catmaid/static/js/tools/navigator.js
+++ b/django/applications/catmaid/static/js/tools/navigator.js
@@ -607,15 +607,15 @@
       if (toolbar) toolbar.style.display = "none";
 
       self.slider_s.update(
-        0,
-        1,
+        undefined,
+        undefined,
         undefined,
         0,
         null );
 
       self.slider_z.update(
-        0,
-        1,
+        undefined,
+        undefined,
         undefined,
         0,
         null );

--- a/django/applications/catmaid/static/js/widgets/3dviewer.js
+++ b/django/applications/catmaid/static/js/widgets/3dviewer.js
@@ -6489,13 +6489,14 @@
               o[c[0]] = new THREE.Color().set(colorizer(i));
               return o;
             }, {});
+      var notComputableColor = new THREE.Color(0.4, 0.4, 0.4);
 
       var fnConnectorValue = function(node_id, connector_id) {
         return density_hill_map[node_id];
       };
 
       var fnMakeColor = function(value) {
-        return cluster_colors[value];
+        return cluster_colors[value] || notComputableColor;
       };
 
       this.synapticTypes.forEach(function(type) {

--- a/django/applications/catmaid/static/js/widgets/slider.js
+++ b/django/applications/catmaid/static/js/widgets/slider.js
@@ -272,6 +272,12 @@
       if (this._input) {
         // Set input textbox to new value, truncating the value for display
         this._input.value = Number(val).toFixed(2).replace(/\.?0+$/,"");
+
+        // increase input textbox size if new value is too big for current box
+        var truncatedLength = this._input.value.toString().length;
+        if (truncatedLength > this._input.size) {
+          this._input.size = truncatedLength + 1;
+        }
       }
 
       if (!cancelOnchange) this.onchange(this.val, step);
@@ -568,7 +574,7 @@
 
     this.setByValue( typeof def !== "undefined" ? def : this._values[ 0 ], true );
 
-    if (this._input)
+    if (this._input && typeof min !== 'undefined' && typeof max !== 'undefined')
     {
       // Resize input text box size to accomodate the number of digits in range.
       this._input.size = [min, max].map(function (x) {


### PR DESCRIPTION
I have use cases with z values > 100000 which were getting clipped in the UI.  This fix works for me but you should review to make sure there isn't a better way.