### PR TITLE
Upgrade to Django 2.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ addons:
   postgresql: 9.6
   sauce_connect:
     username: catmaid
-  jwt:
-    secure: "hj6rvwzab8ptfMKvRyqCZnWqun2uEv69nLCGxLXiDk9QZOUv/UG8PU060m6DTHtYE8iJw5E6qhTIhLKlpPadYptkxmiOXVGKlU6jam8SLKsSbHbdFsoziIPnU4mpqNgjvZ7Xb7xoTmYcd15G7Du3qgTHc28TeT5F9XnyfyDCH7M="
+    access_key:
+      secure: "rFiPF3KRokQqUaMHzr34wdt98pbYKyO47CFm9sJPO/HOKePhDCW6bMhiNa4x5Q2T5oAb0SRb/6CECExlGtA4mnzC5u47S8E9TidlZZ1m/n2TRZr2cvzhBJFhnYYZxcF8+6vCKq4DWVU+wD2/4wWktIHkcBJ9XMErl8HyICUHzLo="
 before_install:
   - mkdir tmp
   - travis_retry sudo apt-get update -y -qq

--- a/django/applications/catmaid/control/importer.py
+++ b/django/applications/catmaid/control/importer.py
@@ -814,7 +814,7 @@ class DataFileForm(forms.Form):
         widget=forms.TextInput(attrs={'size':'40'}),
         help_text="Optionally, you can apply a <em>glob filter</em> to the " \
                   "projects found in your data folder.")
