### PR TITLE
Upgrade to Django 2.0

### DIFF
--- a/django/applications/catmaid/control/importer.py
+++ b/django/applications/catmaid/control/importer.py
@@ -814,7 +814,7 @@ class DataFileForm(forms.Form):
         widget=forms.TextInput(attrs={'size':'40'}),
         help_text="Optionally, you can apply a <em>glob filter</em> to the " \
                   "projects found in your data folder.")
-    known_project_filter = forms.MultipleChoiceField(KNOWN_PROJECT_FILTERS,
+    known_project_filter = forms.MultipleChoiceField(choices=KNOWN_PROJECT_FILTERS,
             label='Projects are known if', initial=('name', 'stacks'),
             widget=forms.CheckboxSelectMultiple(), required=False,
             help_text='Select what makes makes a project known. An OR operation ' \

--- a/django/applications/catmaid/control/treenode.py
+++ b/django/applications/catmaid/control/treenode.py
@@ -620,7 +620,7 @@ def update_radius(request, project_id=None, treenode_id=None):
 
     if 5 == option:
         # Update radius of all nodes (in a single query)
-        skeleton_id = Treenode.objects.filter(pk=treenode_id).values('skeleton_id')
+        skeleton_id = Treenode.objects.get(pk=treenode_id).skeleton_id
         include = list(Treenode.objects.filter(skeleton_id=skeleton_id) \
                 .values_list('id', flat=True))
 

--- a/django/applications/catmaid/migrations/0055_prepare_django_auth_user_update.py
+++ b/django/applications/catmaid/migrations/0055_prepare_django_auth_user_update.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from django.db import migrations
+
+forward = """
+    SELECT disable_history_tracking_for_table('auth_user'::regclass,
+            get_history_table_name('auth_user'::regclass));
+    SELECT drop_history_view_for_table('auth_user'::regclass);
+"""
+
+backward = """
+    SELECT enable_history_tracking_for_table('auth_user'::regclass,
+            get_history_table_name('auth_user'::regclass), FALSE);
+    SELECT create_history_view_for_table('auth_user'::regclass);
+"""
+
+
+class Migration(migrations.Migration):
+    """CATMAID keeps track of the history of most tables in the database,
+    including some Django tables like auth_user. The upgrade to Django 2.0
+    requires an update of the auth_user table. The history system has a view
+    defined that uses this table and Postgres won't alter the type of a column
+    in the auth_user table if a view is defined on it. To get around this, this
+    migration will disable history tracking for auth_user and a second migration
+    will re-enable it again while depending on the changed auth_user table.
+    """
+
+    dependencies = [
+        ('catmaid', '0054_update_skeleton_summary_refresh_function'),
+    ]
+
+    run_before = [
+        ('auth', '0009_alter_user_last_name_max_length'),
+    ]
+
+    operations = [
+        migrations.RunSQL(forward, backward),
+    ]
+

--- a/django/applications/catmaid/migrations/0056_complete_django_auth_user_update.py
+++ b/django/applications/catmaid/migrations/0056_complete_django_auth_user_update.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from django.db import migrations
+
+forward = """
+    SELECT enable_history_tracking_for_table('auth_user'::regclass,
+            get_history_table_name('auth_user'::regclass), FALSE);
+    SELECT create_history_view_for_table('auth_user'::regclass);
+"""
+
+backward = """
+    SELECT disable_history_tracking_for_table('auth_user'::regclass,
+            get_history_table_name('auth_user'::regclass));
+    SELECT drop_history_view_for_table('auth_user'::regclass);
+"""
+
+
+class Migration(migrations.Migration):
+    """CATMAID keeps track of the history of most tables in the database,
+    including some Django tables like auth_user. The upgrade to Django 2.0
+    requires an update of the auth_user table. The history system has a view
+    defined that uses this table and Postgres won't alter the type of a column
+    in the auth_user table if a view is defined on it. To get around this, this
+    migration will re-enable the history tracking for the auth_user table again,
+    after the previous migration disabled it. Before this migration is applied,
+    the auth_user migration hat to be applied as well.
+    """
+
+    dependencies = [
+        ('catmaid', '0055_prepare_django_auth_user_update'),
+        ('auth', '0009_alter_user_last_name_max_length'),
+    ]
+
+    operations = [
+        migrations.RunSQL(forward, backward),
+    ]
+

--- a/django/applications/catmaid/models.py
+++ b/django/applications/catmaid/models.py
@@ -1159,7 +1159,7 @@ class NeuronSearch(forms.Form):
     search = forms.CharField(max_length=100, required=False)
     cell_body_location = forms.ChoiceField(
         choices=((('a', 'Any'),)+CELL_BODY_CHOICES))
-    order_by = forms.ChoiceField(SORT_ORDERS_CHOICES)
+    order_by = forms.ChoiceField(choices=SORT_ORDERS_CHOICES)
 
     def minimal_search_path(self):
         result = ""

--- a/django/applications/catmaid/tests/migrations/test_migration_0018.py
+++ b/django/applications/catmaid/tests/migrations/test_migration_0018.py
@@ -10,6 +10,12 @@ class Migration0018Tests(MigrationTest):
     before = '0017_update_edge_indices'
     after = '0018_add_stack_mirrors_and_groups'
 
+    def migrate_kwargs(self):
+        return {
+            'verbosity': 0,
+            'interactive': False,
+        }
+
     def test_migrate_overlays_to_stack_groups(self):
         OldStack = self.get_model_before('Stack')
         Overlay = self.get_model_before('Overlay')

--- a/django/projects/mysite/settings_base.py
+++ b/django/projects/mysite/settings_base.py
@@ -377,15 +377,15 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ),
-    'VIEW_DESCRIPTION_FUNCTION':
-        'custom_rest_swagger_googledoc.get_googledocstring',
-        # Parser classes priority-wise for Swagger
+    'VIEW_DESCRIPTION_FUNCTION': 'custom_rest_swagger_googledoc.get_googledocstring',
+    # Parser classes priority-wise for Swagger
     'DEFAULT_PARSER_CLASSES': [
         'rest_framework.parsers.FormParser',
         'rest_framework.parsers.MultiPartParser',
         'rest_framework.parsers.JSONParser',
     ],
-    'URL_FORMAT_OVERRIDE': None
+    'DEFAULT_SCHEMA_CLASS': 'custom_swagger_schema.CustomSchema',
+    'URL_FORMAT_OVERRIDE': None,
 }
 
 SWAGGER_SETTINGS = {

--- a/django/projects/mysite/urls.py
+++ b/django/projects/mysite/urls.py
@@ -11,8 +11,10 @@ from django.views.static import serve
 
 from catmaid.control.authentication import ObtainAuthToken
 
-from custom_swagger_schema import SwaggerSchemaView
+from rest_framework_swagger.views import get_swagger_view
 
+
+schema_view = get_swagger_view(title='CATMAID API')
 
 # Administration
 admin.site = AdminSitePlus()
@@ -41,7 +43,7 @@ urlpatterns += [
 
 # API Documentation
 urlpatterns += [
-    url(r'^apis/', SwaggerSchemaView.as_view()),
+    url(r'^apis/', schema_view),
     url(r'^api-token-auth/', ObtainAuthToken.as_view()),
 ]
 

--- a/django/projects/templates/rest_framework_swagger/index.html
+++ b/django/projects/templates/rest_framework_swagger/index.html
@@ -1,4 +1,4 @@
-{% extends 'rest_framework_swagger/base.html' %}
+{% extends 'rest_framework_swagger/index.html' %}
 
 {% block logo %}
     <a id="logo"
@@ -8,28 +8,57 @@
     </a>
 {% endblock %}
 
+{% block extra_styles %}
+  <style>
+    div.information-container div.info p,
+    div.information-container div.info a {
+      font-size: xx-large;
+    }
+  </style>
+{% endblock %}
+
 {% block extra_scripts %}
   <script>
-    $(document).on('ready', function() {
-      var patchTimeoutTime = 100;
+    document.addEventListener('DOMContentLoaded', function() {
+      let patchTimeoutTime = 100;
 
-      var patchUI = function() {
-          var target = $('div.info_description');
-        if (target.length > 0) {
-          target.append('<p>This is an API for accessing project, stack and ' +
+      let patchUI = function() {
+        let target = document.querySelector('div.information-container div.info');
+        if (target) {
+          while (target.lastChild) {
+            target.removeChild(target.lastChild);
+          }
+          target.innerHTML = '<p>This is an API for accessing project, stack and ' +
               'annotation data for this CATMAID instance. More information ' +
-              'is available at <a href="http://catmaid.org/page/api.html">catmaid.org</a></p>');
-          target.append('<p><a href="mailto:catmaid@googlegroups.com">Contact the developers</a>' +
-            ' <a href="https://github.com/catmaid/CATMAID" style="margin-left: 1em;">View the code</a> (GPLv3)</p>');
+              'is available at <a href="http://catmaid.org/page/api.html">catmaid.org</a>.</p>' +
+              '<p><a href="mailto:catmaid@googlegroups.com">Contact the developers</a>' +
+              ' <a href="https://github.com/catmaid/CATMAID" style="margin-left: 1em;">View the code</a> (GPLv3)</p>';
         } else {
           window.setTimeout(patchUI, patchTimeoutTime);
         }
       }
 
-      $('head title').text('CATMAID API documentation (Swagger UI)');
-      $('span.logo__title').text('CATMAID API documentation');
-      $('img.logo__img').attr('src', '{{ STATIC_URL }}/images/catmaidlogo.svg');
-      $('a#logo').attr('href', 'http://www.catmaid.org');
+      let title = document.querySelector('head title');
+      if (title) {
+        title.appendChild(document.createTextNode('CATMAID API documentation (Swagger UI)'));
+      }
+      let logoImage = document.querySelector('div.topbar a.link img');
+      if (logoImage) {
+        logoImage.src = '{{ STATIC_URL }}/images/catmaidlogo.svg';
+        logoImage.alt = 'CATMAID API documentation';
+        logoImage.title = 'CATMAID API documentation';
+      }
+      let logoSpan = document.querySelector('div.topbar a.link span');
+      if (logoSpan) {
+        while (logoSpan.lastChild) {
+          logoSpan.removeChild(logoSpan.lastChild);
+        }
+        logoSpan.appendChild(document.createTextNode('CATMAID API documentation'));
+      }
+      let logoLink = document.querySelector('div.topbar a.link');
+      if (logoLink) {
+        logoLink.href = 'http://www.catmaid.org';
+      }
 
       patchTimeout = window.setTimeout(patchUI, patchTimeoutTime);
     });

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -4,14 +4,14 @@ celery==4.1.1
 channels==1.1.8
 cssmin==0.2.0
 Cython==0.29.0
-Django==1.11.16
+Django==2.0.9
 django-adminplus==0.5
 django-formtools==2.1
 django-guardian==1.4.9
 django-pipeline==1.6.14
-django-rest-swagger==2.1.2
+django-rest-swagger==2.2.0
 django-taggit==0.23.0
-djangorestframework==3.5.4
+djangorestframework==3.9.0
 jsonfield==2.0.2
 kombu==4.2.1
 matplotlib==2.2.3


### PR DESCRIPTION
Django 2.0  is the first Django version that supports Python 3.7. I went to through the changelog and couldn't find any major conflicts with our current code base. The few small ones I found are fixed in this commit. More details can be found here:

  https://docs.djangoproject.com/en/2.1/releases/2.0/

Both djangorestframework and django-rest-swagger have been updated to their most recent versions. In order to keep our /apis endpoint working, I had to rewrite the our custom schema generator. It ties now in with the regular Schema framework of DRF, using the `DEFAULT_SCHEMA_CLASS` setting. This makes it slightly less hacky. Everything seems to work. More details on this can be found here:

  https://www.django-rest-framework.org/api-guide/schemas/6

This is filed as a PR mainly for documentation purposes. Please let me know if you see any problems with this upgrade.