### PR TITLE
Tracing overlay: use default radius edit mode without dialog

### DIFF
--- a/django/applications/catmaid/static/js/widgets/overlay.js
+++ b/django/applications/catmaid/static/js/widgets/overlay.js
@@ -4161,8 +4161,7 @@ SkeletonAnnotations.TracingOverlay.prototype.editRadius = function(treenode_id, 
   var self = this;
 
   function updateRadius(radius, updateMode) {
-    // Default update mode to this node only
-    updateMode = updateMode || 0;
+    updateMode = updateMode || self.editRadius_defaultValue;
     self.promiseNode(treenode_id).then(function(nodeId) {
       return self.submit().then(Promise.resolve.bind(Promise, nodeId));
     }).then(function(nodeId) {


### PR DESCRIPTION
Single-line change, but submitted as a PR because it is a silent change in behavior.

When the radius edit dialog is hidden with CTRL, still use the previously selected default radius edit mode. This is important when quickly adding radius annotations to already existing skeletons.

My only concern would perhaps be showing a warning or message when the default is not single-node (maybe also with the number of nodes changed), but because the current warning display is quite intrusive when this is being done repeatedly, I did not include one here. 