-    known_project_filter = forms.MultipleChoiceField(KNOWN_PROJECT_FILTERS,
+    known_project_filter = forms.MultipleChoiceField(choices=KNOWN_PROJECT_FILTERS,
             label='Projects are known if', initial=('name', 'stacks'),
             widget=forms.CheckboxSelectMultiple(), required=False,
             help_text='Select what makes makes a project known. An OR operation ' \

--- a/django/applications/catmaid/control/treenode.py
+++ b/django/applications/catmaid/control/treenode.py
@@ -620,7 +620,7 @@ def update_radius(request, project_id=None, treenode_id=None):
 
     if 5 == option:
         # Update radius of all nodes (in a single query)
-        skeleton_id = Treenode.objects.filter(pk=treenode_id).values('skeleton_id')
+        skeleton_id = Treenode.objects.get(pk=treenode_id).skeleton_id
         include = list(Treenode.objects.filter(skeleton_id=skeleton_id) \
                 .values_list('id', flat=True))
 

--- a/django/applications/catmaid/migrations/0055_prepare_django_auth_user_update.py
+++ b/django/applications/catmaid/migrations/0055_prepare_django_auth_user_update.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from django.db import migrations
+
+forward = """
+    SELECT disable_history_tracking_for_table('auth_user'::regclass,
+            get_history_table_name('auth_user'::regclass));
+    SELECT drop_history_view_for_table('auth_user'::regclass);
+"""
+
+backward = """
+    SELECT enable_history_tracking_for_table('auth_user'::regclass,
+            get_history_table_name('auth_user'::regclass), FALSE);
+    SELECT create_history_view_for_table('auth_user'::regclass);
+"""
+
+
+class Migration(migrations.Migration):
+    """CATMAID keeps track of the history of most tables in the database,
+    including some Django tables like auth_user. The upgrade to Django 2.0
+    requires an update of the auth_user table. The history system has a view
+    defined that uses this table and Postgres won't alter the type of a column
+    in the auth_user table if a view is defined on it. To get around this, this
+    migration will disable history tracking for auth_user and a second migration
+    will re-enable it again while depending on the changed auth_user table.
+    """
+
+    dependencies = [
+        ('catmaid', '0054_update_skeleton_summary_refresh_function'),
+    ]
+
+    run_before = [
+        ('auth', '0009_alter_user_last_name_max_length'),
+    ]
+
+    operations = [
+        migrations.RunSQL(forward, backward),
+    ]
+

--- a/django/applications/catmaid/migrations/0056_complete_django_auth_user_update.py
+++ b/django/applications/catmaid/migrations/0056_complete_django_auth_user_update.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from django.db import migrations
+
+forward = """
+    SELECT enable_history_tracking_for_table('auth_user'::regclass,
+            get_history_table_name('auth_user'::regclass), FALSE);
+    SELECT create_history_view_for_table('auth_user'::regclass);
+"""
+
+backward = """
+    SELECT disable_history_tracking_for_table('auth_user'::regclass,
+            get_history_table_name('auth_user'::regclass));
+    SELECT drop_history_view_for_table('auth_user'::regclass);
+"""
+
+
+class Migration(migrations.Migration):
+    """CATMAID keeps track of the history of most tables in the database,
+    including some Django tables like auth_user. The upgrade to Django 2.0
+    requires an update of the auth_user table. The history system has a view
+    defined that uses this table and Postgres won't alter the type of a column
+    in the auth_user table if a view is defined on it. To get around this, this
+    migration will re-enable the history tracking for the auth_user table again,
+    after the previous migration disabled it. Before this migration is applied,
+    the auth_user migration hat to be applied as well.
+    """
+
+    dependencies = [
+        ('catmaid', '0055_prepare_django_auth_user_update'),
+        ('auth', '0009_alter_user_last_name_max_length'),
+    ]
+
+    operations = [
+        migrations.RunSQL(forward, backward),
+    ]
+

--- a/django/applications/catmaid/models.py
+++ b/django/applications/catmaid/models.py
@@ -1159,7 +1159,7 @@ class NeuronSearch(forms.Form):
     search = forms.CharField(max_length=100, required=False)
     cell_body_location = forms.ChoiceField(
         choices=((('a', 'Any'),)+CELL_BODY_CHOICES))
-    order_by = forms.ChoiceField(SORT_ORDERS_CHOICES)
+    order_by = forms.ChoiceField(choices=SORT_ORDERS_CHOICES)
 
     def minimal_search_path(self):
         result = ""

--- a/django/applications/catmaid/templates/catmaid/admin/dataview/change_form.html
+++ b/django/applications/catmaid/templates/catmaid/admin/dataview/change_form.html
@@ -1,6 +1,6 @@
 {% extends "admin/guardian/model/change_form.html" %}
 {% load i18n  %}
-{% load admin_static %}
+{% load static %}
 
 {% block extrahead %}
 <script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.min.js' %}"></script>

--- a/django/applications/catmaid/templates/catmaid/classification/admin_setup_tag_groups.html
+++ b/django/applications/catmaid/templates/catmaid/classification/admin_setup_tag_groups.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
-{% load admin_static %}
+{% load static %}
 
 {% block extrahead %}
 <style type="text/css">

--- a/django/applications/catmaid/templates/catmaid/groupmembershiphelper.html
+++ b/django/applications/catmaid/templates/catmaid/groupmembershiphelper.html
@@ -2,7 +2,7 @@
 {# vim: set softtabstop=2 shiftwidth=2 tabstop=2 expandtab: #}
 
 {% extends "admin/base_site.html" %}
-{% load admin_static %}
+{% load static %}
 {% load pipeline %}
 {% load i18n %}
 

--- a/django/applications/catmaid/templates/catmaid/widgets/downsamplefactors.html
+++ b/django/applications/catmaid/templates/catmaid/widgets/downsamplefactors.html
@@ -4,8 +4,7 @@
 	{% for group, options, index in widget.subwidgets.0.optgroups %}
 		<li>
 			{% for option in options %}
-				{# TODO: `wrap_label` behavior will change in the next Django version. #}
-				{% include option.template_name with widget=option wrap_label=True %}
+				{% include option.template_name with widget=option %}
 			{% endfor %}
 			{% if index == 1 %}
 				{% include widget.subwidgets.1.template_name with widget=widget.subwidgets.1 %}

--- a/django/applications/catmaid/tests/gui/test_basic_gui.py
+++ b/django/applications/catmaid/tests/gui/test_basic_gui.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import os, re
+import logging, os, re
 
 from selenium import webdriver
 from selenium.webdriver.common.by import By
@@ -16,6 +16,9 @@ from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from catmaid.models import User, DataView, DataViewType
 
 from guardian.utils import get_anonymous_user
+
+
+logger = logging.getLogger(__name__)
 
 
 class BasicUITest(StaticLiveServerTestCase):
@@ -120,7 +123,7 @@ class BasicUITest(StaticLiveServerTestCase):
             if settings.GUI_TESTS_REMOTE:
                 # Let saucelabs.com know about the outcome of this test
                 id = self.selenium.session_id
-                print('Link to remote Selenium GUI test job: https://saucelabs.com/jobs/{}'.format(id))
+                logger.info('Link to remote Selenium GUI test job: https://saucelabs.com/jobs/{}'.format(id))
 
                 from sauceclient import SauceClient
                 username = os.environ["SAUCE_USERNAME"]

--- a/django/applications/catmaid/tests/migrations/test_migration_0018.py
+++ b/django/applications/catmaid/tests/migrations/test_migration_0018.py
@@ -10,6 +10,12 @@ class Migration0018Tests(MigrationTest):
     before = '0017_update_edge_indices'
     after = '0018_add_stack_mirrors_and_groups'
 
+    def migrate_kwargs(self):
+        return {
+            'verbosity': 0,
+            'interactive': False,
+        }
+
     def test_migrate_overlays_to_stack_groups(self):
         OldStack = self.get_model_before('Stack')
         Overlay = self.get_model_before('Overlay')

--- a/django/applications/catmaid/tests/test_common_apis.py
+++ b/django/applications/catmaid/tests/test_common_apis.py
@@ -309,7 +309,9 @@ class ViewPageTests(TestCase):
              'can_browse': [3],
              'can_import': [],
              'can_queue_compute_task': [],
-             'delete_project': []}, [u'test1']]
+             'delete_project': [],
+             'view_project': [],
+            }, [u'test1']]
         self.assertEqual(expected_result, parsed_response)
 
 

