### PR TITLE
Label stack support

### DIFF
--- a/django/applications/catmaid/control/stack.py
+++ b/django/applications/catmaid/control/stack.py
@@ -155,12 +155,12 @@ def stacks(request, project_id=None):
 
 @requires_user_role([UserRole.Annotate, UserRole.Browse])
 def stack_groups(request, project_id=None, stack_id=None):
-    stackgroup_links = StackStackGroup.objects \
+    stack_group_ids = StackStackGroup.objects \
         .filter(stack=stack_id) \
-        .select_related('group_relation')
+        .values_list('stack_group_id', flat=True)
 
     result = {
-        'stack_group_ids': [l.stack_group_id for l in stackgroup_links]
+        'stack_group_ids': stack_group_ids
     }
 
     return JsonResponse(result)

--- a/django/applications/catmaid/control/stack.py
+++ b/django/applications/catmaid/control/stack.py
@@ -8,7 +8,7 @@ from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 
 from ..models import UserRole, Project, Stack, ProjectStack, \
-        BrokenSlice, StackMirror
+        BrokenSlice, StackMirror, StackStackGroup
 from .authentication import requires_user_role
 
 logger = logging.getLogger(__name__)
@@ -152,3 +152,15 @@ def stacks(request, project_id=None):
         'sort_keys': True,
         'indent': 4
     })
+
+@requires_user_role([UserRole.Annotate, UserRole.Browse])
+def stack_groups(request, project_id=None, stack_id=None):
+    stackgroup_links = StackStackGroup.objects \
+        .filter(stack=stack_id) \
+        .select_related('group_relation')
+
+    result = {
+        'stack_group_ids': [l.stack_group_id for l in stackgroup_links]
+    }
+
+    return JsonResponse(result)

--- a/django/applications/catmaid/control/stackgroup.py
+++ b/django/applications/catmaid/control/stackgroup.py
@@ -17,7 +17,6 @@ def get_stackgroup_info(request, project_id, stackgroup_id):
         .filter(stack_group=stackgroup_id) \
         .order_by('position') \
         .select_related('group_relation')
