### PR TITLE
Add some initial type annotations and a mypy.ini

### DIFF
--- a/django/applications/catmaid/control/skeletonexport.py
+++ b/django/applications/catmaid/control/skeletonexport.py
@@ -13,12 +13,12 @@ from collections import defaultdict, deque
 from math import sqrt
 from datetime import datetime
 
-from django.db.models.query import QuerySet # For mypy
 from typing import Any, DefaultDict, Dict, List, Optional, Set, Tuple, Union
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import connection
 from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.db.models.query import QuerySet
 
 from rest_framework.decorators import api_view
 

--- a/django/applications/catmaid/control/skeletonexport.py
+++ b/django/applications/catmaid/control/skeletonexport.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations  # For Python <3.7
+
 import array
 import json
 import logging
@@ -169,7 +171,7 @@ def get_swc_string(project_id, skeleton_id, treenodes_qs:QuerySet, linearize_ids
 
     if linearize_ids:
         # Find successors for each node
-        successors = defaultdict(list) # type: DefaultDict
+        successors = defaultdict(list)  # type: DefaultDict
         root = None
         for tn in all_rows:
             node, parent = tn[0], tn[6]
@@ -623,8 +625,8 @@ def _compact_skeleton(project_id, skeleton_id, with_connectors=True,
             raise Exception("Skeleton #%s doesn't exist" % skeleton_id)
         # Otherwise returns an empty list of nodes
 
-    connectors = () # type: Tuple
-    tags = defaultdict(list) # type: DefaultDict
+    connectors = ()  # type: Tuple
+    tags = defaultdict(list)  # type: DefaultDict
     reviews = []
 
     if with_connectors or with_tags or with_annotations:
@@ -770,7 +772,7 @@ def _compact_skeleton(project_id, skeleton_id, with_connectors=True,
         for r in cursor.fetchall():
             reviews.append(r)
 
-    annotations = [] # type: List[Optional[Tuple]]
+    annotations = []  # type: List[Optional[Tuple]]
     if with_annotations:
         history_suffix = '__with_history' if with_history else ''
         link_history_query = ', annotation_link.edition_time' if with_history else ''
@@ -830,9 +832,9 @@ def _compact_arbor(project_id=None, skeleton_id=None, with_nodes=None,
 
     cursor = connection.cursor()
 
-    nodes = () # type: Tuple
+    nodes = ()  # type: Tuple
     connectors = []
-    tags = defaultdict(list) # type: DefaultDict
+    tags = defaultdict(list)  # type: DefaultDict
 
     if 0 != with_nodes:
         if with_time:
@@ -939,7 +941,7 @@ def compact_arbor(request:HttpRequest, project_id=None, skeleton_id=None, with_n
 
 def _treenode_time_bins(skeleton_id=None):
     """ Return a map of time bins (minutes) vs. list of nodes. """
-    minutes = defaultdict(list) # type: DefaultDict
+    minutes = defaultdict(list)  # type: DefaultDict
     epoch = datetime.utcfromtimestamp(0).replace(tzinfo=pytz.utc)
 
     for row in Treenode.objects.filter(skeleton_id=int(skeleton_id)).values_list('id', 'creation_time'):
@@ -1010,8 +1012,8 @@ def _skeleton_for_3d_viewer(skeleton_id, project_id, with_connectors=True, lean=
     # array of properties: id, parent_id, user_id, x, y, z, radius, confidence
     nodes = tuple(cursor.fetchall())
 
-    tags = defaultdict(list) # type: DefaultDict
-                             # node ID vs list of tags
+    tags = defaultdict(list)  # type: DefaultDict
+                              # node ID vs list of tags
     connectors = []
 
     # Get all reviews for this skeleton
@@ -1020,7 +1022,7 @@ def _skeleton_for_3d_viewer(skeleton_id, project_id, with_connectors=True, lean=
     else:
         reviews = get_treenodes_to_reviews(skeleton_ids=[skeleton_id])
 
-    if 0 == lean: # meaning not lean
+    if 0 == lean:  # meaning not lean
         # Text tags
         cursor.execute("SELECT id FROM relation WHERE project_id=%s AND relation_name='labeled_as'" % int(project_id))
         labeled_as = cursor.fetchall()[0][0]
@@ -1092,7 +1094,7 @@ def skeleton_with_metadata(request:HttpRequest, project_id=None, skeleton_id=Non
 
         if isinstance(obj, datetime.datetime):
             if obj.utcoffset() is not None:
-                obj = obj - obj.utcoffset() # type: ignore
+                obj = obj - obj.utcoffset()  # type: ignore
             millis = int(
                 calendar.timegm(obj.timetuple()) * 1000 +
                 obj.microsecond / 1000
@@ -1129,15 +1131,15 @@ def _measure_skeletons(skeleton_ids):
             self.x = x
             self.y = y
             self.z = z
-            self.wx = x # weighted average of itself and neighbors
+            self.wx = x  # weighted average of itself and neighbors
             self.wy = y
             self.wz = z
-            self.children = {} # type: Dict[Any, float]
-                               # node ID vs distance - is first type an int or an str?
+            self.children = {}  # type: Dict[Any, float]
+                                # node ID vs distance - is first type an int or an str?
 
     class Skeleton():
         def __init__(self):
-            self.nodes = {} # type: Dict[Any, Node]
+            self.nodes = {}  # type: Dict[Any, Node]
             self.raw_cable = 0
             self.smooth_cable = 0
             self.principal_branch_cable = 0
@@ -1146,8 +1148,8 @@ def _measure_skeletons(skeleton_ids):
             self.n_pre = 0
             self.n_post = 0
 
-    skeletons = defaultdict(dict) # type: DefaultDict
-                                  # skeleton ID vs (node ID vs Node)
+    skeletons = defaultdict(dict)  # type: DefaultDict
+                                   # skeleton ID vs (node ID vs Node)
     for row in cursor.fetchall():
         skeleton = skeletons.get(row[2])
         if not skeleton:
@@ -1266,7 +1268,7 @@ def measure_skeletons(request:HttpRequest, project_id=None) -> JsonResponse:
 
 
 def _skeleton_neuroml_cell(skeleton_id, preID, postID):
-    skeleton_id = int(skeleton_id) # sanitize
+    skeleton_id = int(skeleton_id)  # sanitize
     cursor = connection.cursor()
 
     cursor.execute('''
@@ -1282,10 +1284,10 @@ def _skeleton_neuroml_cell(skeleton_id, preID, postID):
     WHERE tc.skeleton_id = %s
       AND (tc.relation_id = %s OR tc.relation_id = %s)
     ''' % (skeleton_id, preID, postID))
-    pre = defaultdict(list) # type: DefaultDict
-                            # treenode ID vs list of connector ID
-    post = defaultdict(list) # type: DefaultDict
-                             # incomplete type
+    pre = defaultdict(list)  # type: DefaultDict
+                             # treenode ID vs list of connector ID
+    post = defaultdict(list)  # type: DefaultDict
+                              # incomplete type
     for row in cursor.fetchall():
         if row[2] == preID:
             pre[row[0]].append(row[1])
@@ -1361,13 +1363,13 @@ def export_neuroml_level3_v181(request:HttpRequest, project_id=None) -> HttpResp
         ''' % (skeleton_strings, presynaptic_to, postsynaptic_to))
 
         # Dictionary of connector ID vs map of relation_id vs list of treenode IDs
-        connectors = defaultdict(partial(defaultdict, list)) # type: DefaultDict
+        connectors = defaultdict(partial(defaultdict, list))  # type: DefaultDict
 
         for row in cursor.fetchall():
             connectors[row[1]][row[2]].append((row[0], row[3]))
 
         # Dictionary of presynaptic skeleton ID vs map of postsynaptic skeleton ID vs list of tuples with presynaptic treenode ID and postsynaptic treenode ID.
-        connections = defaultdict(partial(defaultdict, list)) # type: DefaultDict
+        connections = defaultdict(partial(defaultdict, list))  # type: DefaultDict
 
         for connectorID, m in connectors.items():
             for pre_treenodeID, skID1 in m[presynaptic_to]:
@@ -1403,7 +1405,7 @@ def export_neuroml_level3_v181(request:HttpRequest, project_id=None) -> HttpResp
         ''' % (skeleton_strings, postsynaptic_to, presynaptic_to, constraint))
 
         # Dictionary of skeleton ID vs list of treenode IDs at which the neuron receives inputs
-        inputs = defaultdict(list) # type: DefaultDict
+        inputs = defaultdict(list)  # type: DefaultDict
         for row in cursor.fetchall():
             inputs[row[0]].append(row[1])
 
@@ -1476,8 +1478,8 @@ def _export_review_skeleton(project_id=None, skeleton_id=None,
                           })
         if reviews[t[0]]:
             reviewed.add(t[0])
-        if t[1]: # if parent
-            g.add_edge(t[1], t[0]) # edge from parent to child
+        if t[1]:  # if parent
+            g.add_edge(t[1], t[0])  # edge from parent to child
         else:
             root_id = t[0]
 
@@ -1510,8 +1512,8 @@ def _export_review_skeleton(project_id=None, skeleton_id=None,
                              "subarbor (%s) in provided skeleton (%s)" % (subarbor_node_id, skeleton_id))
 
     # Create all sequences, as long as possible and always from end towards root
-    distances = edge_count_to_root(g, root_node=root_id) # distance in number of edges from root
-    seen = set() # type: Set
+    distances = edge_count_to_root(g, root_node=root_id)  # distance in number of edges from root
+    seen = set()  # type: Set
     sequences = []
     # Iterate end nodes sorted from highest to lowest distance to root
     endNodeIDs = (nID for nID in g.nodes() if 0 == len(g.successors(nID)))
@@ -1531,7 +1533,7 @@ def _export_review_skeleton(project_id=None, skeleton_id=None,
 
     # Calculate status
 
-    segments = [] # type: List[Dict]
+    segments = []  # type: List[Dict]
     for sequence in sorted(sequences, key=len, reverse=True):
         segments.append({
             'id': len(segments),
@@ -1639,7 +1641,7 @@ def export_review_skeleton(request:HttpRequest, project_id=None, skeleton_id=Non
       required: true
     """
     try:
-        subarbor_node_id = int(request.POST.get('subarbor_node_id', '')) # type: Optional[int]
+        subarbor_node_id = int(request.POST.get('subarbor_node_id', ''))  # type: Optional[int]
     except ValueError:
         subarbor_node_id = None
 
@@ -1671,7 +1673,7 @@ def skeleton_connectors_by_partner(request:HttpRequest, project_id) -> JsonRespo
     ''' % (','.join(map(str, skeleton_ids)), pre, post, pre, post))
 
     # Dict of skeleton vs relation vs skeleton vs list of connectors
-    partners = defaultdict(partial(defaultdict, partial(defaultdict, list))) # type: DefaultDict
+    partners = defaultdict(partial(defaultdict, partial(defaultdict, list)))  # type: DefaultDict
 
     for row in cursor.fetchall():
         relation_name = 'presynaptic_to' if row[1] == pre else 'postsynaptic_to'
@@ -1684,7 +1686,7 @@ def skeleton_connectors_by_partner(request:HttpRequest, project_id) -> JsonRespo
 def export_skeleton_reviews(request:HttpRequest, project_id=None, skeleton_id=None) -> JsonResponse:
     """ Return a map of treenode ID vs list of reviewer IDs,
     without including any unreviewed treenode. """
-    m = defaultdict(list) # type: DefaultDict
+    m = defaultdict(list)  # type: DefaultDict
     for row in Review.objects.filter(skeleton_id=int(skeleton_id)).values_list('treenode_id', 'reviewer_id', 'review_time').iterator():
         m[row[0]].append(row[1:3])
 

--- a/django/applications/catmaid/control/skeletonexport.py
+++ b/django/applications/catmaid/control/skeletonexport.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import annotations  # For Python <3.7
-
 import array
 import json
 import logging

--- a/django/applications/catmaid/control/skeletonexport.py
+++ b/django/applications/catmaid/control/skeletonexport.py
@@ -315,13 +315,13 @@ def compact_skeleton_detail(request:HttpRequest, project_id=None, skeleton_id=No
     # Sanitize
     project_id = int(project_id)
     skeleton_id = int(skeleton_id)
-    with_connectors    = get_request_bool(request.GET, "with_connectors", False)
-    with_tags          = get_request_bool(request.GET, "with_tags", False)
-    with_history       = get_request_bool(request.GET, "with_history", False)
+    with_connectors = get_request_bool(request.GET, "with_connectors", False)
+    with_tags = get_request_bool(request.GET, "with_tags", False)
+    with_history = get_request_bool(request.GET, "with_history", False)
     with_merge_history = get_request_bool(request.GET, "with_merge_history", False)
-    with_reviews       = get_request_bool(request.GET, "with_reviews", False)
-    with_annotations   = get_request_bool(request.GET, "with_annotations", False)
-    with_user_info     = get_request_bool(request.GET, "with_user_info", False)
+    with_reviews = get_request_bool(request.GET, "with_reviews", False)
+    with_annotations = get_request_bool(request.GET, "with_annotations", False)
+    with_user_info = get_request_bool(request.GET, "with_user_info", False)
     return_format = request.GET.get('format', 'json')
     ordered = get_request_bool(request.GET, "ordered", False)
 
@@ -353,15 +353,15 @@ def compact_skeleton(request:HttpRequest, project_id=None, skeleton_id=None,
     project_id = int(project_id)
     skeleton_id = int(skeleton_id)
     with_connectors = int(with_connectors) != 0
-    with_tags       = int(with_tags) != 0
-    with_history       = get_request_bool(request.GET, "with_history", False)
+    with_tags = int(with_tags) != 0
+    with_history = get_request_bool(request.GET, "with_history", False)
     # Indicate if history of merged in skeletons should also be included if
     # history is returned. Ignored if history is not retrieved.
     with_merge_history = get_request_bool(request.GET, "with_merge_history", False)
-    with_reviews       = get_request_bool(request.GET, "with_reviews", False)
-    with_annotations   = get_request_bool(request.GET, "with_annotations", False)
-    with_user_info     = get_request_bool(request.GET, "with_user_info", False)
-    ordered            = get_request_bool(request.GET, "ordered", False)
+    with_reviews = get_request_bool(request.GET, "with_reviews", False)
+    with_annotations = get_request_bool(request.GET, "with_annotations", False)
+    with_user_info = get_request_bool(request.GET, "with_user_info", False)
+    ordered = get_request_bool(request.GET, "ordered", False)
 
     result = _compact_skeleton(project_id, skeleton_id, with_connectors,
                                with_tags, with_history, with_merge_history,

--- a/django/applications/catmaid/control/skeletonexport.py
+++ b/django/applications/catmaid/control/skeletonexport.py
@@ -169,7 +169,7 @@ def get_swc_string(project_id, skeleton_id, treenodes_qs:QuerySet, linearize_ids
 
     if linearize_ids:
         # Find successors for each node
-        successors:DefaultDict = defaultdict(list) # incomplete annotation
+        successors = defaultdict(list) # type: DefaultDict
         root = None
         for tn in all_rows:
             node, parent = tn[0], tn[6]
@@ -623,8 +623,8 @@ def _compact_skeleton(project_id, skeleton_id, with_connectors=True,
             raise Exception("Skeleton #%s doesn't exist" % skeleton_id)
         # Otherwise returns an empty list of nodes
 
-    connectors:Tuple = ()
-    tags:DefaultDict = defaultdict(list) # incomplete type
+    connectors = () # type: Tuple
+    tags = defaultdict(list) # type: DefaultDict
     reviews = []
 
     if with_connectors or with_tags or with_annotations:
@@ -770,7 +770,7 @@ def _compact_skeleton(project_id, skeleton_id, with_connectors=True,
         for r in cursor.fetchall():
             reviews.append(r)
 
-    annotations:List[Optional[Tuple]] = []
+    annotations = [] # type: List[Optional[Tuple]]
     if with_annotations:
         history_suffix = '__with_history' if with_history else ''
         link_history_query = ', annotation_link.edition_time' if with_history else ''
@@ -830,9 +830,9 @@ def _compact_arbor(project_id=None, skeleton_id=None, with_nodes=None,
 
     cursor = connection.cursor()
 
-    nodes:Tuple = ()
+    nodes = () # type: Tuple
     connectors = []
-    tags:DefaultDict = defaultdict(list) # incomplete type
+    tags = defaultdict(list) # type: DefaultDict
 
     if 0 != with_nodes:
         if with_time:
@@ -939,7 +939,7 @@ def compact_arbor(request:HttpRequest, project_id=None, skeleton_id=None, with_n
 
 def _treenode_time_bins(skeleton_id=None):
     """ Return a map of time bins (minutes) vs. list of nodes. """
-    minutes:DefaultDict = defaultdict(list) # incomplete type
+    minutes = defaultdict(list) # type: DefaultDict
     epoch = datetime.utcfromtimestamp(0).replace(tzinfo=pytz.utc)
 
     for row in Treenode.objects.filter(skeleton_id=int(skeleton_id)).values_list('id', 'creation_time'):
@@ -1010,7 +1010,8 @@ def _skeleton_for_3d_viewer(skeleton_id, project_id, with_connectors=True, lean=
     # array of properties: id, parent_id, user_id, x, y, z, radius, confidence
     nodes = tuple(cursor.fetchall())
 
-    tags:DefaultDict = defaultdict(list) # node ID vs list of tags
+    tags = defaultdict(list) # type: DefaultDict
+                             # node ID vs list of tags
     connectors = []
 
     # Get all reviews for this skeleton
@@ -1131,11 +1132,12 @@ def _measure_skeletons(skeleton_ids):
             self.wx = x # weighted average of itself and neighbors
             self.wy = y
             self.wz = z
-            self.children:Dict[Any, float] = {} # node ID vs distance - is first type an int or an str?
+            self.children = {} # type: Dict[Any, float]
+                               # node ID vs distance - is first type an int or an str?
 
     class Skeleton():
         def __init__(self):
-            self.nodes:Dict[Any, Node] = {}
+            self.nodes = {} # type: Dict[Any, Node]
             self.raw_cable = 0
             self.smooth_cable = 0
             self.principal_branch_cable = 0
@@ -1144,7 +1146,8 @@ def _measure_skeletons(skeleton_ids):
             self.n_pre = 0
             self.n_post = 0
 
-    skeletons:DefaultDict = defaultdict(dict) # skeleton ID vs (node ID vs Node)
+    skeletons = defaultdict(dict) # type: DefaultDict
+                                  # skeleton ID vs (node ID vs Node)
     for row in cursor.fetchall():
         skeleton = skeletons.get(row[2])
         if not skeleton:
@@ -1279,8 +1282,10 @@ def _skeleton_neuroml_cell(skeleton_id, preID, postID):
     WHERE tc.skeleton_id = %s
       AND (tc.relation_id = %s OR tc.relation_id = %s)
     ''' % (skeleton_id, preID, postID))
-    pre:DefaultDict = defaultdict(list) # treenode ID vs list of connector ID
-    post:DefaultDict = defaultdict(list) # incomplete type
+    pre = defaultdict(list) # type: DefaultDict
+                            # treenode ID vs list of connector ID
+    post = defaultdict(list) # type: DefaultDict
+                             # incomplete type
     for row in cursor.fetchall():
         if row[2] == preID:
             pre[row[0]].append(row[1])
@@ -1356,13 +1361,13 @@ def export_neuroml_level3_v181(request:HttpRequest, project_id=None) -> HttpResp
         ''' % (skeleton_strings, presynaptic_to, postsynaptic_to))
 
         # Dictionary of connector ID vs map of relation_id vs list of treenode IDs
-        connectors:DefaultDict = defaultdict(partial(defaultdict, list)) # incomplete type
+        connectors = defaultdict(partial(defaultdict, list)) # type: DefaultDict
 
         for row in cursor.fetchall():
             connectors[row[1]][row[2]].append((row[0], row[3]))
 
         # Dictionary of presynaptic skeleton ID vs map of postsynaptic skeleton ID vs list of tuples with presynaptic treenode ID and postsynaptic treenode ID.
-        connections:DefaultDict = defaultdict(partial(defaultdict, list)) # incomplete type
+        connections = defaultdict(partial(defaultdict, list)) # type: DefaultDict
 
         for connectorID, m in connectors.items():
             for pre_treenodeID, skID1 in m[presynaptic_to]:
@@ -1398,7 +1403,7 @@ def export_neuroml_level3_v181(request:HttpRequest, project_id=None) -> HttpResp
         ''' % (skeleton_strings, postsynaptic_to, presynaptic_to, constraint))
 
         # Dictionary of skeleton ID vs list of treenode IDs at which the neuron receives inputs
-        inputs:DefaultDict = defaultdict(list) # incomplete type
+        inputs = defaultdict(list) # type: DefaultDict
         for row in cursor.fetchall():
             inputs[row[0]].append(row[1])
 
@@ -1506,7 +1511,7 @@ def _export_review_skeleton(project_id=None, skeleton_id=None,
 
     # Create all sequences, as long as possible and always from end towards root
     distances = edge_count_to_root(g, root_node=root_id) # distance in number of edges from root
-    seen:Set = set() # incomplete type
+    seen = set() # type: Set
     sequences = []
     # Iterate end nodes sorted from highest to lowest distance to root
     endNodeIDs = (nID for nID in g.nodes() if 0 == len(g.successors(nID)))
@@ -1526,7 +1531,7 @@ def _export_review_skeleton(project_id=None, skeleton_id=None,
 
     # Calculate status
 
-    segments:List[Dict] = []
+    segments = [] # type: List[Dict]
     for sequence in sorted(sequences, key=len, reverse=True):
         segments.append({
             'id': len(segments),
@@ -1634,7 +1639,7 @@ def export_review_skeleton(request:HttpRequest, project_id=None, skeleton_id=Non
       required: true
     """
     try:
-        subarbor_node_id:Optional[int] = int(request.POST.get('subarbor_node_id', ''))
+        subarbor_node_id = int(request.POST.get('subarbor_node_id', '')) # type: Optional[int]
     except ValueError:
         subarbor_node_id = None
 
@@ -1666,7 +1671,7 @@ def skeleton_connectors_by_partner(request:HttpRequest, project_id) -> JsonRespo
     ''' % (','.join(map(str, skeleton_ids)), pre, post, pre, post))
 
     # Dict of skeleton vs relation vs skeleton vs list of connectors
-    partners:DefaultDict = defaultdict(partial(defaultdict, partial(defaultdict, list))) # incomplete type
+    partners = defaultdict(partial(defaultdict, partial(defaultdict, list))) # type: DefaultDict
 
     for row in cursor.fetchall():
         relation_name = 'presynaptic_to' if row[1] == pre else 'postsynaptic_to'
@@ -1679,7 +1684,7 @@ def skeleton_connectors_by_partner(request:HttpRequest, project_id) -> JsonRespo
 def export_skeleton_reviews(request:HttpRequest, project_id=None, skeleton_id=None) -> JsonResponse:
     """ Return a map of treenode ID vs list of reviewer IDs,
     without including any unreviewed treenode. """
-    m:DefaultDict = defaultdict(list) # incomplete type
+    m = defaultdict(list) # type: DefaultDict
     for row in Review.objects.filter(skeleton_id=int(skeleton_id)).values_list('treenode_id', 'reviewer_id', 'review_time').iterator():
         m[row[0]].append(row[1:3])
 

--- a/django/mypy.ini
+++ b/django/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+check_untyped_defs = True
+ignore_missing_imports = True
+warn_incomplete_stub = False


### PR DESCRIPTION
This is a proof-of-concept and initial set of annotations for mypy for skeletonexport.py

```
scclin009:~/src/catmaid_dev/django$ mypy applications/catmaid/control/skeletonexport.py ; echo $?
0
```

Some of the annotations are doing the minimum to make mypy happy and could have more precise anotations; I left a comment with most of these indicating that there's more to do down the line. The mypy.ini contains defaults that I've found useful in the early stages of type-annotating python code; making the rules more strict later may be a good idea.

Line 1091->1094 is an example of deciding to tell mypy to chill about a particular line.

Finally, I was a little naughty in line 315->318 in changing formatting slightly to make things line up; happy to undo that if you want.