--- a/django/applications/catmaid/urls.py
+++ b/django/applications/catmaid/urls.py
@@ -6,8 +6,6 @@ from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import TemplateView
 
-import django.contrib.auth.views as djauth
-
 from rest_framework.decorators import api_view
 
 from catmaid.control import (authentication, user, group, log, message, client,
@@ -55,7 +53,8 @@ urlpatterns += [
     url(r'^user-list$', user.user_list),
     url(r'^user-table-list$', user.user_list_datatable),
     url(r'^user-profile/update$', user.update_user_profile),
-    url(r'^user/password_change/$', user.change_password, {'post_change_redirect': 'catmaid:home'}),
+    url(r'^user/password_change/$', user.NonAnonymousPasswordChangeView.as_view(
+            success_url='catmaid:home', raise_exception=False)),
 ]
 
 # Groups

--- a/django/applications/performancetests/models.py
+++ b/django/applications/performancetests/models.py
@@ -12,7 +12,7 @@ class TestView(models.Model):
     """
     method = models.CharField(max_length=50)
     url = models.TextField()
-    data = JSONField(blank=True, default={})
+    data = JSONField(blank=True, default=dict)
     creation_time = models.DateTimeField(default=timezone.now)
 
     def __unicode__(self):

--- a/django/projects/mysite/settings.py.example
+++ b/django/projects/mysite/settings.py.example
@@ -41,7 +41,7 @@ MEDIA_URL = '/CATMAID_SUBDIR/files/'
 # The URL where static files can be accessed, relative to the domain's root
 STATIC_URL = '/CATMAID_SUBDIR/static/'
 # The absolute local path where the static files get collected to
-STATIC_ROOT =  'CATMAIDPATH/django/static'
+STATIC_ROOT = 'CATMAIDPATH/django/static'
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
@@ -91,7 +91,7 @@ IMPORTER_DEFAULT_IMAGE_BASE = 'http://CATMAID_SERVERNAME/CATMAID_SUBDIR/data'
 # The URL under which custom front-end code can be made available
 STATIC_EXTENSION_URL = '/CATMAID_SUBDIR/staticext/'
 # The absolute local path where the static extension files live
-STATIC_EXTENSION_ROOT =  'CATMAIDPATH/django/staticext'
+STATIC_EXTENSION_ROOT = 'CATMAIDPATH/django/staticext'
 
 # Gives Django access to installed CATMAID extensions - do not change without good reason.
 # See https://catmaid.readthedocs.io/en/stable/extensions.html for more details

--- a/django/projects/mysite/settings_base.py
+++ b/django/projects/mysite/settings_base.py
@@ -377,15 +377,15 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ),
-    'VIEW_DESCRIPTION_FUNCTION':
-        'custom_rest_swagger_googledoc.get_googledocstring',
-        # Parser classes priority-wise for Swagger
+    'VIEW_DESCRIPTION_FUNCTION': 'custom_rest_swagger_googledoc.get_googledocstring',
+    # Parser classes priority-wise for Swagger
     'DEFAULT_PARSER_CLASSES': [
         'rest_framework.parsers.FormParser',
         'rest_framework.parsers.MultiPartParser',
         'rest_framework.parsers.JSONParser',
     ],
-    'URL_FORMAT_OVERRIDE': None
+    'DEFAULT_SCHEMA_CLASS': 'custom_swagger_schema.CustomSchema',
+    'URL_FORMAT_OVERRIDE': None,
 }
 
 SWAGGER_SETTINGS = {

--- a/django/projects/mysite/urls.py
+++ b/django/projects/mysite/urls.py
@@ -11,8 +11,10 @@ from django.views.static import serve
 
 from catmaid.control.authentication import ObtainAuthToken
 
-from custom_swagger_schema import SwaggerSchemaView
+from rest_framework_swagger.views import get_swagger_view
 
+
+schema_view = get_swagger_view(title='CATMAID API')
 
 # Administration
 admin.site = AdminSitePlus()
@@ -41,7 +43,7 @@ urlpatterns += [
 
 # API Documentation
 urlpatterns += [
-    url(r'^apis/', SwaggerSchemaView.as_view()),
+    url(r'^apis/', schema_view),
     url(r'^api-token-auth/', ObtainAuthToken.as_view()),
 ]
 

--- a/django/projects/templates/rest_framework_swagger/index.html
+++ b/django/projects/templates/rest_framework_swagger/index.html
@@ -1,4 +1,4 @@
-{% extends 'rest_framework_swagger/base.html' %}
+{% extends 'rest_framework_swagger/index.html' %}
 
 {% block logo %}
     <a id="logo"
@@ -8,28 +8,57 @@
     </a>
 {% endblock %}
 
+{% block extra_styles %}
+  <style>
+    div.information-container div.info p,
+    div.information-container div.info a {
+      font-size: xx-large;
+    }
+  </style>
+{% endblock %}
+
 {% block extra_scripts %}
   <script>
-    $(document).on('ready', function() {
-      var patchTimeoutTime = 100;
+    document.addEventListener('DOMContentLoaded', function() {
+      let patchTimeoutTime = 100;
 
-      var patchUI = function() {
-          var target = $('div.info_description');
-        if (target.length > 0) {
-          target.append('<p>This is an API for accessing project, stack and ' +
+      let patchUI = function() {
+        let target = document.querySelector('div.information-container div.info');
+        if (target) {
+          while (target.lastChild) {
+            target.removeChild(target.lastChild);
+          }
+          target.innerHTML = '<p>This is an API for accessing project, stack and ' +
               'annotation data for this CATMAID instance. More information ' +
-              'is available at <a href="http://catmaid.org/page/api.html">catmaid.org</a></p>');
-          target.append('<p><a href="mailto:catmaid@googlegroups.com">Contact the developers</a>' +
-            ' <a href="https://github.com/catmaid/CATMAID" style="margin-left: 1em;">View the code</a> (GPLv3)</p>');
+              'is available at <a href="http://catmaid.org/page/api.html">catmaid.org</a>.</p>' +
+              '<p><a href="mailto:catmaid@googlegroups.com">Contact the developers</a>' +
+              ' <a href="https://github.com/catmaid/CATMAID" style="margin-left: 1em;">View the code</a> (GPLv3)</p>';
         } else {
           window.setTimeout(patchUI, patchTimeoutTime);
         }
       }
 
-      $('head title').text('CATMAID API documentation (Swagger UI)');
-      $('span.logo__title').text('CATMAID API documentation');
-      $('img.logo__img').attr('src', '{{ STATIC_URL }}/images/catmaidlogo.svg');
-      $('a#logo').attr('href', 'http://www.catmaid.org');
+      let title = document.querySelector('head title');
+      if (title) {
+        title.appendChild(document.createTextNode('CATMAID API documentation (Swagger UI)'));
+      }
+      let logoImage = document.querySelector('div.topbar a.link img');
+      if (logoImage) {
+        logoImage.src = '{{ STATIC_URL }}/images/catmaidlogo.svg';
+        logoImage.alt = 'CATMAID API documentation';
+        logoImage.title = 'CATMAID API documentation';
+      }
+      let logoSpan = document.querySelector('div.topbar a.link span');
+      if (logoSpan) {
+        while (logoSpan.lastChild) {
+          logoSpan.removeChild(logoSpan.lastChild);
+        }
+        logoSpan.appendChild(document.createTextNode('CATMAID API documentation'));
+      }
+      let logoLink = document.querySelector('div.topbar a.link');
+      if (logoLink) {
+        logoLink.href = 'http://www.catmaid.org';
+      }
 
       patchTimeout = window.setTimeout(patchUI, patchTimeoutTime);
     });

--- a/django/requirements-test.txt
+++ b/django/requirements-test.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 django-migration-testcase==0.0.11
-selenium==3.0.2
+selenium==3.141.0
 sauceclient==1.0.0

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -4,7 +4,7 @@ celery==4.1.1
 channels==1.1.8
 cssmin==0.2.0
 Cython==0.29.0
-Django==2.0.9
+Django==2.1.3
 django-adminplus==0.5
 django-formtools==2.1
 django-guardian==1.4.9

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -4,14 +4,14 @@ celery==4.1.1
 channels==1.1.8
 cssmin==0.2.0
 Cython==0.29.0
-Django==1.11.16
+Django==2.0.9
 django-adminplus==0.5
 django-formtools==2.1
 django-guardian==1.4.9
 django-pipeline==1.6.14
-django-rest-swagger==2.1.2
+django-rest-swagger==2.2.0
 django-taggit==0.23.0
-djangorestframework==3.5.4
+djangorestframework==3.9.0
 jsonfield==2.0.2
 kombu==4.2.1
 matplotlib==2.2.3

--- a/scripts/travis/configure_catmaid.sh
+++ b/scripts/travis/configure_catmaid.sh
@@ -16,6 +16,8 @@ python create_configuration.py
 sed -i -e "s?^\(ALLOWED_HOSTS = \).*?\1['*']?g" projects/mysite/settings.py
 # Enable static file serving without DEBUG = True
 echo "SERVE_STATIC = True" >> projects/mysite/settings.py
+# TODO: Enable pipeline. Right now it doesn't seem to play well with Sauce Labs.
+echo "PIPELINE['PIPELINE_ENABLED'] = False" >> projects/mysite/settings.py
 # Disable cache-busting for front-end tests
 echo "STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'" >> projects/mysite/settings.py
 # Enable front-end tess


### PR DESCRIPTION
This is the most recent version of Django, which fixes a few problems I had with the Django 2.0 upgrade branch on Travis. I had to disable django-pipeline for Travis, because I couldn't find a configuration that would work with Source labs and django-pipeline enabled. This can be fixed at a later point as it is not important enough to spend a lot of time testing this at the moment. The commit messages have more details on the few things that changed.

Also, this removes the JWT Travis dependency, so this deprecation message is finally gone. And of course all Django 2.0 upgrade changes are included too. I closed PR #1807 in favor of this one.