-    stacks = [l.stack_id for l in stackgroup_links]
 
     result = {
         'id': stackgroup.id,

--- a/django/applications/catmaid/static/css/stack.css
+++ b/django/applications/catmaid/static/css/stack.css
@@ -118,16 +118,16 @@ div.smallMapView_hidden div.smallMapRect div {
 }
 
 div.LayerControl {
-  border: solid 1px #00F;
+  border-right: solid 1px #00F;
   margin: 0;
   padding: 8px;
   position: relative;
-  top: 10px;
-  left: 10px;
-  width: 40em;
+  top: 0;
+  left: 0;
+  width: 42em;
   min-width: 13em;
   max-width: 80%;
-  height: 65%;
+  height: 100%;
   overflow-x: hidden;
   overflow-y: auto;
   color: #FFFFFF;
@@ -207,7 +207,7 @@ div.LayerControl li.highlight {
 
 .layerControl .layerFilterControl input.remove {
   position: absolute;
-  left: 0.5em;
+  left: 2em;
 }
 
 .layerControl .layerFilterControl h5 {

--- a/django/applications/catmaid/static/js/init.js
+++ b/django/applications/catmaid/static/js/init.js
@@ -1610,7 +1610,7 @@ var project;
           !hideStackLayer,
           hideStackLayer ? 0 : 1,
           !useExistingViewer,
-          CATMAID.StackLayer.Settings.session.linear_interpolation,
+          CATMAID.StackLayer.INTERPOLATION_MODES.INHERIT,
           true);
 
       if (!useExistingViewer) {

--- a/django/applications/catmaid/static/js/init.js
+++ b/django/applications/catmaid/static/js/init.js
@@ -1595,6 +1595,13 @@ var project;
 
       var stack = new CATMAID.Stack.fromStackInfoJson(e);
 
+      // If this is a label stack, not a raw stack, create a label annotation
+      // manager.
+      // TODO: should eventually use a backend image label space instead.
+      if (!!stack.labelMetadata()) {
+        CATMAID.LabelAnnotations.get(stack);
+      }
+
       if (!useExistingViewer) {
         stackViewer = new CATMAID.StackViewer(project, stack);
       }

--- a/django/applications/catmaid/static/js/init.js
+++ b/django/applications/catmaid/static/js/init.js
@@ -1362,13 +1362,13 @@ var project;
                       stacks: stacks
                     };
                     CATMAID.layoutStackViewers();
-                    // Make all tile layers visible, they have been initialized
+                    // Make all stack layers visible, they have been initialized
                     // invisible.
                     for (var i=0; i<loadedStackViewers.length; ++i) {
                       var sv = loadedStackViewers[i];
-                      var tileLayers = sv.getLayersOfType(CATMAID.TileLayer);
-                      for (var j=0; j<tileLayers.length; ++j) {
-                        var tl = tileLayers[j];
+                      var stackLayers = sv.getLayersOfType(CATMAID.StackLayer);
+                      for (var j=0; j<stackLayers.length; ++j) {
+                        var tl = stackLayers[j];
                         tl.setOpacity(1.0);
                         tl.redraw();
                       }
@@ -1517,7 +1517,7 @@ var project;
    * @param  {StackViewer} stackViewer Viewer to which to add the stack.
    * @param  {number}      mirrorIndex Optional mirror index, defaults to
    *                                   the first available.
-   * @param  {Boolean} hide            The stack's tile layer will initially be
+   * @param  {Boolean} hide            The stack's layer will initially be
    *                                   hidden.
    * @return {Promise}                 A promise yielding the stack viewer
    *                                   containing the new stack.
@@ -1590,7 +1590,7 @@ var project;
       });
     }
 
-    function loadStack(e, stackViewer, hideTileLayer) {
+    function loadStack(e, stackViewer, hideStackLayer) {
       var useExistingViewer = typeof stackViewer !== 'undefined';
 
       var stack = new CATMAID.Stack.fromStackInfoJson(e);
@@ -1601,29 +1601,27 @@ var project;
 
       document.getElementById( "toolbox_project" ).style.display = "block";
 
-      var tilelayerConstructor = CATMAID.TileLayer.Settings.session.prefer_webgl ?
-          CATMAID.PixiTileLayer :
-          CATMAID.TileLayer;
-      var tilelayer = new tilelayerConstructor(
+      var stackLayerConstructor = CATMAID.StackLayer.preferredConstructorForStack();
+      var stackLayer = new stackLayerConstructor(
           stackViewer,
           "Image data (" + stack.title + ")",
           stack,
           mirrorIndex,
-          !hideTileLayer,
-          hideTileLayer ? 0 : 1,
+          !hideStackLayer,
+          hideStackLayer ? 0 : 1,
           !useExistingViewer,
-          CATMAID.TileLayer.Settings.session.linear_interpolation,
+          CATMAID.StackLayer.Settings.session.linear_interpolation,
           true);
 
       if (!useExistingViewer) {
-        stackViewer.addLayer( "TileLayer", tilelayer );
+        stackViewer.addLayer("StackLayer", stackLayer);
 
         project.addStackViewer( stackViewer );
 
         // refresh the overview handler to also register the mouse events on the buttons
         stackViewer.layercontrol.refresh();
       } else {
-        stackViewer.addStackLayer(stack, tilelayer);
+        stackViewer.addStackLayer(stack, stackLayer);
       }
 
       CATMAID.ui.releaseEvents();

--- a/django/applications/catmaid/static/js/label-annotations.js
+++ b/django/applications/catmaid/static/js/label-annotations.js
@@ -71,6 +71,10 @@
 
   const LABEL_FILTER_KEY = 'Object Label Color Map';
 
+  const SPECIAL_LABELS = {
+    background: 0,
+  };
+
   class LabelStackAnnotations {
     constructor(
       primaryStack
@@ -79,14 +83,7 @@
       this.stackIDs = new Set([this.primaryStack.id]);
       this.activeLabelID = undefined;
 
-      this.specialLabels = {
-        background: 0,
-      };
-      if (this.primaryStack.metadata &&
-          this.primaryStack.metadata.catmaidLabelMeta &&
-          this.primaryStack.metadata.catmaidLabelMeta.specialLabels) {
-        $.extend(this.specialLabels, this.primaryStack.metadata.catmaidLabelMeta.specialLabels);
-      }
+      this.specialLabels = Object.assign({}, SPECIAL_LABELS, this.primaryStack.labelMetadata());
       this.stackLayerFilters = new Map();
 
       project.on(CATMAID.Project.EVENT_STACKVIEW_ADDED,

--- a/django/applications/catmaid/static/js/label-annotations.js
+++ b/django/applications/catmaid/static/js/label-annotations.js
@@ -1,0 +1,132 @@
+(function (CATMAID) {
+
+  "use strict";
+
+  class LabelAnnotations {
+    constructor() {
+      this.managers = new Map();
+      this.active = undefined;
+    }
+
+    activate(stackID) {
+      this.active = stackID;
+    }
+
+    clear() {
+      for (const [_stack, manager] of this.managers.entries()) manager.unregister();
+      this.managers.clear();
+      this.active = undefined;
+    }
+
+    get(stack) {
+      let manager = this.managers.get(stack.id);
+
+      if (!manager) {
+        manager = new LabelStackAnnotations(stack);
+        this.managers.set(stack.id, manager);
+      }
+
+      return manager;
+    }
+  }
+
+  CATMAID.LabelAnnotations = new LabelAnnotations();
+
+  CATMAID.Init.on(CATMAID.Init.EVENT_PROJECT_CHANGED, CATMAID.LabelAnnotations.clear, CATMAID.LabelAnnotations);
+
+
+  const LABEL_FILTER_KEY = 'Object Label Color Map';
+
+  class LabelStackAnnotations {
+    constructor(
+      stack
+    ) {
+      this.stack = stack;
+      this.activeLabelID = undefined;
+      this.specialLabels = {
+        background: 0,
+      };
+      if (this.stack.metadata &&
+          this.stack.metadata.catmaidLabelMeta &&
+          this.stack.metadata.catmaidLabelMeta.specialLabels) {
+        $.extend(this.specialLabels, this.stack.metadata.catmaidLabelMeta.specialLabels);
+      }
+      this.stackLayerFilters = new Map();
+
+      project.on(CATMAID.Project.EVENT_STACKVIEW_ADDED,
+          this.registerStackViewerLayers, this);
+      CATMAID.StackViewer.on(CATMAID.StackViewer.EVENT_STACK_LAYER_ADDED,
+          this.registerStackLayer, this);
+      CATMAID.StackViewer.on(CATMAID.StackViewer.EVENT_STACK_LAYER_REMOVED,
+          this.unregisterStackLayer, this);
+    }
+
+    unregister() {
+      project.off(CATMAID.Project.EVENT_STACKVIEW_ADDED,
+          this.registerStackViewerLayers, this);
+      CATMAID.StackViewer.off(CATMAID.StackViewer.EVENT_STACK_LAYER_ADDED,
+          this.registerStackLayer, this);
+      CATMAID.StackViewer.off(CATMAID.StackViewer.EVENT_STACK_LAYER_REMOVED,
+          this.unregisterStackLayer, this);
+      this.stackLayerFilters.clear();
+    }
+
+    activateLabel(labelID) {
+      this.activeLabelID = labelID;
+
+      for (const [stackLayer, filter] of this.stackLayerFilters.entries()) {
+        this.updateFilter(filter);
+        stackLayer.redraw();
+        stackLayer.stackViewer.layercontrol.refresh();
+      }
+    }
+
+    registerAllStackLayers() {
+      for (const stackViewer of project.getStackViewers()) {
+        this.registerStackViewerLayers(stackViewer);
+      }
+    }
+
+    registerStackViewerLayers(stackViewer) {
+      for (const stackLayer of stackViewer.getLayersOfType(CATMAID.StackLayer)) {
+        this.registerStackLayer(stackLayer, stackViewer);
+      }
+    }
+
+    registerStackLayer(stackLayer, stackViewer) {
+      if (this.stack.id !== stackLayer.stack.id) return;
+
+      let layerFilters = stackLayer.getAvailableFilters ? stackLayer.getAvailableFilters() : [];
+      if (LABEL_FILTER_KEY in layerFilters && !this.stackLayerFilters.has(stackLayer)) {
+        stackLayer.setBlendMode('add');
+        stackLayer.setInterpolationMode(false);  // Nearest neighbor interpolation.
+        stackLayer.isHideable = true;
+        let filter = new (layerFilters[LABEL_FILTER_KEY])();
+        this.updateFilter(filter);
+        stackLayer.addFilter(filter);
+        this.stackLayerFilters.set(stackLayer, filter);
+
+        // TODO: coupling state refresh with stack viewer.
+        stackLayer.redraw();
+        stackViewer.layercontrol.refresh();
+      }
+    }
+
+    unregisterStackLayer(stackLayer, stackViewer) {
+      if (this.stack.id !== stackLayer.stack.id) return;
+
+      this.stackLayerFilters.delete(stackLayer);
+    }
+
+    updateFilter(filter) {
+      filter.pixiFilter.backgroundLabel = CATMAID.PixiLayer.Filters.int2arr(
+        this.specialLabels.background);
+      filter.pixiFilter.unknownLabel = typeof this.activeLabelID === 'undefined' ?
+        [-1, -1, -1, -1] :
+        CATMAID.PixiLayer.Filters.int2arr(this.activeLabelID);
+    }
+  }
+
+  CATMAID.LabelStackAnnotations = LabelStackAnnotations;
+
+})(CATMAID);

--- a/django/applications/catmaid/static/js/label-annotations.js
+++ b/django/applications/catmaid/static/js/label-annotations.js
@@ -41,7 +41,7 @@
               // Find if an existing manager for any of these stack groups exists.
               let managing_stack_id = ortho_sgs.find(sg => this.groupManagingStack.get(sg.id));
 
-              if (typeof managing_stack_id !== 'undefined') {
+              if (managing_stack_id !== undefined) {
                 manager = this.managers.get(managing_stack_id);
               } else {
                 // If no manager exists, create a new one.

--- a/django/applications/catmaid/static/js/label-annotations.js
+++ b/django/applications/catmaid/static/js/label-annotations.js
@@ -141,7 +141,7 @@
       let layerFilters = stackLayer.getAvailableFilters ? stackLayer.getAvailableFilters() : [];
       if (LABEL_FILTER_KEY in layerFilters && !this.stackLayerFilters.has(stackLayer)) {
         stackLayer.setBlendMode('add');
-        stackLayer.setInterpolationMode(false);  // Nearest neighbor interpolation.
+        stackLayer.setInterpolationMode(CATMAID.StackLayer.INTERPOLATION_MODES.NEAREST);
         stackLayer.isHideable = true;
         let filter = new (layerFilters[LABEL_FILTER_KEY])();
         this.updateFilter(filter);

--- a/django/applications/catmaid/static/js/layers/layer-control.js
+++ b/django/applications/catmaid/static/js/layers/layer-control.js
@@ -14,7 +14,7 @@
     this.view = document.createElement( "div" );
     this.view.className = "LayerControl";
     this.view.id = "LayerControl" + stackViewer.id;
-    this.view.style.zIndex = 8;
+    this.view.style.zIndex = 6;
 
     stackViewer.getView().appendChild( this.view );
   };

--- a/django/applications/catmaid/static/js/layers/pixi-layer.js
+++ b/django/applications/catmaid/static/js/layers/pixi-layer.js
@@ -65,6 +65,18 @@
     if (allReady) this.renderer.render(this.stage);
   };
 
+  /**
+   * Renderer the content of this context to a URL-encoded type.
+   * @param  {@string} type               URL encoding format, e.g., 'image/png'
+   * @param  {@PIXI.RenderTexture} canvas Target render texture, to reuse.
+   * @return {string}                     URL-encoded content.
+   */
+  PixiContext.prototype.toDataURL = function (type, canvas) {
+    canvas = canvas || new PIXI.RenderTexture.create(this.renderer.width, this.renderer.height);
+    this.renderer.render(this.stage, canvas);
+    return this.renderer.plugins.extract.canvas(canvas).toDataURL(type);
+  };
+
 
   /**
    * Loads textures from URLs, tracks use through reference counting, caches

--- a/django/applications/catmaid/static/js/layers/pixi-layer.js
+++ b/django/applications/catmaid/static/js/layers/pixi-layer.js
@@ -655,9 +655,10 @@
           numberInput.min = '0';
           numberInput.max = '16777215';
           numberInput.step = '1';
+          numberInput.value = PixiLayer.Filters.arr2int(this.pixiFilter[param.name]);
           (function(setParam, numberInput) {
             numberInput.onchange = function() {
-              setParam(int2arr(Number(this.value)));
+              setParam(PixiLayer.Filters.int2arr(Number(this.value)));
             };
           })(self.setParam.bind(self, param.name), numberInput);
           numberDiv.appendChild(numberInput);
@@ -910,7 +911,7 @@
    * @param num
    * @returns {Array.<*>}
    */
-  var int2arr = function(num) {
+  PixiLayer.Filters.int2arr = function(num) {
     var arr = [];
     var divisor;
     var remainder = num;
@@ -924,7 +925,7 @@
     return arr;
   };
 
-  var arr2int = function(arr) {
+  PixiLayer.Filters.arr2int = function(arr) {
     var out = 0;
     for (var i = 0; i < arr.length-1; i++) {
       out += Math.floor(arr[i]*255) * Math.pow(256, i);
@@ -954,37 +955,37 @@
     var fragmentSrc = `
       uniform vec4 unknownLabel;
       uniform vec4 unknownColor;
-      
+
       uniform vec4 backgroundLabel;
       uniform vec4 backgroundColor;
-      
+
       uniform float foregroundAlpha;
       uniform float seed;
-      
+
       varying vec2 vTextureCoord;
       uniform sampler2D uSampler;
-      
+
       float whenEq(vec4 x, vec4 y) {
           return 1.0 - sign(distance(x, y));
       }
-      
+
       vec4 hashToColor(vec4 label) {
           const float SCALE = 33452.5859; // Some large constant to make the truncation interesting.
           label = fract(label * SCALE); // Truncate some information.
           label += dot(label, label.wzyx + 100.0 * seed); // Mix channels and add the salt.
           return vec4(fract((label.xzy + label.ywz) * label.zyw), 1.0) * foregroundAlpha;
       }
-      
+
       void main(void){
           vec4 current = texture2D(uSampler, vTextureCoord);
-      
+
           float isUnknown = whenEq(current, unknownLabel);
           float isBackground = whenEq(current, backgroundLabel);
-      
+
           vec4 final = unknownColor * isUnknown;
           final += backgroundColor * isBackground;
           final += hashToColor(current) * (1.0 - min(isUnknown + isBackground, 1.0));
-      
+
           gl_FragColor.rgba = final;
       }
     `;

--- a/django/applications/catmaid/static/js/layers/pixi-layer.js
+++ b/django/applications/catmaid/static/js/layers/pixi-layer.js
@@ -421,8 +421,7 @@
         .filter(function (modeKey) { // Filter modes that are not different from normal.
           var glBlendFuncs = glBlendModes[PIXI.BLEND_MODES[modeKey]];
           return modeKey == 'NORMAL' ||
-              glBlendFuncs[0] !== normBlendFuncs[0] ||
-              glBlendFuncs[1] !== normBlendFuncs[1]; })
+              !CATMAID.tools.arraysEqual(glBlendFuncs, normBlendFuncs); })
         .map(function (modeKey) {
           return modeKey.toLowerCase().replace(/_/, ' '); });
   };

--- a/django/applications/catmaid/static/js/layers/pixi-tile-layer.js
+++ b/django/applications/catmaid/static/js/layers/pixi-tile-layer.js
@@ -28,7 +28,7 @@
     this._oldZ = undefined;
 
     this._tileRequest = {};
-    this._pixiInterpolationMode = this._interpolationMode ? PIXI.SCALE_MODES.LINEAR : PIXI.SCALE_MODES.NEAREST;
+    this._updatePixiInterpolationMode();
   }
 
   PixiTileLayer.prototype = Object.create(CATMAID.TileLayer.prototype);
@@ -47,10 +47,15 @@
     }
   };
 
+  PixiTileLayer.prototype._updatePixiInterpolationMode = function () {
+    let linear = this.getEffectiveInterpolationMode() === CATMAID.StackLayer.INTERPOLATION_MODES.LINEAR;
+    this._pixiInterpolationMode = linear ? PIXI.SCALE_MODES.LINEAR : PIXI.SCALE_MODES.NEAREST;
+  };
+
   /** @inheritdoc */
-  PixiTileLayer.prototype.setInterpolationMode = function (linear) {
-    this._interpolationMode = linear;
-    this._pixiInterpolationMode = this._interpolationMode ? PIXI.SCALE_MODES.LINEAR : PIXI.SCALE_MODES.NEAREST;
+  PixiTileLayer.prototype.setInterpolationMode = function (mode) {
+    CATMAID.StackLayer.prototype.setInterpolationMode.call(this, mode);
+    this._updatePixiInterpolationMode();
     for (var i = 0; i < this._tiles.length; ++i) {
       for (var j = 0; j < this._tiles[0].length; ++j) {
         var texture = this._tiles[i][j].texture;

--- a/django/applications/catmaid/static/js/layers/pixi-tile-layer.js
+++ b/django/applications/catmaid/static/js/layers/pixi-tile-layer.js
@@ -276,6 +276,7 @@
   PixiTileLayer.prototype._swapBuffers = function (force, timeout) {
     if (timeout && timeout !== this._swapBuffersTimeout) return;
     window.clearTimeout(this._swapBuffersTimeout);
+    this._swapBuffersTimeout = null;
 
     for (var i = 0; i < this._tiles.length; ++i) {
       for (var j = 0; j < this._tiles[0].length; ++j) {
@@ -338,6 +339,16 @@
     var newTileLayer = this.constructCopy({}, CATMAID.TileLayer);
     var layerKey = this.stackViewer.getLayerKey(this);
     this.stackViewer.replaceStackLayer(layerKey, newTileLayer);
+  };
+
+  /** @inheritdoc */
+  PixiTileLayer.prototype._tilePixel = function (tile, x, y) {
+    var img = tile.texture.baseTexture.source;
+    var canvas = document.createElement('canvas');
+    var context = canvas.getContext('2d');
+    context.drawImage(img, 0, 0);
+
+    return context.getImageData(x, y, 1, 1).data;
   };
 
   CATMAID.PixiTileLayer = PixiTileLayer;

--- a/django/applications/catmaid/static/js/layers/stack-layer.js
+++ b/django/applications/catmaid/static/js/layers/stack-layer.js
@@ -486,6 +486,14 @@
     return this.opacity;
   };
 
+  /**
+   * Get the pixel value (from the current scale level) at an (unscaled) stack
+   * coordinate if it is currently in the field of view.
+   */
+  StackLayer.prototype.pixelValueInScaleLevel = function (stackX, stackY, stackZ) {
+    throw new CATMAID.Error('Not implemented');
+  };
+
   StackLayer.Settings = new CATMAID.Settings(
       // Note that for legacy compatibility this settings name is still
       // 'tile-layer'.

--- a/django/applications/catmaid/static/js/layers/stack-layer.js
+++ b/django/applications/catmaid/static/js/layers/stack-layer.js
@@ -1,0 +1,517 @@
+(function(CATMAID) {
+
+  "use strict";
+
+  /**
+   * Base class for layers that display an image stack.
+   * @constructor
+   * @param {StackViewer} stackViewer Stack viewer to which this layer belongs.
+   * @param {string}  displayname  Name displayed in window controls.
+   * @param {Stack}   stack        Image stack to display.
+   * @param {number}  mirrorIndex  Stack mirror index to use as source. If
+   *                               undefined, the fist available mirror is used.
+   * @param {boolean} visibility   Whether the stack layer is initially visible.
+   * @param {number}  opacity      Opacity to draw the layer.
+   * @param {boolean} showOverview Whether to show a "minimap" overview of the
+   *                               stack.
+   * @param {boolean} linearInterpolation Whether to use linear or nearest
+   *                               neighbor texture interpolation.
+   * @param {boolean} readState    Whether last used mirror and custom mirrors
+   *                               should be read from a browser cookie.
+   * @param {boolean} changeMirrorIfNoData Whether to automatically switch to
+   *                               the next accessible mirror if the present one
+   *                               in inaccessible. (Default: true)
+   */
+  function StackLayer(
+      stackViewer,
+      displayname,
+      stack,
+      mirrorIndex,
+      visibility,
+      opacity,
+      showOverview,
+      linearInterpolation,
+      readState,
+      changeMirrorIfNoData) {
+
+    this.stackViewer = stackViewer;
+    this.displayname = displayname;
+    this.stack = stack;
+    this.opacity = opacity; // in the range [0,1]
+    this.showOverview = showOverview;
+    this.visible = visibility;
+    this.isOrderable = true;
+    this.isHideable = false;
+    this.lastMirrorStorageName = 'catmaid-last-mirror-' +
+        project.id + '-' + stack.id;
+    this.customMirrorStorageName = 'catmaid-custom-mirror-' +
+        project.id + '-' + stack.id;
+
+    if (readState) {
+      var serializedCustomMirrorData = readStateItem(this.customMirrorStorageName);
+      if (serializedCustomMirrorData) {
+        var customMirrorData = JSON.parse(serializedCustomMirrorData);
+        stack.addMirror(customMirrorData);
+      }
+
+      // If no mirror index is given, try to read the last used value from a
+      // cookie. If this is unavailable, use the first mirror as default.
+      if (undefined === mirrorIndex) {
+        var lastUsedMirror = readStateItem(this.lastMirrorStorageName);
+        if (lastUsedMirror) {
+          mirrorIndex = parseInt(lastUsedMirror, 10);
+
+          if (mirrorIndex >= this.stack.mirrors.length) {
+            localStorage.removeItem(this.lastMirrorStorageName);
+            mirrorIndex = undefined;
+          }
+        }
+      }
+    }
+    this._readState = readState;
+
+    this.mirrorIndex = mirrorIndex || 0;
+    this.tileSource = stack.createTileSourceForMirror(this.mirrorIndex);
+
+    /* Whether mirros should be changed automatically if image data is
+     * unavailable.
+     */
+    this.changeMirrorIfNoData = CATMAID.tools.getDefined(changeMirrorIfNoData, true);
+
+    /**
+     * Whether to hide this tile layer if the nearest section is marked as
+     * broken, rather than the default behavior of displaying the nearest
+     * non-broken section.
+     * @type {Boolean}
+     */
+    this.hideIfNearestSliceBroken = CATMAID.StackLayer.Settings.session.hide_if_nearest_section_broken;
+
+
+    /**
+     * True to use linear tile texture interpolation, false to use nearest
+     * neighbor.
+     * @type {boolean}
+     */
+    this._interpolationMode = linearInterpolation;
+
+    CATMAID.checkTileSourceCanary(project, this.stack, this.tileSource)
+        .then(this._handleCanaryCheck.bind(this));
+  }
+
+  var readStateItem = function(key) {
+    var item = localStorage.getItem(key);
+    if (!item) {
+    // Try to load custom mirror from cookie if no local storage information
+    // is found. This is removed in a future release and is only meant to not
+    // cause surprising defaults after an update.
+      item = CATMAID.getCookie(key);
+      if (item) {
+        localStorage.setItem(key, item);
+        // Remove old cookie entry
+        CATMAID.setCookie(key, '', -1);
+      }
+    }
+    return item;
+  };
+
+  /**
+   * Handle a canary tile check for the tile source mirror.
+   *
+   * If the mirror is not accessible, switch to the first accessible mirror
+   * (ordered by mirror preference position). Otherwise, warn that no
+   * accessible mirror is available.
+   *
+   * @param  {Object} accessible Check result with normal and cors booleans.
+   */
+  StackLayer.prototype._handleCanaryCheck = function (accessible) {
+    if (!accessible.normal && this.changeMirrorIfNoData) {
+      Promise
+          .all(this.stack.mirrors.map(function (mirror, index) {
+            return CATMAID.checkTileSourceCanary(
+                project,
+                this.stack,
+                this.stack.createTileSourceForMirror(index));
+          }, this))
+          .then((function (mirrorAccessible) {
+            var mirrorIndex = mirrorAccessible.findIndex(function (accessible) {
+              return accessible.normal;
+            });
+
+            if (mirrorIndex !== -1) {
+              var oldMirrorTitle = this.stack.mirrors[this.mirrorIndex].title;
+              var newMirrorTitle = this.stack.mirrors[mirrorIndex].title;
+              CATMAID.warn('Stack mirror "' + oldMirrorTitle + '" is inaccessible. ' +
+                           'Switching to mirror "' + newMirrorTitle + '".');
+              this.switchToMirror(mirrorIndex);
+            } else {
+              CATMAID.warn('No mirrors for this stack are accessible. Image data may not load.');
+            }
+          }).bind(this));
+    }
+  };
+
+  /**
+   * Sets the interpolation mode for tile textures to linear pixel interpolation
+   * or nearest neighbor.
+   * @param {boolean} linear True for linear, false for nearest neighbor.
+   */
+  StackLayer.prototype.setInterpolationMode = function (linear) {
+    throw new CATMAID.Error('Not implemented');
+  };
+
+  /**
+   * Return friendly name of this layer.
+   */
+  StackLayer.prototype.getLayerName = function () {
+    return this.displayname;
+  };
+
+  /**
+   * Remove any DOM created by this layer from the stack viewer.
+   */
+  StackLayer.prototype.unregister = function () {
+    throw new CATMAID.Error('Not implemented');
+  };
+
+  /**
+   * Update and draw the stack based on the current position and scale.
+   */
+  StackLayer.prototype.redraw = function (completionCallback, blocking) {
+    throw new CATMAID.Error('Not implemented');
+  };
+
+  /**
+   * Resize (if necessary) the layer to cover a view of a specified size.
+   * @param  {number} width  Width of the view in pixels.
+   * @param  {number} height Height of the view in pixels.
+   */
+  StackLayer.prototype.resize = function (width, height, completionCallback, blocking) {
+    throw new CATMAID.Error('Not implemented');
+  };
+
+  /**
+   * Loads stack image data or views centered at specified project locations,
+   * but does not display them, so that they are cached for future viewing.
+   * @param  {number[][]}               locations        an array of project
+   *                                                     coords like:
+   *                                                     [x, y, z]
+   * @param  {function(number, number)} progressCallback
+   */
+  StackLayer.prototype.cacheLocations = function (locations, progressCallback) {
+    throw new CATMAID.Error('Not implemented');
+  };
+
+  /**
+   * Show a dialog that give a user the option to configure a custom mirror.
+   */
+  StackLayer.prototype.addCustomMirror = function () {
+    // Get some default values from the current tile source
+    var mirror = this.stack.mirrors[this.mirrorIndex];
+    var dialog = new CATMAID.OptionsDialog('Add custom mirror');
+    dialog.appendMessage("Please specify at least a URL for the custom mirror");
+    var url = dialog.appendField("URL", "customMirrorURL", "", false);
+    var title = dialog.appendField("Title", "customMirrorTitle", "Custom mirror", false);
+    var ext = dialog.appendField("File extension", "customMirrorExt",
+        mirror.file_extension, false);
+    var tileWidth = dialog.appendField("Tile width", "customMirrorTileWidth",
+        mirror.tile_width, false);
+    var tileHeight = dialog.appendField("Tile height", "customMirrorTileHeight",
+        mirror.tile_height, false);
+    var tileSrcType = dialog.appendField("Tile source type",
+        "customMirrorTileSrcType", mirror.tile_source_type, false);
+    var changeMirrorIfNoDataCb = dialog.appendCheckbox("Change mirror on inaccessible data",
+        "change-mirror-if-no-data", false, "If this is selected, a different mirror is " +
+        "selected automatically, if the custom mirror is unreachable");
+
+    var messageContainer = dialog.appendHTML("Depending of the configuration " +
+      "this mirror, you maybe have to add a SSL certificate exception. To do this, " +
+      "click <a href=\"#\">here</a> after the information above is complete. " +
+      "A new page will open, displaying either an image or a SSL warning. In " +
+      "case of the warning, add a security exception for this (and only this) " +
+      "certificate. Only after having this done and the link shows an image, " +
+      "click OK below.");
+
+    var getMirrorData = function() {
+      var imageBase = url.value;
+      if (!imageBase.endsWith('/')) {
+        imageBase = imageBase + '/';
+      }
+      return {
+        id: "custom",
+        title: title.value,
+        position: -1,
+        image_base: imageBase,
+        file_extension: ext.value,
+        tile_width: parseInt(tileWidth.value, 10),
+        tile_height: parseInt(tileHeight.value, 10),
+        tile_source_type: parseInt(tileSrcType.value, 10)
+      };
+    };
+
+    var openCanaryLink = messageContainer.querySelector('a');
+    var stack = this.stack;
+    openCanaryLink.onclick = function() {
+      var customMirrorData = getMirrorData();
+      var tileSource = CATMAID.getTileSource(
+          customMirrorData.tile_source_type,
+          customMirrorData.image_base,
+          customMirrorData.file_extension,
+          customMirrorData.tile_width,
+          customMirrorData.tile_height);
+      var url = CATMAID.getTileSourceCanaryUrl(project, stack, tileSource);
+      // Open a new browser window with a canary tile
+      var win = window.open(url);
+    };
+
+    var self = this;
+    dialog.onOK = function() {
+      self.changeMirrorIfNoData = changeMirrorIfNoDataCb.checked;
+      var customMirrorData = getMirrorData();
+      var newMirrorIndex = self.stack.addMirror(customMirrorData);
+      self.switchToMirror(newMirrorIndex);
+      localStorage.setItem(self.customMirrorStorageName,
+          JSON.stringify(customMirrorData));
+
+      // Update layer control UI to reflect settings changes.
+      if (self.stackViewer && self.stackViewer.layerControl) {
+        self.layerControl.refresh();
+      }
+    };
+
+    dialog.show(500, 'auto');
+  };
+
+  StackLayer.prototype.clearCustomMirrors = function () {
+    var customMirrorIndices = this.stack.mirrors.reduce(function(o, m, i, mirrors) {
+      if (mirrors[i].id === 'custom') {
+        o.push(i);
+      }
+      return o;
+    }, []);
+    var customMirrorUsed = customMirrorIndices.indexOf(this.mirrorIndex) != -1;
+    if (customMirrorUsed) {
+      CATMAID.warn("Please select another mirror first");
+      return;
+    }
+    customMirrorIndices.sort().reverse().forEach(function(ci) {
+      this.stack.removeMirror(ci);
+    }, this);
+    localStorage.removeItem(this.customMirrorStorageName);
+    this.switchToMirror(this.mirrorIndex, true);
+
+    CATMAID.msg("Done", "Custom mirrors cleared");
+  };
+
+  /**
+   * Returns a set of set settings for this layer. This will only contain
+   * anything if the tile layer's tile source provides additional settings.
+   */
+  StackLayer.prototype.getLayerSettings = function () {
+    var settings = [{
+        name: 'hideIfBroken',
+        displayName: 'Hide if nearest slice is broken',
+        type: 'checkbox',
+        value: this.hideIfNearestSliceBroken,
+        help: 'Hide this tile layer if the nearest section is marked as ' +
+              'broken, rather than the default behavior of displaying the ' +
+              'nearest non-broken section.'
+    },{
+        name: 'changeMirrorIfNoData',
+        displayName: 'Change mirror on inaccessible data',
+        type: 'checkbox',
+        value: this.changeMirrorIfNoData,
+        help: 'Automatically switch to the next accessible mirror if ' +
+              'the current mirror is inaccessible. This is usually recomended ' +
+              'except for some use cases involving custom mirrors.'
+    },{
+      name: 'stackInfo',
+      displayName: 'Stack info',
+      type: 'buttons',
+      buttons: [
+        {
+          name: 'Open',
+          onclick: (function () {WindowMaker.create('stack-info', this.stack.id);}).bind(this)
+        }]
+    },{
+      name: 'mirrorSelection',
+      displayName: 'Stack mirror',
+      type: 'select',
+      value: this.mirrorIndex,
+      options: this.stack.mirrors.map(function (mirror, idx) {
+        return [idx, mirror.title];
+      }),
+      help: 'Select from which image host to request image data for this stack.'
+    }, {
+      name: 'customMirrors',
+      displayName: 'Custom mirrors',
+      type: 'buttons',
+      buttons: [
+        {
+          name: 'Add',
+          onclick: this.addCustomMirror.bind(this)
+        },
+        {
+          name: 'Clear',
+          onclick: this.clearCustomMirrors.bind(this)
+        }]
+    }];
+
+    if (this.tileSource) {
+      settings = settings.concat(this.tileSource.getSettings());
+    }
+
+    return settings;
+  };
+
+  /**
+   * Set a layer setting for this layer. The value will only have any effect if
+   * the layer's tile source accepts setting changes.
+   */
+  StackLayer.prototype.setLayerSetting = function(name, value) {
+    if ('hideIfBroken' === name) {
+      this.hideIfNearestSliceBroken = value;
+      if (!this.hideIfNearestSliceBroken) this.setOpacity(this.opacity);
+    } else if ('efficiencyThreshold' === name) {
+      this.efficiencyThreshold = value;
+      this.redraw();
+    } else if ('mirrorSelection' === name) {
+      this.switchToMirror(value);
+    } else if ('changeMirrorIfNoData' === name) {
+      this.changeMirrorIfNoData = value;
+      // If this was set to true, perform a canary test
+      if (this.changeMirrorIfNoData) {
+        CATMAID.checkTileSourceCanary(project, this.stack, this.tileSource)
+            .then(this._handleCanaryCheck.bind(this));
+      }
+    } else if ('webGL' === name) {
+      if (value) {
+        if (!(this instanceof CATMAID.PixiStackLayer)) {
+          var newStackLayer = this.constructCopy({}, CATMAID.PixiStackLayer);
+          var layerKey = this.stackViewer.getLayerKey(this);
+          this.stackViewer.replaceStackLayer(layerKey, newStackLayer);
+        }
+      } else {
+        if (this instanceof CATMAID.PixiStackLayer) {
+          this.switchToDomStackLayer();
+        }
+      }
+    } else if (this.tileSource && CATMAID.tools.isFn(this.tileSource.setSetting)) {
+      return this.tileSource.setSetting(name, value);
+    }
+  };
+
+  /**
+   * Get the stack.
+   */
+  StackLayer.prototype.getStack = function () { return this.stack; };
+
+  /**
+   * Get the stack viewer.
+   */
+  StackLayer.prototype.getStackViewer = function () { return this.stackViewer; };
+
+  /**
+   * Get the DOM element view for this layer.
+   * @return {Element} View for this layer.
+   */
+  StackLayer.prototype.getView = function () {
+    throw new CATMAID.Error('Not implemented');
+  };
+
+  /**
+   * Create a new stack layer with the same parameters as this stack layer.
+   *
+   * @param  {Object}    override    Constructor arguments to override.
+   * @param  {function=} constructor Optional StackLayer subclass constructor.
+   * @return {StackLayer}            Newly constructed StackLayer subclass.
+   */
+  StackLayer.prototype.constructCopy = function (override, constructor) {
+    if (typeof constructor === 'undefined') constructor = this.constructor;
+    var args = {
+      stackViewer: this.stackViewer,
+      displayName: this.displayName,
+      stack: this.stack,
+      mirrorIndex: this.mirrorIndex,
+      visibility: this.visibility,
+      opacity: this.opacity,
+      showOverview: !!this.overviewLayer,
+      linearInterpolation: this._interpolationMode,
+      readState: this._readState,
+      changeMirrorIfNoData: this.changeMirrorIfNoData
+    };
+    $.extend(args, override);
+    return new constructor(
+        args.stackViewer,
+        args.displayName,
+        args.stack,
+        args.mirrorIndex,
+        args.visibility,
+        args.opacity,
+        args.showOverview,
+        args.linearInterpolation,
+        args.readState,
+        args.changeMirrorIfNoData);
+  };
+
+  /**
+   * Switch to a mirror by replacing this tile layer in the stack viewer
+   * with a new one for the specified mirror index.
+   *
+   * @param  {number}  mirrorIdx Index of a mirror in the stack's mirror array.
+   * @param  {boolean} force     If true, the layer will also be refreshed if
+   *                             the mirror didn't change.
+   */
+  StackLayer.prototype.switchToMirror = function (mirrorIndex, force) {
+    if (mirrorIndex === this.mirrorIndex && !force) return;
+    var newStackLayer = this.constructCopy({mirrorIndex: mirrorIndex});
+    var layerKey = this.stackViewer.getLayerKey(this);
+    this.stackViewer.replaceStackLayer(layerKey, newStackLayer);
+
+    // Store last used mirror information in cookie
+    localStorage.setItem(this.lastMirrorStorageName, mirrorIndex);
+  };
+
+  /**
+   * Set opacity in the range from 0 to 1.
+   * @param {number} val New opacity.
+   */
+  StackLayer.prototype.setOpacity = function (val) {
+    throw new CATMAID.Error('Not implemented');
+  };
+
+  /**
+   * Get the layer opacity.
+   */
+  StackLayer.prototype.getOpacity = function () {
+    return this.opacity;
+  };
+
+  StackLayer.Settings = new CATMAID.Settings(
+      // Note that for legacy compatibility this settings name is still
+      // 'tile-layer'.
+      'tile-layer',
+      {
+        version: 0,
+        entries: {
+          prefer_webgl: {
+            default: true
+          },
+          linear_interpolation: {
+            default: true
+          },
+          hide_if_nearest_section_broken: {
+            default: false
+          }
+        },
+        migrations: {}
+      });
+
+  StackLayer.preferredConstructorForStack = function (_stack) {
+    return CATMAID.StackLayer.Settings.session.prefer_webgl ?
+        CATMAID.PixiTileLayer :
+        CATMAID.TileLayer;
+  };
+
+  CATMAID.StackLayer = StackLayer;
+
+})(CATMAID);

--- a/django/applications/catmaid/static/js/layers/tile-layer.js
+++ b/django/applications/catmaid/static/js/layers/tile-layer.js
@@ -54,7 +54,7 @@
 
     this.tilesContainer = document.createElement('div');
     this.tilesContainer.className = 'sliceTiles';
-    this.tilesContainer.classList.add('interpolation-mode-' + (this._interpolationMode ? 'linear' : 'nearest'));
+    this.tilesContainer.classList.add('interpolation-mode-' + this.getEffectiveInterpolationMode());
 
     if (this.tileSource.transposeTiles.has(this.stack.orientation)) {
       // Some tile sources may provide transposed tiles versus CATMAID's
@@ -80,16 +80,15 @@
   TileLayer.prototype = Object.create(CATMAID.StackLayer.prototype);
   TileLayer.prototype.constructor = TileLayer;
 
-  /**
-   * Sets the interpolation mode for tile textures to linear pixel interpolation
-   * or nearest neighbor.
-   * @param {boolean} linear True for linear, false for nearest neighbor.
-   */
-  TileLayer.prototype.setInterpolationMode = function (linear) {
-    this.tilesContainer.classList.remove('interpolation-mode-' + (this._interpolationMode ? 'linear' : 'nearest'));
-    this._interpolationMode = linear;
-    this.tilesContainer.classList.add('interpolation-mode-' + (this._interpolationMode ? 'linear' : 'nearest'));
+  /** @inheritdoc */
+  TileLayer.prototype.setInterpolationMode = function (mode) {
+    CATMAID.StackLayer.prototype.setInterpolationMode.call(this, mode);
+    for (let possible of Object.values(CATMAID.StackLayer.INTERPOLATION_MODES)) {
+      this.tilesContainer.classList.remove('interpolation-mode-' + possible);
+    }
+    this.tilesContainer.classList.add('interpolation-mode-' + this.getEffectiveInterpolationMode());
   };
+
   /**
    * Remove any DOM created by this layer from the stack viewer.
    */

--- a/django/applications/catmaid/static/js/stack-viewer.js
+++ b/django/applications/catmaid/static/js/stack-viewer.js
@@ -1027,7 +1027,17 @@
     if (StackViewer.Settings.session.respect_broken_sections_new_stacks) {
       this._brokenSliceStacks.add(stack);
     }
-    this.addLayer('StackLayer' + stack.id, layer);
+
+    // Create a unique key for this layer.
+    let base_key = 'StackLayer' + stack.id;
+    var key = base_key;
+    var duplicate = 1;
+    while (this._layers.has(key)) {
+      key = base_key + '-' + duplicate;
+      duplicate += 1;
+    }
+
+    this.addLayer(key, layer);
     if (this._tool) {
       this._tool.unregister(this);
       this._tool.register(this);

--- a/django/applications/catmaid/static/js/stack-viewer.js
+++ b/django/applications/catmaid/static/js/stack-viewer.js
@@ -1131,6 +1131,17 @@
     }).bind(this));
   };
 
+  /**
+   * Renderer the WebGL content of this viewer to a URL-encoded type.
+   * @param  {@string} type               URL encoding format, e.g., 'image/png'
+   * @param  {@PIXI.RenderTexture} canvas Target render texture, to reuse.
+   * @return {string}                     URL-encoded content.
+   */
+  StackViewer.prototype.toDataURL = function (type, canvas) {
+    let context = CATMAID.PixiLayer.contexts.get(this);
+    if (context) return context.toDataURL(type, canvas);
+  };
+
   StackViewer.Settings = new CATMAID.Settings(
       'stack-viewer',
       {

--- a/django/applications/catmaid/static/js/stack-viewer.js
+++ b/django/applications/catmaid/static/js/stack-viewer.js
@@ -152,6 +152,10 @@
   $.extend(StackViewer.prototype, new InstanceRegistry());
   StackViewer.prototype.constructor = StackViewer;
 
+  StackViewer.EVENT_STACK_LAYER_ADDED = 'stackviewer_stack_layer_added';
+  StackViewer.EVENT_STACK_LAYER_REMOVED = 'stackviewer_stack_layer_removed';
+  CATMAID.asEventSource(StackViewer);
+
   /**
    * Get a valid Z location based on all stacks that are selected to be
    * respected.
@@ -945,6 +949,8 @@
             this._tool.register(this);
           }
         }
+
+        StackViewer.trigger(StackViewer.EVENT_STACK_LAYER_REMOVED, layer, this);
       }
 
       this.layercontrol.refresh();
@@ -1019,6 +1025,8 @@
       this._tool.register(this);
     }
     this.resize();
+
+    StackViewer.trigger(StackViewer.EVENT_STACK_LAYER_ADDED, layer, this);
   };
 
   /**
@@ -1053,6 +1061,10 @@
     }
 
     this.resize();
+
+    StackViewer.trigger(StackViewer.EVENT_STACK_LAYER_REMOVED, oldLayer, this);
+    StackViewer.trigger(StackViewer.EVENT_STACK_LAYER_ADDED, newLayer, this);
+
     this.layercontrol.refresh();
     this.updateTitle();
     this.redraw();

--- a/django/applications/catmaid/static/js/stack-viewer.js
+++ b/django/applications/catmaid/static/js/stack-viewer.js
@@ -302,9 +302,9 @@
    */
   StackViewer.prototype.updateTitle = function() {
     var title = this.primaryStack.title;
-    var tileLayer = this._layers.get('TileLayer');
-    if (tileLayer) {
-      var mirror = this.primaryStack.mirrors[tileLayer.mirrorIndex];
+    var stackLayer = this._layers.get('StackLayer');
+    if (stackLayer) {
+      var mirror = this.primaryStack.mirrors[stackLayer.mirrorIndex];
       title = title + " | " + mirror.title;
     }
 
@@ -533,7 +533,7 @@
 
 
   /**
-   * align and update the tiles to be ( x, y ) in the image center
+   * align and update the stacks to be ( x, y ) in the image center
    */
   StackViewer.prototype.redraw = function (completionCallback) {
     var allQueued = false, semaphore = 0, layer,
@@ -929,13 +929,13 @@
       this._layers.delete(key);
       this._layerOrder.splice(this._layerOrder.indexOf(key), 1);
 
-      if (layer instanceof CATMAID.TileLayer) {
+      if (layer instanceof CATMAID.StackLayer) {
         var self = this;
         var otherStackLayers = this._layers.forEach(function (otherLayer) {
-          return otherLayer instanceof CATMAID.TileLayer && otherLayer.stack.id === layer.stack.id;
+          return otherLayer instanceof CATMAID.StackLayer && otherLayer.stack.id === layer.stack.id;
         });
 
-        // If this was the last tile layer for a particular stack...
+        // If this was the last stack layer for a particular stack...
         if (!otherStackLayers) {
           // Remove that stack from this stack viewer and update the tool.
           this._stacks = this._stacks.filter(function (s) { return s.id !== layer.stack.id; });
@@ -963,7 +963,7 @@
     if (this._layers.size === 1) return false;
 
     var layer = this._layers.get(key);
-    if ( typeof layer !== "undefined" && layer && layer instanceof CATMAID.TileLayer ) {
+    if ( typeof layer !== "undefined" && layer && layer instanceof CATMAID.StackLayer ) {
       return layer.stack.id !== this.primaryStack.id;
     }
     else
@@ -1000,7 +1000,7 @@
   };
 
   /**
-   * Add a tile layer for a stack to this stack viewer.
+   * Add a stack layer to this stack viewer.
    * @param {Stack} stack The stack associated with this layer.
    * @param {Object} layer The layer to add.
    */
@@ -1013,7 +1013,7 @@
     if (StackViewer.Settings.session.respect_broken_sections_new_stacks) {
       this._brokenSliceStacks.add(stack);
     }
-    this.addLayer('TileLayer' + stack.id, layer);
+    this.addLayer('StackLayer' + stack.id, layer);
     if (this._tool) {
       this._tool.unregister(this);
       this._tool.register(this);
@@ -1022,17 +1022,17 @@
   };
 
   /**
-   * Replace a stack's tile layer with a new one.
+   * Replace a stack's layer with a new one.
    *
    * @param {Object} oldLayerKey Key for the layer to be replaced.
-   * @param {Object} newLayer    New layer, must be a tile layer for the
+   * @param {Object} newLayer    New layer, must be a stack layer for the
    *                             same stack as the existing layer.
    */
   StackViewer.prototype.replaceStackLayer = function (oldLayerKey, newLayer) {
     var oldLayer = this._layers.get(oldLayerKey);
 
     if (!oldLayer || oldLayer.stack !== newLayer.stack) {
-      throw new Error('Can only replace a tile layer with a new tile layer for the same stack.');
+      throw new Error('Can only replace a stack layer with a new layer for the same stack.');
     }
 
     this._layers.set(oldLayerKey, newLayer);

--- a/django/applications/catmaid/static/js/stack-viewer.js
+++ b/django/applications/catmaid/static/js/stack-viewer.js
@@ -970,7 +970,15 @@
 
     var layer = this._layers.get(key);
     if ( typeof layer !== "undefined" && layer && layer instanceof CATMAID.StackLayer ) {
-      return layer.stack.id !== this.primaryStack.id;
+      if (layer.stack.id === this.primaryStack.id) {
+        // If this layer is for the primary stack, it is only removable if
+        // there are other primary stack layers.
+        return this.getLayersOfType(CATMAID.StackLayer)
+          .filter(s => s.stack.id === this.primaryStack.id)
+          .length > 1;
+      }
+
+      return true;
     }
     else
       return false;

--- a/django/applications/catmaid/static/js/stack.js
+++ b/django/applications/catmaid/static/js/stack.js
@@ -578,6 +578,12 @@
     self.removeMirror = function(mirrorIndex) {
       self.mirrors.splice(mirrorIndex, 1);
     };
+
+    self.labelMetadata = function () {
+      if (this.metadata) {
+        return this.metadata.catmaidLabelMeta;
+      }
+    };
   }
 
   /**

--- a/django/applications/catmaid/static/js/tools/cropping-tool.js
+++ b/django/applications/catmaid/static/js/tools/cropping-tool.js
@@ -338,9 +338,9 @@
 
       // For now, present available stacks in order that individual stack
       // viewers are set to.
-      var tileLayers = project.focusedStackViewer.getOrderedLayersOfType(CATMAID.TileLayer);
-      var stacks = tileLayers.map(function(l) {
-        return l.stack;
+      var stackLayers = project.focusedStackViewer.getOrderedLayersOfType(CATMAID.StackLayer);
+      var stacks = stackLayers.map(function(l) {
+        return l.getStack();
       });
 
       // initialize the stacks we offer to crop

--- a/django/applications/catmaid/static/js/widgets/3dviewer.js
+++ b/django/applications/catmaid/static/js/widgets/3dviewer.js
@@ -3641,19 +3641,19 @@
   };
 
   /**
-   * Get a pixel count estimation for loading a whole Z section of all tile
+   * Get a pixel count estimation for loading a whole Z section of all stack
    * layers in the passed in stack viewer for the given zoom level.
    */
   function getZPlanePixelCountEstimate(stackViewer, textureZoomLevel) {
-    let tileLayers = stackViewer.getLayersOfType(CATMAID.TileLayer);
+    let stackLayers = stackViewer.getLayersOfType(CATMAID.StackLayer);
     let pixelCountEstimate = 0;
 
-    for (let i=0; i<tileLayers.length; ++i) {
-      let tileLayer = tileLayers[i];
-      let stack = tileLayer.stack;
+    for (let i=0; i<stackLayers.length; ++i) {
+      let stackLayer = stackLayers[i];
+      let stack = stackLayer.getStack();
       // Estimate number of data to be transferred.
       let zoomLevel = "max" === textureZoomLevel ? stack.MAX_S : Math.min(stack.MAX_S, textureZoomLevel);
-      let tileSource = tileLayer.stack.createTileSourceForMirror(tileLayer.mirrorIndex);
+      let tileSource = stack.createTileSourceForMirror(stackLayer.mirrorIndex);
       let nHTiles = getNZoomedParts(stack.dimension.x, zoomLevel, tileSource.tileWidth);
       let nVTiles = getNZoomedParts(stack.dimension.y, zoomLevel, tileSource.tileHeight);
 

--- a/django/applications/catmaid/static/js/widgets/review.js
+++ b/django/applications/catmaid/static/js/widgets/review.js
@@ -1144,12 +1144,12 @@
       var counterContainer = $('#counting-cache');
       counterContainer.empty();
       project.getStackViewers().forEach(function(stackViewer) {
-        var tilelayer = stackViewer.getLayer('TileLayer');
+        var stackLayer = stackViewer.getLayer('StackLayer');
         // Create loading information text for each stack viewer.
         var layerCounter = document.createElement('div');
         counterContainer.append(layerCounter);
-        if (tilelayer) {
-          tilelayer.cacheLocations(locations,
+        if (stackLayer) {
+          stackLayer.cacheLocations(locations,
               loadImageCallback.bind(self, layerCounter, stackViewer.primaryStack.title));
         }
       });

--- a/django/applications/catmaid/static/js/widgets/settings.js
+++ b/django/applications/catmaid/static/js/widgets/settings.js
@@ -262,9 +262,9 @@
     };
 
     /**
-     * Adds TileLayer settings to the given container.
+     * Adds StackLayer settings to the given container.
      */
-    var addTileLayerSettings = function(container)
+    var addStackLayerSettings = function(container)
     {
       var ds = CATMAID.DOM.addSettingsContainer(container, "Stack view");
 
@@ -320,16 +320,16 @@
       ds.append(wrapSettingsControl(
           CATMAID.DOM.createCheckboxSetting(
               "Prefer WebGL Layers",
-              CATMAID.TileLayer.Settings[SETTINGS_SCOPE].prefer_webgl,
+              CATMAID.StackLayer.Settings[SETTINGS_SCOPE].prefer_webgl,
               'Choose whether to use WebGL or Canvas tile layer rendering when ' +
               'supported by your tile source and browser. Note that your tile ' +
               'source server may need to be <a href="http://enable-cors.org/">' +
               'configured to enable use in WebGL</a>. (Note: you must reload ' +
               'the page for this setting to take effect.)',
               function() {
-                CATMAID.TileLayer.Settings[SETTINGS_SCOPE].prefer_webgl = this.checked;
+                CATMAID.StackLayer.Settings[SETTINGS_SCOPE].prefer_webgl = this.checked;
               }),
-          CATMAID.TileLayer.Settings,
+          CATMAID.StackLayer.Settings,
           'prefer_webgl',
           SETTINGS_SCOPE));
 
@@ -337,14 +337,14 @@
       ds.append(wrapSettingsControl(
           CATMAID.DOM.createCheckboxSetting(
               "Hide layers if nearest section broken",
-              CATMAID.TileLayer.Settings[SETTINGS_SCOPE].hide_if_nearest_section_broken,
+              CATMAID.StackLayer.Settings[SETTINGS_SCOPE].hide_if_nearest_section_broken,
               'Whether to hide tile layers by default if the nearest section ' +
               'is marked as broken, rather than displaying the nearest non-broken ' +
               'section. This can be adjusted for each individual layer.',
               function() {
-                CATMAID.TileLayer.Settings[SETTINGS_SCOPE].hide_if_nearest_section_broken = this.checked;
+                CATMAID.StackLayer.Settings[SETTINGS_SCOPE].hide_if_nearest_section_broken = this.checked;
               }),
-          CATMAID.TileLayer.Settings,
+          CATMAID.StackLayer.Settings,
           'hide_if_nearest_section_broken',
           SETTINGS_SCOPE));
 
@@ -428,7 +428,7 @@
         {name: 'Keep images pixelated (nearest)', id: 'nearest'}
       ];
       interpolationModes.forEach(function(o) {
-        var selected = (o.id === (CATMAID.TileLayer.Settings[SETTINGS_SCOPE].linear_interpolation ? 'linear' : 'nearest'));
+        var selected = (o.id === (CATMAID.StackLayer.Settings[SETTINGS_SCOPE].linear_interpolation ? 'linear' : 'nearest'));
         this.append(new Option(o.name, o.id, selected, selected));
       }, tileInterpolation);
 
@@ -438,15 +438,15 @@
               tileInterpolation,
               'Choose how to interpolate pixel values when image tiles ' +
               'are magnified.'),
-          CATMAID.TileLayer.Settings,
+          CATMAID.StackLayer.Settings,
           'linear_interpolation',
           SETTINGS_SCOPE));
       tileInterpolation.on('change', function(e) {
         var interp = this.value === 'linear';
-        CATMAID.TileLayer.Settings[SETTINGS_SCOPE].linear_interpolation = interp;
+        CATMAID.StackLayer.Settings[SETTINGS_SCOPE].linear_interpolation = interp;
         project.getStackViewers().forEach(function (stackViewer) {
           stackViewer.getLayers().forEach(function (layer) {
-            if (layer instanceof CATMAID.TileLayer) {
+            if (layer instanceof CATMAID.StackLayer) {
               layer.setInterpolationMode(interp);
             }
           });
@@ -1851,7 +1851,7 @@
 
       // Add all settings
       addGeneralSettings(space);
-      addTileLayerSettings(space);
+      addStackLayerSettings(space);
       addGridSettings(space);
       addTracingSettings(space);
 

--- a/django/applications/catmaid/static/js/widgets/stack-viewer-grid.js
+++ b/django/applications/catmaid/static/js/widgets/stack-viewer-grid.js
@@ -595,11 +595,11 @@
 
         var panelStackViewer = new CATMAID.StackViewer(project, stack, panelWindow);
 
-        var tileLayer =  this.sourceStackViewer.getLayer('TileLayer').constructCopy(
+        var stackLayer = this.sourceStackViewer.getLayer('StackLayer').constructCopy(
           {stackViewer: panelStackViewer, displayName: `Image data (${stack.title})`}
           );
 
-        panelStackViewer.addLayer("TileLayer", tileLayer);
+        panelStackViewer.addLayer("StackLayer", stackLayer);
 
         panelStackViewer.layercontrol.refresh();
         this.stackViewers.push(panelStackViewer);

--- a/django/applications/catmaid/urls.py
+++ b/django/applications/catmaid/urls.py
@@ -100,6 +100,7 @@ urlpatterns += [
 urlpatterns += [
     url(r'^(?P<project_id>\d+)/stacks$', stack.stacks),
     url(r'^(?P<project_id>\d+)/stack/(?P<stack_id>\d+)/info$', stack.stack_info),
+    url(r'^(?P<project_id>\d+)/stack/(?P<stack_id>\d+)/groups$', stack.stack_groups),
 ]
 
 # General stack group access

--- a/django/projects/mysite/pipelinefiles.py
+++ b/django/projects/mysite/pipelinefiles.py
@@ -172,6 +172,7 @@ JAVASCRIPT['catmaid'] = {
         'js/tools/roi-tool.js',
         'js/tools/segmentation-tool.js',
         'js/tools/*.js',
+        'js/layers/stack-layer.js',
         'js/layers/tile-layer.js',
         'js/layers/pixi-layer.js',
         'js/layers/*.js',

--- a/django/projects/mysite/pipelinefiles.py
+++ b/django/projects/mysite/pipelinefiles.py
@@ -179,6 +179,7 @@ JAVASCRIPT['catmaid'] = {
         'js/widgets/detail-dialog.js',
         'js/widgets/options-dialog.js',
         'js/3d/*.js',
+        'js/label-annotations.js',
         'js/widgets/*.js',
     ),
     'output_filename': 'js/catmaid.js',


### PR DESCRIPTION
This is the first block of changes from #1801.

The main new functionality of this branch is that stacks whose metadata has a special property, `catmaidLabelMeta`, will automatically be rendered as label stacks. Label stacks are rendered with a color map filter and with nearest neighbor interpolation. The selected label ID in these stacks is synchronized between stacks that are views of the same group.

Note that in this PR, few of these features are available without using the console. For example, methods are added for retrieving pixel values from stack layers, and those could be used to select label IDs in the label annotation manager, but wiring this functionality is left for later PRs. Most of the changes here are refactorings to enable those PRs.

On a dev note, this is the first code making full use of ES6.