### PR TITLE
Grid based cache option for spatial queries including basic level-of-detail support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,28 @@ Measurement table:
   node filter application can be aggregated into one row by summing individual
   values.
 
+Administration:
+
+- A grid based node query cache can now be used to speed up tracing data
+  retrieval by precomputing intersection results. This can be useful for larger
+  field of views in big data set. It supports multiple levels of detail per grid
+  cell and can therefore provide a somewhat uniform sampling when limiting the
+  number of displayed nodes. The sorting of this LOD configuration can be
+  controlled so that e.g. only the top N largest skeletons will be shown per
+  cell with growing LOD. The documentation has more details. This cache can be
+  kept up updated using two extra worker processes that listen to database
+  changes, implemented as management commands `catmaid_spatial_update_worker`
+  and `catmaid_cache_update_worker`.
+
+- The database can now emit notifications on tracing data changes using the
+  "catmaid.spatial-update" channel and when grid cache cells get marked dirty
+  on the "catmaid.dirty-cacche" channel. These can be subscribed to using
+  Postgres' LISTEN command. To enable emitting these events and let cache update
+  workers work, set `SPATIAL_UPDATE_NOTIFICATIONS = True` in `settings.py`. This
+  is disabled by default, because sending events for spatial cache updates can
+  add slightly more time to spatial queries, which will mainly be relevant for
+  importing and merging large skeleotons.
+
 Miscellaneous:
 
 - Add a new Tracing Tool icon button to compute the distance between two nodes

--- a/django/applications/catmaid/apps.py
+++ b/django/applications/catmaid/apps.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from catmaid import history
+from catmaid import history, spatial
 
 from django.apps import AppConfig
 from django.conf import settings
@@ -95,12 +95,31 @@ def check_history_setup(app_configs, **kwargs):
     # Ignore silently, if the database wasn't migrated yet.
     if getattr(settings, 'HISTORY_TRACKING', True):
         run = history.enable_history_tracking(True)
+        logger.info('History tracking enabled')
     else:
         run = history.disable_history_tracking(True)
+        logger.info('History tracking disabled')
 
     if not run:
         messages.append(Warning(
             "Couldn't check history setup, missing database functions",
+            hint="Migrate CATMAID"))
+    return messages
+
+def check_spatial_update_setup(app_configs, **kwargs):
+    messages = []
+    # Enable or disable history tracking, depending on the configuration.
+    # Ignore silently, if the database wasn't migrated yet.
+    if getattr(settings, 'SPATIAL_UPDATE_NOTIFICATIONS', False):
+        run = spatial.enable_spatial_update_events(True)
+        logger.info('Spatial update events enabled')
+    else:
+        run = spatial.disable_spatial_update_events(True)
+        logger.info('Spatial update events disabled')
+
+    if not run:
+        messages.append(Warning(
+            "Couldn't check spatial update notification setup, missing database functions",
             hint="Migrate CATMAID"))
     return messages
 
@@ -147,6 +166,9 @@ class CATMAIDConfig(AppConfig):
 
         # Register history checks
         register(check_history_setup)
+
+        # Enable or disable spatial update notifications
+        register(check_spatial_update_setup)
 
     # A list of settings that are expected to be available.
     required_setting_fields = {

--- a/django/applications/catmaid/control/node.py
+++ b/django/applications/catmaid/control/node.py
@@ -2107,7 +2107,7 @@ def node_list_tuples(request, project_id=None, provider=None):
 
 def _node_list_tuples_query(params, project_id, node_provider,
         explicit_treenode_ids=tuple(), explicit_connector_ids=tuple(),
-        include_labels=False, with_relation_map=True):
+        include_labels=False, with_relation_map='used'):
     """The returned JSON data is sensitive to indices in the array, so care
     must be taken never to alter the order of the variables in the SQL
     statements without modifying the accesses to said data both in this

--- a/django/applications/catmaid/control/node.py
+++ b/django/applications/catmaid/control/node.py
@@ -2,9 +2,12 @@
 
 import copy
 import json
+import math
 import msgpack
 import ujson
 import psycopg2.extras
+import progressbar
+import struct
 
 from collections import defaultdict
 from abc import ABCMeta
@@ -101,8 +104,16 @@ def get_extra_nodes(params, project_id, explicit_treenode_ids,
         explicit_treenode_ids, explicit_connector_ids, include_labels,
         with_relation_map)
 
-class CachedJsonNodeNodeProvder(BasicNodeProvider):
-    """Retrieve cached msgpack data from the node_query_cache table.
+class CachedNodeProvider(BasicNodeProvider):
+    """A node provider that is based on cached data.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cache_id = kwargs.get('cache_id')
+
+class CachedJsonNodeNodeProvder(CachedNodeProvider):
+    """Retrieve cached JSON data from the node_query_cache table.
     """
 
     def get_tuples(self, params, project_id, explicit_treenode_ids,
@@ -140,8 +151,8 @@ class CachedJsonNodeNodeProvder(BasicNodeProvider):
             return None, None
 
 
-class CachedJsonTextNodeProvder(BasicNodeProvider):
-    """Retrieve cached msgpack data from the node_query_cache table.
+class CachedJsonTextNodeProvder(CachedNodeProvider):
+    """Retrieve cached JSON text data from the node_query_cache table.
     """
 
     def get_tuples(self, params, project_id, explicit_treenode_ids,
@@ -180,7 +191,7 @@ class CachedJsonTextNodeProvder(BasicNodeProvider):
             return None, None
 
 
-class CachedMsgpackNodeProvder(BasicNodeProvider):
+class CachedMsgpackNodeProvder(CachedNodeProvider):
     """Retrieve cached msgpack data from the node_query_cache table.
     """
 
@@ -221,6 +232,207 @@ class CachedMsgpackNodeProvder(BasicNodeProvider):
         else:
             return None, None
 
+
+def get_pack_array_header(n):
+    """Return binary header for msgpack conform array header. This is is size
+    dependent. See:
+    https://github.com/msgpack/msgpack-python/blob/8b6ce53cce40e528af7cce89f358f7dde1a09289/msgpack/fallback.py#L907
+    """
+    if n <= 0x0f:
+        return struct.pack('B', 0x90 + n)
+    if n <= 0xffff:
+        return struct.pack(">BH", 0xdc, n)
+    if n <= 0xffffffff:
+        return struct.pack(">BI", 0xdd, n)
+    raise ValueError("Array is too large")
+
+
+class GridCachedNodeProvider(CachedNodeProvider):
+    """Find nodes in node grid caches.
+    """
+
+    data_type = 'json'
+
+    def update_tuples(self, target, decoded_extra_tuples, encoded_extra_tuples=None):
+        if self.data_type == 'json':
+            if len(target) == 5:
+                target.append([])
+            extra_tuples = target[5]
+            extra_tuples.extend(encoded_extra_tuples)
+            extra_tuples.extend(decoded_extra_tuples)
+            return target
+        elif self.data_type == 'json_text':
+            target_json = json.dumps(decoded_extra_tuples)
+            if encoded_extra_tuples:
+                for eet in encoded_extra_tuples:
+                    if eet:
+                        if eet[-1] == ']':
+                            target_json = '[' + eet + ', ' + target_json[1:]
+                        else:
+                            raise ValueError("Unexpected encoded JSON text tuple format")
+            if target[-2] == '}':
+                # If cached response doesn't contain any extra nodes, add a
+                # new field
+                return target[0:-1] + ', ' + target_json + ']'
+            elif tuples[-2] == ']':
+                return target[0:-2] + ', ' + target_json[1:] + ']'
+            else:
+                raise ValueError("Unexpected cached JSON text tuple format")
+        elif self.data_type == 'msgpack':
+            total_extra_tuples = len(decoded_extra_tuples)
+            if encoded_extra_tuples:
+                total_extra_tuples += len(encoded_extra_tuples)
+            # To inject msgpack data, we first check the binary data
+            # representing the list length. In the eaiest case, we have five
+            # elements (\x95) and we can just append the data and change the
+            # list length.
+            if target[0] == b'\x95':
+                # Construct a new msgpack array manually to not create
+                # unnecessary copies.
+                extra_msgpack = b''
+                if encoded_extra_tuples:
+                    extra_msgpack = b''.join(t for t in encoded_extra_tuples if t)
+                    total_extra_tuples -= sum(1 for t in encoded_extra_tuples if not t)
+                else:
+                    extra_msgpack = b''
+
+                for det in decoded_extra_tuples:
+                    extra_msgpack += msgpack.packb(det)
+                bin_len = get_pack_array_header(total_extra_tuples)
+
+                # Extend the five-element list with extra tuples by making it a
+                # six element list and just appending the extra list
+                return bytes(b'\x96' + target[1:] + bin_len + extra_msgpack)
+            else:
+                raise ValueError("Unexpected cached Msgpack tuple format")
+        else:
+            raise ValueError("Unexpected cached JSON tuple format")
+
+    def get_tuples(self, params, project_id, explicit_treenode_ids,
+            explicit_connector_ids, include_labels, with_relation_map):
+        # Find a fitting grid index, return empty result if there is none.
+        cursor = connection.cursor()
+        params['volume'] = (params['right'] - params['left']) * \
+                (params['bottom'] - params['top']) * (params['z2'] - params['z1'])
+
+        # For JSONB type cache, use ujson to decode, this is roughly 2x faster
+        psycopg2.extras.register_default_jsonb(loads=ujson.loads)
+        # Find grid that has a cell configuration closest to what we are looking for.
+        cursor.execute("""
+            SELECT id, cell_width, cell_height, cell_depth, n_lod_levels
+            FROM node_grid_cache g
+            WHERE project_id = %(project_id)s
+            ORDER BY @((g.cell_width::double precision * g.cell_height::double precision * g.cell_depth::double precision) - %(volume)s::double precision) ASC
+            LIMIT 1;
+        """, params)
+
+        grid_data = cursor.fetchone()
+        if not grid_data:
+            return None, None
+
+        grid_id, cell_width, cell_height, cell_depth, lod_levels = grid_data[0], \
+                grid_data[1], grid_data[2], grid_data[3], grid_data[4]
+
+        min_w_i = int(params['left'] // cell_width)
+        min_h_i = int(params['top'] // cell_height)
+        min_d_i = int(params['z1'] // cell_depth)
+
+        max_w_i = int(params['right'] // cell_width)
+        max_h_i = int(params['bottom'] // cell_height)
+        max_d_i = int(params['z2'] // cell_depth)
+
+        # Get the LOD this query wants to work with. It defines the index in the
+        # data array up to which entries will be read for the data returned to
+        # the caller. For instance, an LOD of 1 means, only the first entry
+        # (index 0) will be read. An LOD of 4 means, the first four entries will
+        # be read. What this means exactly in terms of nodes is defined by the
+        # grid cache itself in terms of its bucket size and bucket count (levels).
+        lod_min = 1
+        lod = params.get('lod', 'max')
+        lod_max = lod_levels if lod == 'max' or lod in (0, '0') else min(int(lod), lod_levels)
+
+        # Do the actual grid cell lookup in a separate query, to only use
+        # constant values in the index checks. The Z index condition is slightly
+        # special, because the parameter is exclusive
+        cursor.execute("""
+            SELECT {data_type_column}[%(lod_min)s:%(lod_max)s]
+            FROM node_grid_cache_cell c
+            LEFT JOIN dirty_node_grid_cache_cell dc
+                -- Alternative: use ON dc.id = c.id and have update function
+                -- create ID entries in the dirty table.
+                ON dc.grid_id = c.grid_id
+                AND dc.x_index = c.x_index
+                AND dc.y_index = c.y_index
+                AND dc.z_index = c.z_index
+            WHERE c.grid_id = %(grid_id)s
+                AND c.x_index >= %(min_x_index)s AND c.x_index <= %(max_x_index)s
+                AND c.y_index >= %(min_y_index)s AND c.y_index <= %(max_y_index)s
+                AND c.z_index >= %(min_z_index)s AND c.z_index < %(max_z_index)s
+                AND {data_type_column} IS NOT NULL
+        """.format(**{
+            'data_type_column': self.data_type + '_data',
+        }), {
+            'grid_id': grid_id,
+            'min_x_index': min_w_i,
+            'min_y_index': min_h_i,
+            'min_z_index': min_d_i,
+            'max_x_index': max_w_i,
+            'max_y_index': max_h_i,
+            'max_z_index': max_d_i,
+            'lod_min': lod_min,
+            'lod_max': lod_max,
+        })
+        rows = cursor.fetchall()
+
+        if rows and rows[0]:
+            # It is the first LOD of the LOD set of the first result cell.
+            first_cell_lods = rows[0][0]
+            tuples = first_cell_lods[0]
+
+            # All extra LODs that are included are transmitted as extra tuples.
+            extra_lod_cells = first_cell_lods[1:]
+            encoded_extra_tuples = [r for r in extra_lod_cells if r]
+
+            # Add all result LODs of each returned grid cell to extra tuples
+            for extra_row in rows[1:]:
+                encoded_extra_tuples.extend(r for r in extra_row[0])
+
+            # If there are exta nodes required, query them explicitely using a
+            # regular Postgis 2D query. Inject the result into cached data.
+            decoded_extra_tuples = None
+            if explicit_treenode_ids or explicit_connector_ids:
+                decoded_extra_tuples, extra_type = get_extra_nodes(params, project_id,
+                    explicit_treenode_ids, explicit_connector_ids, include_labels,
+                    with_relation_map)
+                if extra_type != 'json':
+                    raise ValueError("Unexpected type")
+
+            tuples = self.update_tuples(tuples,
+                    [decoded_extra_tuples] if decoded_extra_tuples else [],
+                    encoded_extra_tuples)
+
+            return tuples, self.data_type
+        else:
+            return None, None
+
+
+class GridCachedJsonNodeProvider(GridCachedNodeProvider):
+    data_type = 'json'
+
+
+class GridCachedJsonTextNodeProvider(GridCachedNodeProvider):
+    data_type = 'json_text'
+
+
+class GridCachedMsgpackNodeProvider(GridCachedNodeProvider):
+    data_type = 'msgpack'
+
+    def get_tuples(self, *args, **kwargs):
+        tuples, dt = super().get_tuples(*args, **kwargs)
+        if tuples:
+            return bytes(tuples), dt
+        else:
+            return tuples, dt
 
 class PostgisNodeProvider(BasicNodeProvider, metaclass=ABCMeta):
 
@@ -1065,6 +1277,9 @@ AVAILABLE_NODE_PROVIDERS = {
     'cached_json_text': CachedJsonTextNodeProvder,
     'cached_msgpack': CachedMsgpackNodeProvder,
     'extra_nodes_only': ExtraNodesOnlyNodeProvider,
+    'cached_json_grid': GridCachedJsonNodeProvider,
+    'cached_json_text_grid': GridCachedJsonTextNodeProvider,
+    'cached_msgpack_grid': GridCachedMsgpackNodeProvider,
 }
 
 
@@ -1076,7 +1291,8 @@ CACHE_NODE_PROVIDER_DATA_TYPES = {
 }
 
 
-def get_configured_node_providers(provider_entries, connection=None):
+def get_configured_node_providers(provider_entries, connection=None,
+        enabled_only=False):
     node_providers = []
     for entry in provider_entries:
         options = {}
@@ -1090,8 +1306,10 @@ def get_configured_node_providers(provider_entries, connection=None):
             key = entry
 
         Provider = AVAILABLE_NODE_PROVIDERS.get(key)
+        include = options.get('enabled', True) or not enabled_only
         if Provider:
-            node_providers.append(Provider(connection, **options))
+            if include:
+                node_providers.append(Provider(connection, **options))
         else:
             raise ValueError('Unknown node provider: ' + key)
 
@@ -1122,6 +1340,9 @@ def update_node_query_cache(node_providers=None, log=print, force=False):
         n_largest_skeletons_limit = options.get('n_largest_skeletons_limit', None)
         n_last_edited_skeletons_limit = options.get('n_last_edited_skeletons_limit', None)
         hidden_last_editor_id = options.get('hidden_last_editor_id')
+        lod_levels = options.get('lod_levels')
+        lod_bucket_size = options.get('lod_bucket_size')
+        lod_strategy = options.get('lod_strategy')
 
         data_type = CACHE_NODE_PROVIDER_DATA_TYPES.get(key)
         if not data_type:
@@ -1144,15 +1365,39 @@ def update_node_query_cache(node_providers=None, log=print, force=False):
                     node_limit=node_limit,
                     n_largest_skeletons_limit=n_largest_skeletons_limit,
                     n_last_edited_skeletons_limit=n_last_edited_skeletons_limit,
-                    hidden_last_editor_id=hidden_last_editor_id,
+                    hidden_last_editor_id=hidden_last_editor_id, lod_levels=lod_levels,
+                    lod_bucket_size=lod_bucket_size, lod_strategy=lod_strategy,
                     delete=clean_cache, log=log)
 
 
-def get_tracing_bounding_box(project_id, cursor=None):
+def get_tracing_bounding_box(project_id, cursor=None, bb_limits=None):
     """Return the tracing data bounding box.
     """
     if not cursor:
         cursor = connection.cursor()
+
+    params = {
+        'project_id': project_id,
+    }
+
+    extra_filter = ''
+    if bb_limits:
+        extra_filter = '''
+            AND ST_XMin(edge) >= %(min_x)s
+            AND ST_YMin(edge) >= %(min_y)s
+            AND ST_ZMin(edge) >= %(min_z)s
+            AND ST_XMax(edge) <= %(max_x)s
+            AND ST_YMax(edge) <= %(max_y)s
+            AND ST_ZMax(edge) <= %(max_z)s
+        '''
+        params.update({
+            'min_x': bb_limits[0][0],
+            'min_y': bb_limits[0][1],
+            'min_z': bb_limits[0][2],
+            'max_x': bb_limits[1][0],
+            'max_y': bb_limits[1][1],
+            'max_z': bb_limits[1][2],
+        })
 
     cursor.execute("""
         SELECT ARRAY[ST_XMin(bb.box), ST_YMin(bb.box), ST_ZMin(bb.box)],
@@ -1160,10 +1405,11 @@ def get_tracing_bounding_box(project_id, cursor=None):
         FROM (
             SELECT ST_3DExtent(edge) box FROM treenode_edge
             WHERE project_id = %(project_id)s
+            {extra_filter}
         ) bb;
-    """, {
-        'project_id': project_id
-    })
+    """.format(**{
+        'extra_filter': extra_filter,
+    }), params)
 
     row = cursor.fetchone()
     if not row:
@@ -1171,9 +1417,77 @@ def get_tracing_bounding_box(project_id, cursor=None):
 
     return row
 
+
+def get_lod_buckets(result_tuple, lod_levels, lod_bucket_size, lod_strategy):
+    nodes = result_tuple[0]
+    connectors = result_tuple[1]
+    n_nodes_to_add = len(nodes)
+    n_connectors_to_add = len(connectors)
+
+    # Split data into LOD buckets, assume filtering and sorting has been
+    # done in the node provider.
+    result_buckets = [[]] * lod_levels
+    half_bucket_size = int(lod_bucket_size / 2)
+    connector_slice_end = 0
+    node_slice_end = 0
+    n_total_imported_nodes = 0
+    for lod_level in range(0, lod_levels):
+        node_slice_start = node_slice_end
+        connector_slice_start = connector_slice_end
+        if lod_level == lod_levels - 1:
+            # Last log level takes all remaining elements
+            node_slice_end = len(result_tuple[0])
+            connector_slice_end = len(result_tuple[1])
+        elif lod_strategy == 'linear':
+            offset = half_bucket_size
+        elif lod_strategy == 'quadratic':
+            offset = int(half_bucket_size * (lod_level + 1) ** 2)
+        elif lod_strategy == 'exponential':
+            offset = int(half_bucket_size * 2 ** lod_level)
+        else:
+            raise ValueError("Unknown LOD strategy: {}".format(lod_strategy))
+
+        node_slice_end = min(n_nodes_to_add, node_slice_end + offset)
+        connector_slice_end =  min(n_connectors_to_add, connector_slice_start + offset)
+
+        # Try to reuse unused connector half for nodes and vice versa
+        availble_nodes = offset - (node_slice_end - node_slice_start)
+        availble_connector_nodes = offset - (connector_slice_end - connector_slice_start)
+        if availble_connector_nodes:
+            if node_slice_end < n_nodes_to_add:
+                node_slice_end = min(node_slice_end, node_slice_end + availble_connector_nodes)
+        if availble_nodes:
+            if connector_slice_end < n_connectors_to_add:
+                connector_slice_end = min(connector_slice_end, connector_slice_end + availble_nodes)
+
+        n_imported_entries = (node_slice_end - node_slice_start) + \
+                (connector_slice_end - connector_slice_start)
+        n_total_imported_nodes += n_imported_entries
+        if n_imported_entries:
+            # Format: [[treenodes], [connectors], {labels}, node_limit_reached,
+            # {relation_map}, {exstraNodes}]
+            result_buckets[lod_level] = [
+                result_tuple[0][node_slice_start:node_slice_end],
+                result_tuple[1][connector_slice_start:connector_slice_end],
+                {}, False, {},
+            ]
+
+    # Provide data other than treenodes and connectors in first bucket. In case
+    # there was no data in the first place, assign the original result to the
+    # first bucket.
+    if result_buckets[0]:
+        for col in range(2, len(result_tuple)):
+            result_buckets[0][col] = result_tuple[col]
+    else:
+        result_buckets[0] = result_tuple
+
+    return result_buckets
+
+
 def update_cache(project_id, data_type, orientations, steps, node_limit=None,
         n_largest_skeletons_limit=None, n_last_edited_skeletons_limit=None,
-        hidden_last_editor_id=None, delete=False, bb_limits=None, log=print):
+        hidden_last_editor_id=None, lod_levels=1, lod_bucket_size=500,
+        lod_strategy='quadratic', delete=False, bb_limits=None, log=print):
     if data_type not in ('json', 'json_text', 'msgpack'):
         raise ValueError('Type must be one of: json, json_text, msgpack')
     if len(steps) != len(orientations):
@@ -1235,12 +1549,15 @@ def update_cache(project_id, data_type, orientations, steps, node_limit=None,
     if n_last_edited_skeletons_limit:
         params['n_last_edited_skeletons_limit'] = int(n_last_edited_skeletons_limit)
         log((' -> Allowing {} most recently edited skeletons in the '
-                'field of view in eeach section'). format(n_last_edited_skeletons_limit))
+                'field of view in each section'). format(n_last_edited_skeletons_limit))
 
     if hidden_last_editor_id:
         param['hidden_last_editor_id'] = int(hidden_last_editor_id)
         log((' -> Only nodes not edited last by user {} will be allowed'.format(
                 hidden_last_editor_id)))
+
+    log(' -> Level-of-detail steps: {}, bucket size: {}, strategy: {}'.format(
+            lod_levels, lod_bucket_size, lod_strategy))
 
     min_z = bb[0][2]
     max_z = bb[1][2]
@@ -1250,7 +1567,8 @@ def update_cache(project_id, data_type, orientations, steps, node_limit=None,
     update_json_text_cache = 'json_text' in data_types
     update_msgpack_cache = 'msgpack' in data_types
 
-    provider = Postgis2dNodeProvider()
+    # TODO: Use matching settings node provider
+    provider = Postgis3dNodeProvider()
     types = ', '.join(data_types)
 
     for o, step in zip(orientations, steps):
@@ -1261,35 +1579,306 @@ def update_cache(project_id, data_type, orientations, steps, node_limit=None,
             params['z1'] = z
             params['z2'] = z + step
             result_tuple = _node_list_tuples_query(params, project_id, provider)
+            result_buckets = get_lod_buckets(result_tuple, lod_levels,
+                    lod_bucket_size, lod_strategy)
 
             if update_json_cache:
                 data = ujson.dumps(result_tuple)
                 cursor.execute("""
-                    INSERT INTO node_query_cache (project_id, orientation, depth, update_time, json_data)
-                    VALUES (%s, %s, %s, now(), %s)
+                    INSERT INTO node_query_cache (project_id, orientation, depth,
+                        update_time, n_lod_levels, lod_min_bucket_size, json_data)
+                    VALUES (%s, %s, %s, now(), %s, %s %s)
                     ON CONFLICT (project_id, orientation, depth)
                     DO UPDATE SET json_data = EXCLUDED.json_data, update_time = EXCLUDED.update_time;
-                """, (project_id, orientation_id, z, json.dumps(result_tuple)))
+                """, (project_id, orientation_id, z, lod_levels, lod_bucket_size,
+                        [None if not v else json.dumps(v) for v in result_buckets]))
 
             if update_json_text_cache:
                 data = ujson.dumps(result_tuple)
                 cursor.execute("""
-                    INSERT INTO node_query_cache (project_id, orientation, depth, update_time, json_text_data)
-                    VALUES (%s, %s, %s, now(), %s)
+                    INSERT INTO node_query_cache (project_id, orientation, depth,
+                        update_time, n_lod_levels, lod_min_bucket_size, json_text_data)
+                    VALUES (%s, %s, %s, now(), %s, %s, %s)
                     ON CONFLICT (project_id, orientation, depth)
                     DO UPDATE SET json_text_data = EXCLUDED.json_text_data, update_time = EXCLUDED.update_time;
-                """, (project_id, orientation_id, z, json.dumps(result_tuple)))
+                """, (project_id, orientation_id, z, lod_levels, lod_bucket_size,
+                        [None if not v else json.dumps(v) for v in result_buckets]))
 
             if update_msgpack_cache:
-                data = msgpack.packb(result_tuple)
                 cursor.execute("""
-                    INSERT INTO node_query_cache (project_id, orientation, depth, update_time, msgpack_data)
+                    INSERT INTO node_query_cache (project_id, orientation, depth,
+                        update_time, n_lod_levels, lod_bucket_size, msgpack_data)
                     VALUES (%s, %s, %s, now(), %s)
                     ON CONFLICT (project_id, orientation, depth)
                     DO UPDATE SET msgpack_data = EXCLUDED.msgpack_data, update_time = EXCLUDED.update_time;
-                """, (project_id, orientation_id, z, psycopg2.Binary(data)))
+                """, (project_id, orientation_id, z, lod_levels, lod_bucket_size,
+                        [None if not v else psycopg2.Binary(msgpack.packb(v)) for v in result_buckets]))
 
             z += step
+
+
+def update_grid_cache(project_id, data_type, orientations,
+        cell_width=settings.DEFAULT_CACHE_GRID_CELL_WIDTH,
+        cell_height=settings.DEFAULT_CACHE_GRID_CELL_HEIGHT,
+        cell_depth=settings.DEFAULT_CACHE_GRID_CELL_DEPTH,
+        node_limit=None, n_largest_skeletons_limit=None,
+        n_last_edited_skeletons_limit=None, hidden_last_editor_id=None,
+        delete=False, bb_limits=None, log=print, progress=True,
+        allow_empty=False, lod_levels=1, lod_bucket_size=500,
+        lod_strategy='quadratic'):
+    if data_type not in ('json', 'json_text', 'msgpack'):
+        raise ValueError('Type must be one of: json, json_text, msgpack')
+    if project_id is None:
+        raise ValueError('Need project ID')
+    if not cell_width:
+        raise ValueError('Need non-zero cell width information')
+    if not cell_height:
+        raise ValueError('Need non-zero cell height information')
+    if not cell_depth:
+        raise ValueError('Need non-zero cell depth information')
+
+    orientation_ids = list(map(lambda x: ORIENTATIONS[x], orientations))
+
+    cursor = connection.cursor()
+
+    log(' -> Finding tracing data bounding box')
+    row = get_tracing_bounding_box(project_id, cursor, bb_limits)
+    bb = [row[0], row[1]]
+    if None in bb[0] or None in bb[1]:
+        log(' -> Found no valid bounding box, skipping project: {}'.format(bb))
+        return
+    if bb_limits:
+        bb[0][0] = max(bb[0][0], bb_limits[0][0])
+        bb[0][1] = max(bb[0][1], bb_limits[0][1])
+        bb[0][2] = max(bb[0][2], bb_limits[0][2])
+        bb[1][0] = min(bb[1][0], bb_limits[1][0])
+        bb[1][1] = min(bb[1][1], bb_limits[1][1])
+        bb[1][2] = min(bb[1][2], bb_limits[1][2])
+        log(' -> Found bounding box within limits: {}'.format(bb))
+    else:
+        log(' -> Found bounding box: {}'.format(bb))
+
+    if delete:
+        for n, o in enumerate(orientations):
+            orientation_id = orientation_ids[n]
+            log(' -> Deleting existing grid cache entries in orientation {}'.format(project_id, o))
+            cursor.execute("""
+                DELETE FROM node_grid_cache
+                WHERE project_id = %(project_id)s
+                AND orientation = %(orientation)s
+                CASCADE
+            """, {
+                'project_id': project_id,
+                'orientation': orientation_id
+            })
+
+    params = {
+        'left':   bb[0][0],
+        'top':    bb[0][1],
+        'z1':     bb[0][2],
+        'right':  bb[1][0],
+        'bottom': bb[1][1],
+        'z2':     bb[1][2],
+        'project_id': project_id,
+        'limit':  node_limit
+    }
+
+    if n_largest_skeletons_limit:
+        params['n_largest_skeletons_limit'] = int(n_largest_skeletons_limit)
+        log((' -> Allowing {} largest skeletons in the field of view in '
+                'each section').format(n_largest_skeletons_limit))
+
+    if n_last_edited_skeletons_limit:
+        params['n_last_edited_skeletons_limit'] = int(n_last_edited_skeletons_limit)
+        log((' -> Allowing {} most recently edited skeletons in the '
+                'field of view in each section'). format(n_last_edited_skeletons_limit))
+
+    if hidden_last_editor_id:
+        param['hidden_last_editor_id'] = int(hidden_last_editor_id)
+        log((' -> Only nodes not edited last by user {} will be allowed'.format(
+                hidden_last_editor_id)))
+
+    data_types = [data_type]
+    update_json_cache = 'json' in data_types
+    update_json_text_cache = 'json_text' in data_types
+    update_msgpack_cache = 'msgpack' in data_types
+
+    provider = Postgis3dNodeProvider()
+    types = ', '.join(data_types)
+
+    for o in orientations:
+        orientation_id = ORIENTATIONS[o]
+        log(' -> Populating grid cache for orientation {} with block size {} (x, y, z) for types: {}'.format(
+                o, (cell_width, cell_height, cell_depth), types))
+
+        cursor.execute("""
+            SELECT id
+            FROM node_grid_cache
+            WHERE project_id = %(project_id)s
+                AND orientation = %(orientation)s
+                AND cell_width = %(cell_width)s
+                AND cell_height = %(cell_height)s
+                AND cell_depth = %(cell_depth)s
+            ORDER BY cell_width, cell_height, cell_depth DESC
+        """, {
+            'project_id': project_id,
+            'orientation': orientation_id,
+            'cell_width': cell_width,
+            'cell_height': cell_height,
+            'cell_depth': cell_depth,
+            'n_largest_sk_limit': n_largest_skeletons_limit or None,
+            'n_last_edit_limit': n_last_edited_skeletons_limit or None,
+            'hidden_last_editor_id': hidden_last_editor_id or None,
+        })
+        grid_ids = cursor.fetchall()
+        if grid_ids:
+            grid_id = grid_ids[0]
+        else:
+            cursor.execute("""
+                INSERT INTO node_grid_cache (project_id, orientation,
+                    cell_width, cell_height, cell_depth, n_largest_skeletons_limit,
+                    n_last_edited_skeletons_limit, hidden_last_editor_id,
+                    n_lod_levels, lod_min_bucket_size, lod_strategy, allow_empty,
+                    has_json_data, has_json_text_data, has_msgpack_data)
+                VALUES (%(project_id)s, %(orientation)s, %(cell_width)s,
+                    %(cell_height)s, %(cell_depth)s, %(n_largest_sk_limit)s,
+                    %(n_last_edit_limit)s, %(hidden_last_editor_id)s,
+                    %(n_lod_levels)s, %(lod_min_bucket_size)s, %(lod_strategy)s,
+                    %(allow_empty)s, %(has_json_data)s, %(has_json_text_data)s,
+                    %(has_msgpack_data)s)
+                RETURNING id;
+            """, {
+                'project_id': project_id,
+                'orientation': orientation_id,
+                'cell_width': cell_width,
+                'cell_height': cell_height,
+                'cell_depth': cell_depth,
+                'n_largest_sk_limit': n_largest_skeletons_limit or None,
+                'n_last_edit_limit': n_last_edited_skeletons_limit or None,
+                'hidden_last_editor_id': hidden_last_editor_id or None,
+                'n_lod_levels': lod_levels or None,
+                'lod_min_bucket_size': lod_bucket_size or None,
+                'lod_strategy': lod_strategy or None,
+                'allow_empty': allow_empty,
+                'has_json_data': update_json_cache,
+                'has_json_text_data': update_json_text_cache,
+                'has_msgpack_data': update_msgpack_cache,
+            })
+            grid_id = cursor.fetchone()[0]
+
+        # Only look at cells that cover the bounding box
+        min_w_i = int(params['left'] // cell_width)
+        min_h_i = int(params['top'] // cell_height)
+        min_d_i = int(params['z1'] // cell_depth)
+
+        max_w_i = int(params['right'] // cell_width)
+        max_h_i = int(params['bottom'] // cell_height)
+        max_d_i = int(params['z2'] // cell_depth)
+
+        n_cells_w = max_w_i - min_w_i + 1
+        n_cells_h = max_h_i - min_h_i + 1
+        n_cells_d = max_d_i - min_d_i + 1
+        n_cells = n_cells_w * n_cells_h * n_cells_d
+
+        log(' -> Grid dimension (cells per dimension X, Y and Z): {}, {}, {} Total cells: {}'.format(
+                n_cells_w, n_cells_h, n_cells_d, n_cells))
+
+        log(' -> Level-of-detail steps: {}, bucket size: {}, strategy: {}'.format(
+                lod_levels, lod_bucket_size, lod_strategy))
+
+        if progress:
+            bar = progressbar.ProgressBar(max_value=n_cells, redirect_stdout=True).start()
+
+        counter = 0
+        created = 0
+        for d_i in range(min_d_i, max_d_i + 1):
+            for h_i in range(min_h_i, max_h_i + 1):
+                for w_i in range(min_w_i, max_w_i + 1):
+                    if progress:
+                        counter += 1
+                        bar.update(counter)
+
+                    added = update_grid_cell(project_id, grid_id, w_i, h_i, d_i,
+                            cell_width, cell_height, cell_depth, provider,
+                            params, allow_empty, lod_levels, lod_bucket_size,
+                            lod_strategy, update_json_cache,
+                            update_json_text_cache, update_msgpack_cache, cursor)
+                    if added:
+                        created += 1
+        log(' -> Materialized {} grid cells'.format(created))
+        if progress:
+            bar.finish()
+
+
+def update_grid_cell(project_id, grid_id, w_i, h_i, d_i, cell_width,
+        cell_height, cell_depth, provider, params, allow_empty, lod_levels,
+        lod_bucket_size, lod_strategy, update_json_cache,
+        update_json_text_cache, update_msgpack_cache, cursor):
+    params['left'] = w_i * cell_width
+    params['right'] = (w_i + 1) * cell_width
+    params['top'] = h_i * cell_height
+    params['bottom'] = (h_i + 1) * cell_width
+    params['z1'] = d_i * cell_depth
+    params['z2'] = (d_i + 1) * cell_depth
+
+    result_tuple = _node_list_tuples_query(params, project_id, provider,
+            include_labels=True)
+
+    if not (allow_empty or result_tuple[0] or result_tuple[1]):
+        return False
+
+    result_buckets = get_lod_buckets(result_tuple, lod_levels,
+            lod_bucket_size, lod_strategy)
+
+    if update_json_cache:
+        cursor.execute("""
+            INSERT INTO node_grid_cache_cell (grid_id,
+                x_index, y_index, z_index, update_time, json_data)
+            VALUES (%(grid_id)s, %(x_index)s, %(y_index)s, %(z_index)s,
+                now(), %(data)s::jsonb[])
+            ON CONFLICT (grid_id, x_index, y_index, z_index)
+            DO UPDATE SET json_data = EXCLUDED.json_data, update_time = EXCLUDED.update_time;
+        """, {
+            'grid_id': grid_id,
+            'x_index': w_i,
+            'y_index': h_i,
+            'z_index': d_i,
+            'data': [None if not v else json.dumps(v) for v in result_buckets],
+        })
+
+    if update_json_text_cache:
+        cursor.execute("""
+            INSERT INTO node_grid_cache_cell (grid_id,
+                x_index, y_index, z_index, update_time, json_text_data)
+            VALUES (%(grid_id)s, %(x_index)s, %(y_index)s, %(z_index)s,
+                now(), %(data)s)
+            ON CONFLICT (grid_id, x_index, y_index, z_index)
+            DO UPDATE SET json_text_data = EXCLUDED.json_text_data, update_time = EXCLUDED.update_time;
+        """, {
+            'grid_id': grid_id,
+            'x_index': w_i,
+            'y_index': h_i,
+            'z_index': d_i,
+            'data': [None if not v else json.dumps(v) for v in result_buckets],
+        })
+
+    if update_msgpack_cache:
+        cursor.execute("""
+            INSERT INTO node_grid_cache_cell (grid_id,
+                x_index, y_index, z_index, update_time, msgpack_data)
+            VALUES (%(grid_id)s, %(x_index)s, %(y_index)s, %(z_index)s,
+                now(), %(data)s)
+            ON CONFLICT (grid_id, x_index, y_index, z_index)
+            DO UPDATE SET msgpack_data = EXCLUDED.msgpack_data, update_time = EXCLUDED.update_time;
+        """, {
+            'grid_id': grid_id,
+            'x_index': w_i,
+            'y_index': h_i,
+            'z_index': d_i,
+            'data':  [None if not v else psycopg2.Binary(msgpack.packb(v)) for v in result_buckets],
+        })
+
+    return True
 
 
 def prepare_db_statements(connection):
@@ -1488,6 +2077,7 @@ def node_list_tuples(request, project_id=None, provider=None):
             else:
                 orientation = 'xz'
     params['orientation'] = orientation
+    params['lod'] = data.get('lod', 'max')
 
     if override_provider:
         node_providers = get_configured_node_providers([override_provider])

--- a/django/applications/catmaid/management/commands/catmaid_cache_update_worker.py
+++ b/django/applications/catmaid/management/commands/catmaid_cache_update_worker.py
@@ -1,0 +1,199 @@
+import json
+import logging
+import select
+import signal
+import time
+
+from collections import defaultdict
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+from catmaid.control.edge import get_intersected_grid_cells
+from catmaid.control.node import (get_configured_node_providers,
+        GridCachedNodeProvider, Postgis3dNodeProvider, update_grid_cell)
+from catmaid.models import NodeGridCache, DirtyNodeGridCacheCell
+from catmaid.util import str2bool
+
+
+logger = logging.getLogger(__name__)
+
+
+class GridWorker():
+
+    def __init__(self):
+        pass
+
+    def update(self, updates, cursor):
+        """Pop the oldest item from the diry cell table, compute the respective
+        FOV and update the cache cell.
+        """
+        # Get all referenced grids along with their project IDs and node
+        # constraints: n_last_edited_skeletons_limit,
+        # n_last_edited_skeletons_limit, hidden_last_editor_id
+        referenced_grid_ids = set(u['grid_id'] for u in updates)
+        grids = NodeGridCache.objects.filter(pk__in=referenced_grid_ids)
+        grid_map = dict((g.id, g) for g in grids)
+
+        provider = Postgis3dNodeProvider()
+        cursor = connection.cursor()
+
+        # Batch of grids to update during one run
+        grid_coords_to_update = {}
+        updated_cells = 0
+        for update in updates:
+            g = grid_map[update['grid_id']]
+            w_i, h_i, d_i = update['x'], update['y'], update['z']
+
+            params = {
+                'project_id': g.project_id,
+                'limit': settings.NODE_LIST_MAXIMUM_COUNT,
+            }
+            if g.n_last_edited_skeletons_limit:
+                params['n_largest_skeletons_limit'] = int(g.n_largest_skeletons_limit)
+            if g.n_last_edited_skeletons_limit:
+                params['n_last_edited_skeletons_limit'] = int(g.n_last_edited_skeletons_limit)
+            if g.hidden_last_editor_id:
+                param['hidden_last_editor_id'] = int(g.hidden_last_editor_id)
+
+            added = update_grid_cell(g.project_id, g.id, w_i, h_i, d_i,
+                    g.cell_width, g.cell_height, g.cell_depth, provider,
+                    params, g.allow_empty, g.n_lod_levels, g.lod_min_bucket_size,
+                    g.lod_strategy, g.has_json_data, g.has_json_text_data,
+                    g.has_msgpack_data, cursor)
+
+            if added:
+                updated_cells += 1
+
+                # TODO: delete in batches
+                DirtyNodeGridCacheCell.objects.get(grid_id=g.id, x_index=w_i,
+                        y_index=h_i, z_index=d_i).delete()
+
+        logger.debug('Updated {} grid cell(s) in {} grid cache(s)'.format(
+            updated_cells, len(referenced_grid_ids)))
+
+
+class Command(BaseCommand):
+    help = ""
+    # The queue to process. Subclass and set this.
+    queue = []
+    notify_channel = "catmaid.dirty-cache"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--delay',
+            type=float,
+            default=1,
+            help="The number of seconds to wait to check for new tasks.",
+        )
+        parser.add_argument("--grid-cache", type=str2bool, nargs='?',
+                const=True, default=True, help="Update spatial grid caches.")
+
+    def handle(self, **options):
+        self._shutdown = False
+        self._in_task = False
+        self.delay = options['delay']
+        self.grid_cache_update = options['grid_cache']
+
+        self.workers = []
+
+        if options['grid_cache']:
+            self.workers.append(GridWorker())
+
+        if not self.workers:
+            logger.warn("No grids provided")
+            return
+
+        self.listen()
+
+        try:
+            # Handle the signals for warm shutdown.
+            signal.signal(signal.SIGINT, self.handle_shutdown)
+            signal.signal(signal.SIGTERM, self.handle_shutdown)
+
+            while True:
+                #self.run_available_tasks()
+                self.wait_and_queue()
+        except InterruptedError:
+            # got shutdown signal
+            pass
+
+    def handle_shutdown(self, sig, frame):
+        if self._in_task:
+            logger.info('Waiting for active tasks to finish...')
+            self._shutdown = True
+        else:
+            raise InterruptedError
+
+    def run_available_tasks(self):
+        """
+        Runs tasks continuously until there are no more available.
+        """
+        # Prevents tasks that failed from blocking others.
+        failed_tasks = set()
+        while True:
+            job = None
+            self._in_task = True
+            try:
+                job = self.queue.run_once(exclude_ids=failed_tasks)
+            except Exception as e:
+                logger.exception('Error in %r: %r.', e.job, e, extra={
+                    'data': {
+                        'job': e.job.to_json(),
+                    },
+                })
+                failed_tasks.add(e.job.id)
+            self._in_task = False
+            if self._shutdown:
+                raise InterruptedError
+            if not job:
+                break
+
+
+    def listen(self):
+        with connection.cursor() as cur:
+            cur.execute('LISTEN "{}"'.format(self.notify_channel))
+
+
+    def filter_notifies(self):
+        notifies = [
+            i for i in connection.connection.notifies
+            if i.channel == self.notify_channel
+        ]
+        connection.connection.notifies = [
+            i for i in connection.connection.notifies
+            if i.channel != self.notify_channel
+        ]
+        return notifies
+
+
+    def wait(self):
+        connection.connection.poll()
+        notifies = self.filter_notifies()
+        if notifies:
+            return notifies
+
+        select.select([connection.connection], [], [], self.delay)
+        connection.connection.poll()
+        notifies = self.filter_notifies()
+        count = len(self.filter_notifies())
+        logger.debug('Woke up with %s NOTIFYs.', count)
+        return notifies
+
+    def wait_and_queue(self):
+        notifications = self.wait()
+        if notifications:
+            cursor = connection.cursor()
+
+            updates = []
+            for n in notifications:
+                try:
+                    data = json.loads(n.payload)
+                    updates.append(data)
+                except json.decoder.JSONDecodeError:
+                    logger.warn('Could not parse Postgres NOTIFY message: {}'.format(n.payload))
+                    continue
+
+            for worker in self.workers:
+                worker.update(updates, cursor)

--- a/django/applications/catmaid/management/commands/catmaid_spatial_update_worker.py
+++ b/django/applications/catmaid/management/commands/catmaid_spatial_update_worker.py
@@ -1,0 +1,291 @@
+import json
+import logging
+import select
+import signal
+import time
+
+from collections import defaultdict
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+from catmaid.control.edge import get_intersected_grid_cells
+from catmaid.control.node import (get_configured_node_providers,
+        GridCachedNodeProvider)
+from catmaid.models import NodeGridCache
+from catmaid.util import str2bool
+
+
+logger = logging.getLogger(__name__)
+
+
+class GridWorker():
+
+    def __init__(self):
+        # Keep a reference to all enabled grid caches
+        enabled_node_providers = get_configured_node_providers(
+                settings.NODE_PROVIDERS, enabled_only=True)
+
+        enabled_grid_cache_providers = list(filter(lambda x: isinstance(x,
+                GridCachedNodeProvider), enabled_node_providers))
+
+        # Keep track of received events
+        self.updatesReceived = 0
+        self.cellsMarkedDirty = 0
+
+        if enabled_grid_cache_providers:
+            logger.info("Found {} enabled grid cache provider(s)".format(len(enabled_grid_cache_providers)))
+        else:
+            logger.info("Could not find any enabled grid cache provider")
+
+        # Find a grid cache for each provider and make sure each cache is only
+        # referenced onece
+        self.grid_caches = []
+        for provider in enabled_grid_cache_providers:
+            # If a particular cache is referenced explicitly, use it if it is
+            # enabled.
+            if provider.cache_id is not None:
+                grid_cache = NodeGridCache.get(pk=provider.cache_id,
+                        enabled=True)
+                if grid_cache:
+                    self.grid_caches.append(grid_cache)
+            # Without an explicit ID, get all enabled grid caches
+            else:
+                enabled_grid_caches = list(NodeGridCache.objects.filter(enabled=True))
+                self.grid_caches.extend(enabled_grid_caches)
+
+    def update(self, updates, cursor):
+        """ We want regular node queries to be able to tell whether a particular
+        cache segment is valid. Therefore we queue a new dirty cell entry and
+        send another notify(). Queue entries are then processed by a set of
+        different workers. To do this, get all the enabled grid caches for each
+        project and then, for each notification compute the insected grid
+        indices with each grid, update existing grids and create missing ones.
+        """
+        # Batch of grids to update during one run
+        grid_coords_to_update = {}
+        for update in updates:
+            self.updatesReceived += 1
+            self.get_intersected_grid_cell_ids(update,
+                    cursor, create=True, grid_coords_to_update=grid_coords_to_update)
+
+        dirty_rows = set()
+        for grid_id, coords in grid_coords_to_update.items():
+            for c in coords:
+                self.cellsMarkedDirty += 1
+                key = "({},{},{},{})".format(grid_id, c[0], c[1], c[2])
+                if key not in dirty_rows:
+                    dirty_rows.add(key)
+
+        if dirty_rows:
+            # Mark cells as dirty
+            cursor.execute("""
+                INSERT INTO dirty_node_grid_cache_cell (grid_id, x_index, y_index, z_index)
+                VALUES {data}
+                ON CONFLICT (grid_id, x_index, y_index, z_index)
+                DO UPDATE SET invalidation_time = EXCLUDED.invalidation_time
+            """.format(data=','.join(dirty_rows)))
+
+            logger.debug('Marked {} grid cells as dirty and queued update'.format(
+                len(dirty_rows)))
+
+    def append_cells_to_update(self, coords_to_update, p1, p2, cell_width,
+            cell_height, cell_depth):
+
+        # Find intersecting grid cell indices for each cache and create
+        # the ones that aren't there yet.
+        p1_cell = [
+            int(p1[0] // cell_width),
+            int(p1[1] // cell_height),
+            int(p1[2] // cell_depth),
+        ]
+
+        p2_cell = [
+            int(p2[0] // cell_width),
+            int(p2[1] // cell_height),
+            int(p2[2] // cell_depth),
+        ]
+
+        n_cells = [
+            abs(p2_cell[0] - p1_cell[0]) + 1,
+            abs(p2_cell[1] - p1_cell[1]) + 1,
+            abs(p2_cell[2] - p1_cell[2]) + 1,
+        ]
+
+        n_cells_total = n_cells[0] * n_cells[1] * n_cells[2]
+        if n_cells_total == 1:
+            # Common case, only one cell is changed.
+            coords_to_update.append(p1_cell)
+        else:
+            # Find all intersecting cells in this grid.
+            coords_to_update.extend(get_intersected_grid_cells(p1,
+                p2, cell_width, cell_height, cell_depth, p1_cell, p2_cell))
+
+    def get_intersected_grid_cell_ids(self, data, cursor, create=True,
+            grid_coords_to_update=dict()):
+        """Iterate over all known enabled grid caches and find all intersected
+        cells.
+        """
+        data_type = data['type']
+        # Find all cells to update in each enabled grid
+        for grid_cache in self.grid_caches:
+            grid_id = grid_cache.id
+            coords_to_update = grid_coords_to_update.get(grid_id)
+            if not coords_to_update:
+                coords_to_update = []
+                grid_coords_to_update[grid_id] = coords_to_update
+            cell_width = grid_cache.cell_width
+            cell_height = grid_cache.cell_height
+            cell_depth = grid_cache.cell_depth
+            if data_type == 'edge':
+                p1 = data['p1']
+                p2 = data['p2']
+                self.append_cells_to_update(coords_to_update, p1, p2,
+                        cell_width, cell_height, cell_depth)
+            elif data_type == 'edges':
+                # Format: {"project_id": 1, "type": "edges", "edges": [
+                #    [[595708,418558,40000], [608508,418558,40000]],
+                #    [[595708,418558,40000], [608508,418558,40000]]]}
+                edge_1 = data['edges'][0]
+                edge_2 = data['edges'][1]
+                self.append_cells_to_update(coords_to_update, edge_1[0], edge_1[1],
+                        cell_width, cell_height, cell_depth)
+                self.append_cells_to_update(coords_to_update, edge_2[0], edge_2[1],
+                        cell_width, cell_height, cell_depth)
+            elif data_type == 'point':
+                p = data['p']
+                coords_to_update.append([
+                    int(p[0] // cell_width),
+                    int(p[1] // cell_height),
+                    int(p[2] // cell_depth),
+                ])
+            else:
+                logger.error("Unknown data type: {}".format(data_type))
+
+        return grid_coords_to_update
+
+
+class Command(BaseCommand):
+    help = ""
+    # The queue to process. Subclass and set this.
+    queue = []
+    notify_channel = "catmaid.spatial-update"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--delay',
+            type=float,
+            default=1,
+            help="The number of seconds to wait to check for new tasks.",
+        )
+        parser.add_argument("--grid-cache", type=str2bool, nargs='?',
+                const=True, default=True, help="Update spatial grid caches.")
+
+    def handle(self, **options):
+        self._shutdown = False
+        self._in_task = False
+        self.delay = options['delay']
+        self.grid_cache_update = options['grid_cache']
+
+        self.workers = []
+
+        if options['grid_cache']:
+            self.workers.append(GridWorker())
+
+        if not self.workers:
+            logger.warn("No grids provided")
+            return
+
+        self.listen()
+
+        try:
+            # Handle the signals for warm shutdown.
+            signal.signal(signal.SIGINT, self.handle_shutdown)
+            signal.signal(signal.SIGTERM, self.handle_shutdown)
+
+            while True:
+                #self.run_available_tasks()
+                self.wait_and_queue()
+        except InterruptedError:
+            # got shutdown signal
+            pass
+
+    def handle_shutdown(self, sig, frame):
+        if self._in_task:
+            logger.info('Waiting for active tasks to finish...')
+            self._shutdown = True
+        else:
+            raise InterruptedError
+
+    def run_available_tasks(self):
+        """
+        Runs tasks continuously until there are no more available.
+        """
+        # Prevents tasks that failed from blocking others.
+        failed_tasks = set()
+        while True:
+            job = None
+            self._in_task = True
+            try:
+                job = self.queue.run_once(exclude_ids=failed_tasks)
+            except Exception as e:
+                logger.exception('Error in %r: %r.', e.job, e, extra={
+                    'data': {
+                        'job': e.job.to_json(),
+                    },
+                })
+                failed_tasks.add(e.job.id)
+            self._in_task = False
+            if self._shutdown:
+                raise InterruptedError
+            if not job:
+                break
+
+
+    def listen(self):
+        with connection.cursor() as cur:
+            cur.execute('LISTEN "{}"'.format(self.notify_channel))
+
+
+    def filter_notifies(self):
+        notifies = [
+            i for i in connection.connection.notifies
+            if i.channel == self.notify_channel
+        ]
+        connection.connection.notifies = [
+            i for i in connection.connection.notifies
+            if i.channel != self.notify_channel
+        ]
+        return notifies
+
+
+    def wait(self):
+        connection.connection.poll()
+        notifies = self.filter_notifies()
+        if notifies:
+            return notifies
+
+        select.select([connection.connection], [], [], self.delay)
+        connection.connection.poll()
+        notifies = self.filter_notifies()
+        count = len(self.filter_notifies())
+        logger.debug('Woke up with %s NOTIFYs.', count)
+        return notifies
+
+    def wait_and_queue(self):
+        notifications = self.wait()
+        if notifications:
+            cursor = connection.cursor()
+
+            updates = []
+            for n in notifications:
+                try:
+                    data = json.loads(n.payload)
+                    updates.append(data)
+                except json.decoder.JSONDecodeError:
+                    logger.warn('Could not parse Postgres NOTIFY message: {}'.format(n.payload))
+                    continue
+
+            for worker in self.workers:
+                worker.update(updates, cursor)

--- a/django/applications/catmaid/management/commands/catmaid_update_cache_tables.py
+++ b/django/applications/catmaid/management/commands/catmaid_update_cache_tables.py
@@ -7,7 +7,8 @@ from django.conf import settings
 from django.db import connection
 
 from catmaid.control.node import (_node_list_tuples_query, update_cache,
-        Postgis2dNodeProvider, ORIENTATIONS, update_node_query_cache)
+        Postgis2dNodeProvider, ORIENTATIONS, update_node_query_cache,
+        update_grid_cache)
 from catmaid.models import Project
 
 
@@ -19,10 +20,13 @@ class Command(BaseCommand):
             default=False, help='Remove all existing cache data before update'),
         parser.add_argument('--project_id', dest='project_id', nargs='+',
             default=False, help='Compute only statistics for these projects only (otherwise all)'),
+        parser.add_argument('--cache', dest='cache_type', default="section",
+            help='Which type of cache should be used: grid or section'),
         parser.add_argument('--type', dest='data_type', default="msgpack",
             help='Which type of cache to populate: json, json_text, msgpack'),
         parser.add_argument('--orientation', dest='orientations', nargs='+',
-            default='xz', help='Which orientations should be generated: xy, xz, zy'),
+            default='xy', help='Which orientations should be generated: xy, ' +
+            'xz, zy. Only used if a section cache type is used.'),
         parser.add_argument('--step', dest='steps', nargs='+',
             help='Map section thickness (depth resultion) for each orientation (in nm)'),
         parser.add_argument('--min-x', dest='min_x', default='-inf',
@@ -37,14 +41,36 @@ class Command(BaseCommand):
             help='Optional minimum Z project space coordinate for cache update'),
         parser.add_argument('--max-z', dest='max_z', default='inf',
             help='Optional maximum Z project space coordinate for cache update'),
+        parser.add_argument('--cell-width', dest='cell_width',
+            default=settings.DEFAULT_CACHE_GRID_CELL_WIDTH,
+            required=False, help='Optional, used with grid cache type: grid cell width in nm'),
+        parser.add_argument('--cell-height', dest='cell_height',
+            default=settings.DEFAULT_CACHE_GRID_CELL_HEIGHT,
+            required=False, help='Optional, used with grid cache type: grid cell height in nm'),
+        parser.add_argument('--cell-depth', dest='cell_depth',
+            default=settings.DEFAULT_CACHE_GRID_CELL_DEPTH,
+            required=False, help='Optional, used with grid cache type: grid cell width in nm'),
+        parser.add_argument('--allow-empty', dest='allow_empty', action='store_true', default=False,
+            required=False, help='Optional, used with grid cache type: whether empty cells are created'),
         parser.add_argument('--node-limit', dest='node_limit',
             default=settings.NODE_LIST_MAXIMUM_COUNT, help='Override node limit from settings. 0 means no limit'),
         parser.add_argument('--n-largest-skeletons-limit', dest='n_largest_skeletons_limit',
-                default=None, help='Only show treenodes of the N largest skeletons in the field of view'),
+            default=None, help='Only show treenodes of the N largest skeletons in the field of view'),
         parser.add_argument('--n-last-edited-skeletons-limit', dest='n_last_edited_skeletons_limit',
-                default=None, help='Only show treenodes of the N most recently edited skeletons in the field of view'),
+            default=None, help='Only show treenodes of the N most recently edited skeletons in the field of view'),
+        parser.add_argument('--hidden-last-editor', dest='hidden_last_editor',
+            default=None, help='Only show treenodes that have not been edited last by this user (username)'),
+        parser.add_argument('--lod-levels', dest='lod_levels', default=1,
+                type=int, help='Optional, number of level-of-detail levels'),
+        parser.add_argument('--lod-bucket-size', dest='lod_bucket_size', default=500,
+                type=int, help='Optional, number of (smallest) LOD bucket.'),
+        parser.add_argument('--lod-strategy', dest='lod_strategy', default='quadratic',
+                type=str, help='Optional, the strategy of LOD bucket size change with LOD. Can be "linear" or "quadratic".'),
         parser.add_argument('--from-config', action="store_true", dest='from_config',
-                default=False, help="Update cache based on NODE_PROVIDERS variable in settings")
+            default=False, help="Update cache based on NODE_PROVIDERS variable in settings")
+        parser.add_argument('--progress', dest='progress', default=True,
+            const=True, type=lambda x: (str(x).lower() == 'true'), nargs='?',
+            help='Whether to show progress information')
 
     def handle(self, *args, **options):
         if options['from_config']:
@@ -65,6 +91,10 @@ class Command(BaseCommand):
         else:
             projects = Project.objects.all()
 
+        cache_type = options['cache_type']
+        if cache_type not in ('section', 'grid'):
+            raise CommandError('Cache type must be one of: section, grid')
+
         orientations = options['orientations']
         if type(orientations) in (list, tuple):
             orientations = [o for o in orientations]
@@ -72,9 +102,13 @@ class Command(BaseCommand):
             orientations = ['xy']
 
         steps = options['steps']
-        if not steps:
-            raise CommandError('Need depth resolution per orientation (--step)')
-        steps = [float(s) for s in steps]
+        if cache_type == 'section':
+            if not steps:
+                raise CommandError('Need depth resolution per orientation (--step)')
+            steps = [float(s) for s in steps]
+
+            if len(steps) != len(orientations):
+                raise CommandError('Need one depth resolution flag per orientation')
 
         delete = False
         clean = options['clean']
@@ -90,8 +124,10 @@ class Command(BaseCommand):
             [float(options['max_x']), float(options['max_y']), float(options['max_z'])]
         ]
 
-        node_limit = int(options['node_limit'])
-        if node_limit == 0:
+        node_limit = options['node_limit']
+        if node_limit:
+            node_limit = int(options['node_limit'])
+        else:
             node_limit = None
 
         n_largest_skeletons_limit = None
@@ -102,16 +138,56 @@ class Command(BaseCommand):
         if options['n_last_edited_skeletons_limit']:
             n_last_edited_skeletons_limit = int(options['n_last_edited_skeletons_limit'])
 
+        hidden_last_editor_id = None
+        if options['hidden_last_editor']:
+            user = User.objects.get(username=options['hidden_last_editor'])
+            hidden_last_editor_id = user.id
+
         data_type = options['data_type']
 
         if data_type not in ('json', 'json_text', 'msgpack'):
             raise CommandError('Type must be one of: json, json_text, msgpack')
-        if len(steps) != len(orientations):
-            raise CommandError('Need one depth resolution flag per orientation')
+
+        cell_width = options['cell_width']
+        if cell_width:
+            cell_width = float(cell_width)
+
+        cell_height = options['cell_height']
+        if cell_height:
+            cell_height = float(cell_height)
+
+        cell_depth = options['cell_depth']
+        if cell_depth:
+            cell_depth = float(cell_depth)
+
+        allow_empty = options['allow_empty']
+
+        lod_levels = options['lod_levels']
+        if lod_levels:
+            lod_levels = int(lod_levels)
+
+        lod_bucket_size = options['lod_bucket_size']
+        if lod_bucket_size:
+            lod_bucket_size = int(lod_bucket_size)
+
+
+        lod_strategy = options['lod_strategy']
+        if lod_strategy not in ('linear', 'quadratic', 'exponential'):
+            raise ValueError("Unknown LOD strategy: {}".format(lod_strategy))
+
+        progress = options['progress']
 
         for p in projects:
-            self.stdout.write('Updating cache for project {}'.format(p.id))
-            update_cache(p.id, data_type, orientations, steps, node_limit,
-                    n_largest_skeletons_limit, n_last_edited_skeletons_limit,
-                    delete, bb_limits, log=self.stdout.write)
-            self.stdout.write('Updated cache for project {}'.format(p.id))
+            self.stdout.write('Updating {} cache for project {}'.format(cache_type, p.id))
+            if cache_type == 'section':
+                update_cache(p.id, data_type, orientations, steps, node_limit,
+                        n_largest_skeletons_limit, n_last_edited_skeletons_limit,
+                        hidden_last_editor_id, delete, bb_limits, log=self.stdout.write)
+            elif cache_type == 'grid':
+                update_grid_cache(p.id, data_type, orientations, cell_width,
+                        cell_height, cell_depth, node_limit, n_largest_skeletons_limit,
+                        n_last_edited_skeletons_limit, hidden_last_editor_id, delete,
+                        bb_limits, log=self.stdout.write, progress=progress,
+                        allow_empty=allow_empty, lod_levels=lod_levels,
+                        lod_bucket_size=lod_bucket_size, lod_strategy=lod_strategy)
+            self.stdout.write('Updated {} cache for project {}'.format(cache_type, p.id))

--- a/django/applications/catmaid/migrations/0059_add_node_query_grid_cache.py
+++ b/django/applications/catmaid/migrations/0059_add_node_query_grid_cache.py
@@ -1,0 +1,1182 @@
+# -*- coding: utf-8 -*-
+
+import django.utils.timezone
+
+from django.conf import settings
+import django.contrib.postgres.fields.jsonb
+from django.db import migrations, models
+import django.db.models.deletion
+
+forward = """
+  -- Create table that represents a 3D grid in project space.
+  CREATE TABLE node_grid_cache (
+    id serial PRIMARY KEY,
+    project_id integer REFERENCES project (id) ON DELETE CASCADE,
+    orientation integer DEFAULT 0 NOT NULL,
+    cell_width bigint,
+    cell_height bigint,
+    cell_depth bigint,
+    n_largest_skeletons_limit integer,
+    n_last_edited_skeletons_limit integer,
+    -- Data is organized in an array that consists of `n_lod_levels` buckets.
+    -- These buckets can be used to configure level of detail (LOD), which in
+    -- turn can be used by node queries to speed up data retrieval. By default,
+    -- there is only one bucket, i.e. no actual LOD lookup is performed. If set
+    -- to 2, the first array item will contain `lod_min_bucket_size` nodes and the
+    -- second one all the rest.
+    n_lod_levels int DEFAULT 1 NOT NULL,
+    -- The LOD cutoff is used as a starting value for LOD bucket sizes and is
+    -- essentially the minimum bucket size of first data array entry. If there
+    -- only one LOD level, all other nodes are contained in this bucket as well.
+    lod_min_bucket_size int DEFAULT 500 NOT NULL,
+    -- In 'linear' strategy, the first LOD bucket has the size of
+    -- `lod_min_bucket_size`. The second one twice this size and so on until the
+    -- last bucket contains all remaining nodes (which can be filtered with
+    -- other settings. In `quadratic` mode the n-th bucket will have a size of
+    -- `lod_min_bucket_size^n`.
+    lod_strategy text DEFAULT 'linear' NOT NULL,
+    hidden_last_editor_id integer REFERENCES auth_user (id) ON DELETE SET NULL,
+    allow_empty boolean DEFAULT FALSE NOT NULL,
+    has_json_data boolean DEFAULT FALSE NOT NULL,
+    has_json_text_data boolean DEFAULT FALSE NOT NULL,
+    has_msgpack_data boolean DEFAULT FALSE NOT NULL,
+    enabled boolean DEFAULT TRUE NOT NULL,
+    UNIQUE (project_id, orientation, cell_width, cell_height, cell_depth)
+  );
+
+  ALTER TABLE node_grid_cache ADD CONSTRAINT check_valid_lod_strategy
+      CHECK (lod_strategy IN ('linear', 'quadratic', 'exponential'));
+
+  -- Add table for individual grid cells. Technically, there is no need to store
+  -- the bounding box, but it makes some queries easier and for now we don't
+  -- expect a huge set of cells. Data is stored as level-of-detail (LOD) lists.
+  -- The grid cache defines how many LOD levels there are, i.e. how many array
+  -- elements each data entry has. The first element is the most detailed one, the
+  -- the last element is the most corse one. Data of individual levels is
+  -- supposed to add up. If a grid cache has four zoom levels, and the client
+  -- requests all data for LOD level 2, all entries from the second array entry
+  -- to the last entry have to be retrieved as a union. If all entries (= zoom
+  -- level 1) should be returned, all array elements will be returned as a
+  -- union.
+  CREATE TABLE node_grid_cache_cell (
+    id bigserial PRIMARY KEY,
+    grid_id integer REFERENCES node_grid_cache (id) ON DELETE CASCADE,
+    x_index integer NOT NULL,
+    y_index integer NOT NULL,
+    z_index integer NOT NULL,
+    update_time timestamp with time zone DEFAULT now() NOT NULL,
+    msgpack_data bytea[],
+    json_data jsonb[],
+    json_text_data text[],
+    UNIQUE (grid_id, x_index, y_index, z_index)
+  );
+
+  -- A separate table keeps track of dirty cells that need to be updated. This
+  -- This is done separately from the cells table to not require too much locking
+  -- on the main table during updates.
+  CREATE TABLE dirty_node_grid_cache_cell (
+    id bigserial PRIMARY KEY,
+    -- grid_cell_id bigint REFERENCES node_grid_cache_cell (id) ON DELETE CASCADE,
+    grid_id integer REFERENCES node_grid_cache (id) ON DELETE CASCADE,
+    x_index integer NOT NULL,
+    y_index integer NOT NULL,
+    z_index integer NOT NULL,
+    invalidation_time timestamp with time zone DEFAULT now() NOT NULL,
+    UNIQUE (grid_id, x_index, y_index, z_index)
+  );
+
+  -- If a new cell is marked dirty, emit the signal "catmaid.dirty-cache".
+  CREATE OR REPLACE FUNCTION on_update_dirty_node_grid_cache_cell() RETURNS trigger
+  LANGUAGE plpgsql AS
+  $$
+  BEGIN
+      -- Trigger event with edge information as JSON encoded payload.
+      PERFORM notify_conditionally('catmaid.dirty-cache', '{"grid_id": ' || NEW.grid_id ||
+          ', "x": ' || NEW.x_index || ', "y": ' || NEW.y_index ||
+          ', "z": ' || NEW.z_index || '}');
+
+      RETURN NEW;
+  END;
+  $$;
+
+  CREATE TRIGGER on_insert_dirty_node_grid_cache_cell_tgr
+  AFTER INSERT ON dirty_node_grid_cache_cell
+  FOR EACH ROW EXECUTE PROCEDURE on_update_dirty_node_grid_cache_cell();
+
+  CREATE TRIGGER on_update_dirty_node_grid_cache_cell_tgr
+  AFTER UPDATE ON dirty_node_grid_cache_cell
+  FOR EACH ROW EXECUTE PROCEDURE on_update_dirty_node_grid_cache_cell();
+
+  -- Add some indices, B-Tree is more useful here than e.g. BRIN, the extra
+  -- storage needed is justified by the performance improvements.
+  CREATE INDEX node_grid_cache_cell_x_index_idx ON node_grid_cache_cell (x_index);
+  CREATE INDEX node_grid_cache_cell_y_index_idx ON node_grid_cache_cell (y_index);
+  CREATE INDEX node_grid_cache_cell_z_index_idx ON node_grid_cache_cell (z_index);
+
+  CREATE INDEX dirty_node_grid_cache_cell_x_index_idx ON dirty_node_grid_cache_cell (x_index);
+  CREATE INDEX dirty_node_grid_cache_cell_y_index_idx ON dirty_node_grid_cache_cell (y_index);
+  CREATE INDEX dirty_node_grid_cache_cell_z_index_idx ON dirty_node_grid_cache_cell (z_index);
+
+  CREATE OR REPLACE FUNCTION enable_spatial_update_events() RETURNS void
+  LANGUAGE plpgsql AS
+  $$
+  BEGIN
+      CREATE OR REPLACE FUNCTION notify_conditionally(channel text, payload text) RETURNS int
+      LANGUAGE plpgsql AS
+      $inner$
+      BEGIN
+          PERFORM pg_notify(channel, payload);
+          RETURN 0;
+      END;
+      $inner$;
+  END;
+  $$;
+
+  CREATE OR REPLACE FUNCTION disable_spatial_update_events() RETURNS void
+  LANGUAGE plpgsql AS
+  $$
+  BEGIN
+      CREATE OR REPLACE FUNCTION notify_conditionally(channel text, payload text) RETURNS int
+      LANGUAGE plpgsql AS
+      $inner$
+      BEGIN
+          PERFORM 1 WHERE 1 = 0;
+          RETURN 0;
+      END;
+      $inner$;
+  END;
+  $$;
+
+  -- Disable spatial update events by default.
+  SELECT disable_spatial_update_events();
+
+  -- If a new node is inserted: add a new row to the summary table if
+  -- inserted node has no parent. If this results in a conflict,
+  -- increase node count of existing. Also send a NOTIFY event, in case there
+  -- are interested listeners, channel 'catmaid.spatial-update' is used.
+  CREATE OR REPLACE FUNCTION on_insert_treenode_update_summary_and_edges() RETURNS trigger
+  LANGUAGE plpgsql AS
+  $$
+  BEGIN
+      WITH new_edges AS (
+          -- Compute new edges and collect some other needed information
+          SELECT c.id, c.project_id, c.skeleton_id, c.creation_time,
+              c.edition_time, c.editor_id, ST_MakeLine(
+                  ST_MakePoint(c.location_x, c.location_y, c.location_z),
+                  ST_MakePoint(p.location_x, p.location_y, p.location_z)
+              ) AS edge,
+              -- Trigger event with edge information as JSON encoded payload.
+              notify_conditionally('catmaid.spatial-update',
+                  '{"project_id": ' || p.project_id || ', "type": "edge", "p1": [' ||
+                  c.location_x || ',' || c.location_y || ',' || c.location_z || '], "p2": [' ||
+                  p.location_x || ',' || p.location_y || ',' || p.location_z || ']}')
+          FROM inserted_treenode c JOIN treenode p ON
+              (c.parent_id = p.id) OR (c.parent_id IS NULL AND c.id = p.id)
+      ), edge_insert AS (
+          -- Insert new edges into edge table
+          INSERT INTO treenode_edge (id, project_id, edge)
+          SELECT e.id, e.project_id, e.edge FROM new_edges e
+      ), skeleton_data AS (
+          -- Aggregate data over skeletons to prepare for summary update.
+          SELECT skeleton_id, project_id,
+              COUNT(*) AS num_nodes,
+              SUM(ST_3DLength(edge)) AS length,
+              MIN(creation_time) AS min_creation_time,
+              MAX(edition_time) AS max_edition_time,
+              last_editor_id
+          FROM (
+              SELECT skeleton_id, project_id, edge, creation_time, edition_time,
+                  first_value(editor_id) OVER w AS last_editor_id
+              FROM new_edges e
+              WINDOW w AS (PARTITION BY skeleton_id, project_id ORDER BY edition_time DESC)
+          ) edge_info
+          GROUP BY skeleton_id, project_id, last_editor_id
+      )
+      INSERT INTO catmaid_skeleton_summary (project_id, skeleton_id,
+          last_summary_update, original_creation_time,
+          last_edition_time, last_editor_id, num_nodes, cable_length)
+      (
+          SELECT s.project_id, s.skeleton_id, now(), s.min_creation_time,
+              s.max_edition_time,
+              COALESCE(NULLIF(current_setting('catmaid.user_id', TRUE), '')::integer, s.last_editor_id),
+              s.num_nodes, s.length
+          FROM skeleton_data s
+      )
+      ON CONFLICT (skeleton_id) DO UPDATE
+      SET num_nodes = catmaid_skeleton_summary.num_nodes + EXCLUDED.num_nodes,
+          last_summary_update = EXCLUDED.last_summary_update,
+          original_creation_time = LEAST(
+              catmaid_skeleton_summary.original_creation_time,
+              EXCLUDED.original_creation_time),
+          last_edition_time = GREATEST(
+              catmaid_skeleton_summary.last_edition_time,
+              EXCLUDED.last_edition_time),
+          last_editor_id = EXCLUDED.last_editor_id,
+          cable_length = catmaid_skeleton_summary.cable_length + EXCLUDED.cable_length;
+
+      RETURN NEW;
+
+  END;
+  $$;
+
+
+  CREATE OR REPLACE FUNCTION on_edit_treenode_update_summary_and_edges() RETURNS trigger
+  LANGUAGE plpgsql AS
+  $$
+  BEGIN
+      -- Transition tables (old_treenode and new_treenode) can only be
+      -- read once per statement. This is why we select them
+      -- completely into a CTE. With Postgres 10.4 this can be replaced
+      -- by direct transition table access, because it fixes the bug
+      -- causing the current behavior.
+      WITH old_treenode_data AS (
+          SELECT * FROM old_treenode
+      ), new_treenode_data AS (
+          SELECT * FROM new_treenode
+      ), updated_parent_edge_data AS (
+          -- Find all nodes that changed their position or parent
+          SELECT t.id, t.project_id, t.skeleton_id, t.creation_time,
+              t.edition_time, t.editor_id, ST_MakeLine(
+                  ST_MakePoint(t.location_x, t.location_y, t.location_z),
+                  ST_MakePoint(p.location_x, p.location_y, p.location_z)
+              ) AS edge,
+              t.parent_id,
+              ot.edition_time as old_edition_time,
+              ot.creation_time AS old_creation_time,
+              ot.skeleton_id AS old_skeleton_id,
+              -- Trigger event with information on changed edges (old and new)
+              -- as JSON encoded payload.
+              notify_conditionally('catmaid.spatial-update', '{"project_id": ' ||
+                  t.project_id || ', "type": "edges", "edges": [[[' ||
+                  t.location_x || ',' || t.location_y || ',' || t.location_z || '], [' ||
+                  p.location_x || ',' || p.location_y || ',' || p.location_z ||
+                  ']], [[' ||
+                  ot.location_x || ',' || ot.location_y || ',' || ot.location_z || '], [' ||
+                  p.location_x || ',' || p.location_y || ',' || p.location_z || ']]]}')
+          FROM new_treenode_data t
+          JOIN old_treenode_data ot
+              ON t.id = ot.id
+          JOIN treenode p
+              ON (t.parent_id IS NOT NULL AND p.id = t.parent_id) OR
+                 (t.parent_id IS NULL AND p.id = t.id)
+          WHERE ot.parent_id IS DISTINCT FROM t.parent_id OR
+             ot.location_x != t.location_x OR
+             ot.location_y != t.location_y OR
+             ot.location_z != t.location_z OR
+             ot.skeleton_id != t.skeleton_id
+      ), updated_child_edge_data AS (
+          -- Find all unseen child nodes of the nodes with a changed
+          -- edge using an anti join.
+          SELECT c.id, c.project_id, c.skeleton_id, c.creation_time,
+              c.edition_time, c.editor_id, ST_MakeLine(
+                  ST_MakePoint(c.location_x, c.location_y, c.location_z),
+                  ST_MakePoint(e.location_x, e.location_y, e.location_z)
+              ) AS edge,
+              c.parent_id,
+              c.edition_time AS old_edition_time,
+              c.creation_time AS old_creation_time,
+              c.skeleton_id AS old_skeleton_id,
+              -- Trigger event with edge information as JSON encoded payload.
+              notify_conditionally('catmaid.spatial-update', '{"project_id": ' ||
+              e.project_id || ', "type": "edges", "edges": [[[' ||
+                  c.location_x || ',' || c.location_y || ',' || c.location_z || '], [' ||
+                  e.location_x || ',' || e.location_y || ',' || e.location_z ||
+                  ']], [[' ||
+                  c.location_x || ',' || c.location_y || ',' || c.location_z || '], [' ||
+                  ot.location_x || ',' || ot.location_y || ',' || ot.location_z || ']]]}')
+          FROM treenode c
+          JOIN old_treenode_data ot
+              ON ot.id = c.parent_id
+          JOIN new_treenode_data e
+              ON c.parent_id = e.id
+          LEFT JOIN new_treenode_data c2
+              ON c.id = c2.id
+          WHERE c2.id IS NULL
+      ), updated_edge_data AS (
+          -- Combine all directly changed nodes with a changed
+          -- location as well as the extra child nodes where the
+          -- parent changed location. The limit is needed to indicate
+          -- to the planner an upper limit of this CTE. This is
+          -- unfortunately needed, because no real estimates are done
+          -- on CTEs and no actual stats are used. This leads to
+          -- unfortunate join plans in the updated_edge CTE.
+          (SELECT *
+          FROM updated_parent_edge_data
+          LIMIT (SELECT COUNT(*) FROM updated_parent_edge_data))
+          UNION ALL
+          (SELECT *
+          FROM updated_child_edge_data
+          LIMIT (SELECT COUNT(*) FROM updated_child_edge_data))
+      ), old_edge AS (
+          -- Get all old edges of changed nodes as well as their
+          -- children (if any). Child edges contribute to the cable
+          -- length as well and need to be updated.
+          SELECT t.id, t.project_id, t.old_skeleton_id AS skeleton_id,
+              t.old_creation_time AS creation_time,
+              t.old_edition_time AS edition_time,
+              e.edge,
+              t.editor_id
+          FROM updated_edge_data t
+          JOIN treenode_edge e
+              ON e.id = t.id
+      ), updated_edge AS (
+          -- Update all changed edges. To have this join work fast, we
+          -- rely on reasonable statistics on the row count of
+          -- updated_edge_data. This is provided, by setting (obivious)
+          -- limits on its size when creating it.
+          UPDATE treenode_edge e
+          SET edge = ue.edge
+          FROM updated_edge_data ue
+          WHERE e.id = ue.id
+          RETURNING e.id
+      ), new_edge AS (
+          -- Collect changed nodes both with and without location
+          -- change. Updated edge information takes precedence.
+          SELECT ue.id, ue.project_id, ue.skeleton_id,
+              ue.creation_time, ue.edition_time, ue.edge, ue.editor_id
+          FROM updated_edge_data ue
+          UNION ALL
+          SELECT nt.id, nt.project_id, nt.skeleton_id,
+              nt.creation_time, nt.edition_time, oe.edge, nt.editor_id
+          FROM new_treenode_data nt
+          LEFT JOIN updated_edge_data ue
+              ON nt.id = ue.id
+          JOIN old_edge oe
+              ON nt.id = oe.id
+          WHERE ue.id IS NULL
+      ), old_skeleton_data AS (
+          -- Aggregate data over old skeleton datas to delete for summary.
+          SELECT skeleton_id, project_id,
+              -COUNT(*) AS num_nodes,
+              -SUM(ST_3DLength(edge)) AS length,
+              MIN(creation_time) AS min_creation_time,
+              MAX(edition_time) AS max_edition_time,
+              last_editor_id
+          FROM (
+              SELECT skeleton_id, project_id, edge, creation_time, edition_time,
+                  first_value(editor_id) OVER w AS last_editor_id
+              FROM old_edge
+              WINDOW w AS (PARTITION BY skeleton_id, project_id ORDER BY edition_time DESC)
+          ) edge_info
+          GROUP BY skeleton_id, project_id, last_editor_id
+      ), new_skeleton_data AS (
+          -- Aggregate data over skeletons to prepare for summary update.
+          SELECT skeleton_id, project_id,
+              COUNT(*) AS num_nodes,
+              SUM(ST_3DLength(edge)) AS length,
+              MIN(creation_time) AS min_creation_time,
+              MAX(edition_time) AS max_edition_time,
+              last_editor_id
+          FROM (
+              SELECT skeleton_id, project_id, edge, creation_time, edition_time,
+                  first_value(editor_id) OVER w AS last_editor_id
+              FROM new_edge
+              WINDOW w AS (PARTITION BY skeleton_id, project_id ORDER BY edition_time DESC)
+          ) edge_info
+          GROUP BY skeleton_id, project_id, last_editor_id
+      ), summary_update_delta AS (
+          SELECT skeleton_id, project_id,
+              SUM(num_nodes) AS num_nodes,
+              SUM(length) AS length,
+              MIN(min_creation_time) AS min_creation_time,
+              MAX(max_edition_time) AS max_edition_time,
+              last_editor_id
+          FROM (
+              SELECT skeleton_id, project_id, num_nodes, length,
+                  min_creation_time, max_edition_time,
+                  first_value(last_editor_id) OVER w AS last_editor_id
+              FROM (
+                  SELECT os.skeleton_id, os.project_id, os.num_nodes,
+                      os.length, os.min_creation_time, os.max_edition_time,
+                      os.last_editor_id
+                  FROM old_skeleton_data os
+                  UNION ALL
+                  SELECT ns.skeleton_id, ns.project_id, ns.num_nodes,
+                      ns.length, ns.min_creation_time, ns.max_edition_time,
+                      ns.last_editor_id
+                  FROM new_skeleton_data ns
+              ) _update_data
+              WINDOW w AS (PARTITION BY skeleton_id, project_id ORDER BY max_edition_time DESC)
+          ) update_data
+          GROUP BY skeleton_id, project_id, last_editor_id
+      )
+      INSERT INTO catmaid_skeleton_summary (project_id, skeleton_id,
+          last_summary_update, original_creation_time,
+          last_edition_time, last_editor_id, num_nodes, cable_length)
+      (
+          SELECT s.project_id, s.skeleton_id, now(), s.min_creation_time,
+              s.max_edition_time,
+              COALESCE(NULLIF(current_setting('catmaid.user_id', TRUE), '')::integer, s.last_editor_id),
+              s.num_nodes, s.length
+          FROM summary_update_delta s
+      )
+      ON CONFLICT (skeleton_id) DO UPDATE
+      SET num_nodes = catmaid_skeleton_summary.num_nodes + EXCLUDED.num_nodes,
+          last_summary_update = EXCLUDED.last_summary_update,
+          last_edition_time = GREATEST(
+              catmaid_skeleton_summary.last_edition_time,
+              EXCLUDED.last_edition_time),
+          last_editor_id = EXCLUDED.last_editor_id,
+          cable_length = catmaid_skeleton_summary.cable_length + EXCLUDED.cable_length;
+
+      RETURN NEW;
+  END;
+  $$;
+
+
+  -- Remove all deleted nodes and their contributed cable length from
+  -- skeleton summary and delete the edge reference.
+  CREATE OR REPLACE FUNCTION on_delete_treenode_update_summary_and_edges()
+      RETURNS trigger
+      LANGUAGE plpgsql AS
+  $$
+  BEGIN
+      -- Compute aggregated node count and cable length of deleted
+      -- nodes per skeleton. Use this information to update summary.
+      WITH skeleton_data AS (
+          SELECT t.skeleton_id,
+              t.project_id AS project_id,
+              COUNT(*) AS num_nodes,
+              SUM(ST_3DLength(e.edge)) AS length
+          FROM deleted_treenode t
+          JOIN treenode_edge e
+              ON t.id = e.id
+          GROUP BY t.skeleton_id, t.project_id
+      ), notify AS (
+          SELECT notify_conditionally('catmaid.spatial-update', '{"project_id": ' ||
+              e.project_id || ', "type": "edge", "p1": [' ||
+              ST_X(ST_StartPoint(e.edge)) || ',' ||
+              ST_Y(ST_StartPoint(e.edge)) || ',' ||
+              ST_Z(ST_StartPoint(e.edge)) || '], "p2": [' ||
+              ST_X(ST_EndPoint(e.edge)) || ',' ||
+              ST_Y(ST_EndPoint(e.edge)) || ',' ||
+              ST_Z(ST_EndPoint(e.edge)) || ']}')
+          FROM deleted_treenode t
+          JOIN treenode_edge e
+              ON t.id = e.id
+      )
+      UPDATE catmaid_skeleton_summary s
+      SET num_nodes = s.num_nodes - d.num_nodes,
+          cable_length = s.cable_length - d.length,
+          last_edition_time = now(),
+          -- Try to get current user from transaction setting. Don't change it
+          -- if no user is found, because we don't want to prevent deletion,
+          -- but also don't have more information.
+          last_editor_id = COALESCE(NULLIF(current_setting('catmaid.user_id', TRUE), '')::integer, s.last_editor_id)
+      FROM skeleton_data d
+      WHERE d.skeleton_id = s.skeleton_id
+      AND d.project_id = s.project_id;
+
+      -- Delete existing edge
+      DELETE FROM treenode_edge e
+      USING deleted_treenode t
+      WHERE t.id = e.id
+      AND t.project_id = e.project_id;
+
+      RETURN OLD;
+  END;
+  $$;
+
+
+  CREATE OR REPLACE FUNCTION on_delete_connector_update_geom() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$ BEGIN
+      DELETE FROM connector_geom
+          WHERE id = OLD.id;
+
+      PERFORM notify_conditionally('catmaid.spatial-update', '{"project_id": ' || OLD.project_id || ', "type": "point", "p": [' ||
+          OLD.location_x || ',' || OLD.location_y || ',' || OLD.location_z || ']}');
+
+      RETURN OLD;
+  END;
+  $$;
+
+
+  CREATE OR REPLACE FUNCTION on_edit_treenode_connector_update_edges() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$ BEGIN
+      IF OLD.treenode_id IS DISTINCT FROM NEW.treenode_id OR
+         OLD.connector_id IS DISTINCT FROM NEW.connector_ID THEN
+
+          UPDATE treenode_connector_edge
+              SET
+                  id = NEW.id,
+                  edge = sub.edge
+              FROM (
+                  SELECT ST_MakeLine(
+                          ST_MakePoint(t.location_x, t.location_y, t.location_z),
+                          ST_MakePoint(c.location_x, c.location_y, c.location_z)) AS edge,
+                      notify_conditionally('catmaid.spatial-update', '{"project_id": ' || NEW.project_id || ', "type": "edge", "p1": [' ||
+                          c.location_x || ',' || c.location_y || ',' || c.location_z || '], "p2": [' ||
+                          t.location_x || ',' || t.location_y || ',' || t.location_z || ']}')
+              FROM treenode t, connector c
+              WHERE id = OLD.id
+                AND t.id = NEW.treenode_id
+                AND c.id = NEW.connector_id
+              ) sub;
+      END IF;
+      RETURN NEW;
+  END;
+  $$;
+
+
+  CREATE OR REPLACE FUNCTION on_edit_treenode_update_treenode_connector_edges() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$ BEGIN
+      IF OLD.location_x != NEW.location_x OR
+         OLD.location_y != NEW.location_y OR
+         OLD.location_z != NEW.location_z THEN
+          UPDATE treenode_connector_edge
+              SET edge = sub.edge
+              FROM (SELECT
+                      tc.id AS tcid,
+                      ST_MakeLine(
+                          ST_MakePoint(NEW.location_x, NEW.location_y, NEW.location_z),
+                          ST_MakePoint(c.location_x, c.location_y, c.location_z)) AS edge,
+                      notify_conditionally('catmaid.spatial-update', '{"project_id": ' || NEW.project_id || ', "type": "edges", "edges": [[[' ||
+                          c.location_x || ',' || c.location_y || ',' || c.location_z || '], [' ||
+                          NEW.location_x || ',' || NEW.location_y || ',' || NEW.location_z ||
+                          ']], [[' ||
+                          c.location_x || ',' || c.location_y || ',' || c.location_z || '], [' ||
+                          OLD.location_x || ',' || OLD.location_y || ',' || OLD.location_z || ']]]}')
+                  FROM
+                      treenode_connector tc,
+                      connector c
+                  WHERE tc.treenode_id = NEW.id
+                    AND c.id = tc.connector_id) sub
+              WHERE id = sub.tcid;
+      END IF;
+      RETURN NEW;
+  END;
+  $$;
+
+
+  CREATE OR REPLACE FUNCTION on_edit_connector_update_treenode_connector_edges() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$ BEGIN
+      IF OLD.location_x != NEW.location_x OR
+         OLD.location_y != NEW.location_y OR
+         OLD.location_z != NEW.location_z THEN
+          UPDATE treenode_connector_edge
+              SET edge = sub.edge
+              FROM (SELECT
+                      tc.id AS tcid,
+                      ST_MakeLine(
+                          ST_MakePoint(t.location_x, t.location_y, t.location_z),
+                          ST_MakePoint(NEW.location_x, NEW.location_y, NEW.location_z)) AS edge,
+                      notify_conditionally('catmaid.spatial-update', '{"project_id": ' || NEW.project_id || ', "type": "edges", "edges": [[[' ||
+                          t.location_x || ',' || t.location_y || ',' || t.location_z || '], [' ||
+                          NEW.location_x || ',' || NEW.location_y || ',' ||
+                          NEW.location_z
+                          || ']], [[' ||
+                          t.location_x || ',' || t.location_y || ',' || t.location_z || '], [' ||
+                          OLD.location_x || ',' || OLD.location_y || ',' || OLD.location_z || ']]]}')
+                  FROM treenode_connector tc, treenode t
+                  WHERE tc.connector_id = NEW.id
+                    AND t.id = tc.treenode_id) sub
+              WHERE id = sub.tcid;
+
+          UPDATE connector_geom
+              SET geom = ST_MakePoint(NEW.location_x, NEW.location_y, NEW.location_z)
+              WHERE id = NEW.id;
+      END IF;
+      RETURN NEW;
+  END;
+  $$;
+
+
+  CREATE OR REPLACE FUNCTION on_insert_treenode_connector_update_edges() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$ BEGIN
+      INSERT INTO treenode_connector_edge (
+              id,
+              project_id,
+              edge)
+      (SELECT id, project_id, edge
+       FROM (
+           SELECT
+           NEW.id,
+           NEW.project_id,
+           ST_MakeLine(
+               ST_MakePoint(t.location_x, t.location_y, t.location_z),
+               ST_MakePoint(c.location_x, c.location_y, c.location_z)) AS edge,
+           notify_conditionally('catmaid.spatial-update', '{"project_id": ' || NEW.project_id || ', "type": "edge", "p1": [' ||
+               t.location_x || ',' || t.location_y || ',' || t.location_z || '], "p2": [' ||
+               c.location_x || ',' || c.location_y || ',' || c.location_z || ']}')
+           FROM treenode t, connector c
+           WHERE t.id = NEW.treenode_id
+             AND c.id = NEW.connector_id) sub);
+      RETURN NEW;
+  END;
+  $$;
+
+
+  CREATE OR REPLACE FUNCTION on_insert_connector_update_connector_geom() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$ BEGIN
+      INSERT INTO connector_geom (
+              id,
+              project_id,
+              geom)
+          VALUES (
+              NEW.id,
+              NEW.project_id,
+              ST_MakePoint(NEW.location_x, NEW.location_y, NEW.location_z));
+
+      PERFORM notify_conditionally('catmaid.spatial-update', '{"project_id": ' || NEW.project_id || ', "type": "point", "p": [' ||
+          NEW.location_x || ',' || NEW.location_y || ',' || NEW.location_z || ']}');
+
+      RETURN NEW;
+  END;
+  $$;
+"""
+
+backward = """
+  DROP TABLE dirty_node_grid_cache_cell;
+  DROP TABLE node_grid_cache_cell;
+  DROP TABLE node_grid_cache;
+
+
+  DROP FUNCTION enable_spatial_update_events();
+  DROP FUNCTION disable_spatial_update_events();
+  DROP FUNCTION IF EXISTS notify_conditionally(text, text);
+
+  -- If a new node is inserted: add a new row to the summary table if
+  -- inserted node has no parent. If this results in a conflict,
+  -- increase node count of existing.
+  CREATE OR REPLACE FUNCTION on_insert_treenode_update_summary_and_edges() RETURNS trigger
+  LANGUAGE plpgsql AS
+  $$
+  BEGIN
+      WITH new_edges AS (
+          -- Compute new edges and collect some other needed information
+          SELECT c.id, c.project_id, c.skeleton_id, c.creation_time,
+              c.edition_time, c.editor_id, ST_MakeLine(
+                  ST_MakePoint(c.location_x, c.location_y, c.location_z),
+                  ST_MakePoint(p.location_x, p.location_y, p.location_z)
+              ) AS edge
+          FROM inserted_treenode c JOIN treenode p ON
+              (c.parent_id = p.id) OR (c.parent_id IS NULL AND c.id = p.id)
+      ), edge_insert AS (
+          -- Insert new edges into edge table
+          INSERT INTO treenode_edge (id, project_id, edge)
+          SELECT e.id, e.project_id, e.edge FROM new_edges e
+      ), skeleton_data AS (
+          -- Aggregate data over skeletons to prepare for summary update.
+          SELECT skeleton_id, project_id,
+              COUNT(*) AS num_nodes,
+              SUM(ST_3DLength(edge)) AS length,
+              MIN(creation_time) AS min_creation_time,
+              MAX(edition_time) AS max_edition_time,
+              last_editor_id
+          FROM (
+              SELECT skeleton_id, project_id, edge, creation_time, edition_time,
+                  first_value(editor_id) OVER w AS last_editor_id
+              FROM new_edges e
+              WINDOW w AS (PARTITION BY skeleton_id, project_id ORDER BY edition_time DESC)
+          ) edge_info
+          GROUP BY skeleton_id, project_id, last_editor_id
+      )
+      INSERT INTO catmaid_skeleton_summary (project_id, skeleton_id,
+          last_summary_update, original_creation_time,
+          last_edition_time, last_editor_id, num_nodes, cable_length)
+      (
+          SELECT s.project_id, s.skeleton_id, now(), s.min_creation_time,
+              s.max_edition_time,
+              COALESCE(NULLIF(current_setting('catmaid.user_id', TRUE), '')::integer, s.last_editor_id),
+              s.num_nodes, s.length
+          FROM skeleton_data s
+      )
+      ON CONFLICT (skeleton_id) DO UPDATE
+      SET num_nodes = catmaid_skeleton_summary.num_nodes + EXCLUDED.num_nodes,
+          last_summary_update = EXCLUDED.last_summary_update,
+          original_creation_time = LEAST(
+              catmaid_skeleton_summary.original_creation_time,
+              EXCLUDED.original_creation_time),
+          last_edition_time = GREATEST(
+              catmaid_skeleton_summary.last_edition_time,
+              EXCLUDED.last_edition_time),
+          last_editor_id = EXCLUDED.last_editor_id,
+          cable_length = catmaid_skeleton_summary.cable_length + EXCLUDED.cable_length;
+
+      RETURN NEW;
+
+  END;
+  $$;
+
+
+  CREATE OR REPLACE FUNCTION on_edit_treenode_update_summary_and_edges() RETURNS trigger
+  LANGUAGE plpgsql AS
+  $$
+  BEGIN
+      -- Transition tables (old_treenode and new_treenode) can only be
+      -- read once per statement. This is why we select them
+      -- completely into a CTE. With Postgres 10.4 this can be replaced
+      -- by direct transition table access, because it fixes the bug
+      -- causing the current behavior.
+      WITH old_treenode_data AS (
+          SELECT * FROM old_treenode
+      ), new_treenode_data AS (
+          SELECT * FROM new_treenode
+      ), updated_parent_edge_data AS (
+          -- Find all nodes that changed their position or parent
+          SELECT t.id, t.project_id, t.skeleton_id, t.creation_time,
+              t.edition_time, t.editor_id, ST_MakeLine(
+                  ST_MakePoint(t.location_x, t.location_y, t.location_z),
+                  ST_MakePoint(p.location_x, p.location_y, p.location_z)
+              ) AS edge,
+              t.parent_id,
+              ot.edition_time as old_edition_time,
+              ot.creation_time AS old_creation_time,
+              ot.skeleton_id AS old_skeleton_id
+          FROM new_treenode_data t
+          JOIN old_treenode_data ot
+              ON t.id = ot.id
+          JOIN treenode p
+              ON (t.parent_id IS NOT NULL AND p.id = t.parent_id) OR
+                 (t.parent_id IS NULL AND p.id = t.id)
+          WHERE ot.parent_id IS DISTINCT FROM t.parent_id OR
+             ot.location_x != t.location_x OR
+             ot.location_y != t.location_y OR
+             ot.location_z != t.location_z OR
+             ot.skeleton_id != t.skeleton_id
+      ), updated_child_edge_data AS (
+          -- Find all unseen child nodes of the nodes with a changed
+          -- edge using an anti join.
+          SELECT c.id, c.project_id, c.skeleton_id, c.creation_time,
+              c.edition_time, c.editor_id, ST_MakeLine(
+                  ST_MakePoint(c.location_x, c.location_y, c.location_z),
+                  ST_MakePoint(e.location_x, e.location_y, e.location_z)
+              ) AS edge,
+              c.parent_id,
+              c.edition_time AS old_edition_time,
+              c.creation_time AS old_creation_time,
+              c.skeleton_id AS old_skeleton_id
+          FROM treenode c
+          JOIN new_treenode_data e
+              ON c.parent_id = e.id
+          LEFT JOIN new_treenode_data c2
+              ON c.id = c2.id
+          WHERE c2.id IS NULL
+      ), updated_edge_data AS (
+          -- Combine all directly changed nodes with a changed
+          -- location as well as the extra child nodes where the
+          -- parent changed location. The limit is needed to indicate
+          -- to the planner an upper limit of this CTE. This is
+          -- unfortunately needed, because no real estimates are done
+          -- on CTEs and no actual stats are used. This leads to
+          -- unfortunate join plans in the updated_edge CTE.
+          (SELECT *
+          FROM updated_parent_edge_data
+          LIMIT (SELECT COUNT(*) FROM updated_parent_edge_data))
+          UNION ALL
+          (SELECT *
+          FROM updated_child_edge_data
+          LIMIT (SELECT COUNT(*) FROM updated_child_edge_data))
+      ), old_edge AS (
+          -- Get all old edges of changed nodes as well as their
+          -- children (if any). Child edges contribute to the cable
+          -- length as well and need to be updated.
+          SELECT t.id, t.project_id, t.old_skeleton_id AS skeleton_id,
+              t.old_creation_time AS creation_time,
+              t.old_edition_time AS edition_time,
+              e.edge,
+              t.editor_id
+          FROM updated_edge_data t
+          JOIN treenode_edge e
+              ON e.id = t.id
+      ), updated_edge AS (
+          -- Update all changed edges. To have this join work fast, we
+          -- rely on reasonable statistics on the row count of
+          -- updated_edge_data. This is provided, by setting (obivious)
+          -- limits on its size when creating it.
+          UPDATE treenode_edge e
+          SET edge = ue.edge
+          FROM updated_edge_data ue
+          WHERE e.id = ue.id
+          RETURNING e.id
+      ), new_edge AS (
+          -- Collect changed nodes both with and without location
+          -- change. Updated edge information takes precedence.
+          SELECT ue.id, ue.project_id, ue.skeleton_id,
+              ue.creation_time, ue.edition_time, ue.edge, ue.editor_id
+          FROM updated_edge_data ue
+          UNION ALL
+          SELECT nt.id, nt.project_id, nt.skeleton_id,
+              nt.creation_time, nt.edition_time, oe.edge, nt.editor_id
+          FROM new_treenode_data nt
+          LEFT JOIN updated_edge_data ue
+              ON nt.id = ue.id
+          JOIN old_edge oe
+              ON nt.id = oe.id
+          WHERE ue.id IS NULL
+      ), old_skeleton_data AS (
+          -- Aggregate data over old skeleton datas to delete for summary.
+          SELECT skeleton_id, project_id,
+              -COUNT(*) AS num_nodes,
+              -SUM(ST_3DLength(edge)) AS length,
+              MIN(creation_time) AS min_creation_time,
+              MAX(edition_time) AS max_edition_time,
+              last_editor_id
+          FROM (
+              SELECT skeleton_id, project_id, edge, creation_time, edition_time,
+                  first_value(editor_id) OVER w AS last_editor_id
+              FROM old_edge
+              WINDOW w AS (PARTITION BY skeleton_id, project_id ORDER BY edition_time DESC)
+          ) edge_info
+          GROUP BY skeleton_id, project_id, last_editor_id
+      ), new_skeleton_data AS (
+          -- Aggregate data over skeletons to prepare for summary update.
+          SELECT skeleton_id, project_id,
+              COUNT(*) AS num_nodes,
+              SUM(ST_3DLength(edge)) AS length,
+              MIN(creation_time) AS min_creation_time,
+              MAX(edition_time) AS max_edition_time,
+              last_editor_id
+          FROM (
+              SELECT skeleton_id, project_id, edge, creation_time, edition_time,
+                  first_value(editor_id) OVER w AS last_editor_id
+              FROM new_edge
+              WINDOW w AS (PARTITION BY skeleton_id, project_id ORDER BY edition_time DESC)
+          ) edge_info
+          GROUP BY skeleton_id, project_id, last_editor_id
+      ), summary_update_delta AS (
+          SELECT skeleton_id, project_id,
+              SUM(num_nodes) AS num_nodes,
+              SUM(length) AS length,
+              MIN(min_creation_time) AS min_creation_time,
+              MAX(max_edition_time) AS max_edition_time,
+              last_editor_id
+          FROM (
+              SELECT skeleton_id, project_id, num_nodes, length,
+                  min_creation_time, max_edition_time,
+                  first_value(last_editor_id) OVER w AS last_editor_id
+              FROM (
+                  SELECT os.skeleton_id, os.project_id, os.num_nodes,
+                      os.length, os.min_creation_time, os.max_edition_time,
+                      os.last_editor_id
+                  FROM old_skeleton_data os
+                  UNION ALL
+                  SELECT ns.skeleton_id, ns.project_id, ns.num_nodes,
+                      ns.length, ns.min_creation_time, ns.max_edition_time,
+                      ns.last_editor_id
+                  FROM new_skeleton_data ns
+              ) _update_data
+              WINDOW w AS (PARTITION BY skeleton_id, project_id ORDER BY max_edition_time DESC)
+          ) update_data
+          GROUP BY skeleton_id, project_id, last_editor_id
+      )
+      INSERT INTO catmaid_skeleton_summary (project_id, skeleton_id,
+          last_summary_update, original_creation_time,
+          last_edition_time, last_editor_id, num_nodes, cable_length)
+      (
+          SELECT s.project_id, s.skeleton_id, now(), s.min_creation_time,
+              s.max_edition_time,
+              COALESCE(NULLIF(current_setting('catmaid.user_id', TRUE), '')::integer, s.last_editor_id),
+              s.num_nodes, s.length
+          FROM summary_update_delta s
+      )
+      ON CONFLICT (skeleton_id) DO UPDATE
+      SET num_nodes = catmaid_skeleton_summary.num_nodes + EXCLUDED.num_nodes,
+          last_summary_update = EXCLUDED.last_summary_update,
+          last_edition_time = GREATEST(
+              catmaid_skeleton_summary.last_edition_time,
+              EXCLUDED.last_edition_time),
+          last_editor_id = EXCLUDED.last_editor_id,
+          cable_length = catmaid_skeleton_summary.cable_length + EXCLUDED.cable_length;
+
+      RETURN NEW;
+
+  END;
+  $$;
+
+
+  -- Remove all deleted nodes and their contributed cable length from
+  -- skeleton summary and delete the edge reference.
+  CREATE OR REPLACE FUNCTION on_delete_treenode_update_summary_and_edges()
+      RETURNS trigger
+      LANGUAGE plpgsql AS
+  $$
+  BEGIN
+      -- Compute aggregated node count and cable length of deleted
+      -- nodes per skeleton. Use this information to update summary.
+      WITH skeleton_data AS (
+          SELECT t.skeleton_id,
+              t.project_id AS project_id,
+              COUNT(*) AS num_nodes,
+              SUM(ST_3DLength(e.edge)) AS length
+          FROM deleted_treenode t
+          JOIN treenode_edge e
+              ON t.id = e.id
+          GROUP BY t.skeleton_id, t.project_id
+      )
+      UPDATE catmaid_skeleton_summary s
+      SET num_nodes = s.num_nodes - d.num_nodes,
+          cable_length = s.cable_length - d.length,
+          last_edition_time = now(),
+          -- Try to get current user from transaction setting. Don't change it
+          -- if no user is found, because we don't want to prevent deletion,
+          -- but also don't have more information.
+          last_editor_id = COALESCE(NULLIF(current_setting('catmaid.user_id', TRUE), '')::integer, s.last_editor_id)
+      FROM skeleton_data d
+      WHERE d.skeleton_id = s.skeleton_id
+      AND d.project_id = s.project_id;
+
+      -- Delete existing edge
+      DELETE FROM treenode_edge e
+      USING deleted_treenode t
+      WHERE t.id = e.id
+      AND t.project_id = e.project_id;
+
+      RETURN OLD;
+
+  END;
+  $$;
+
+
+  CREATE OR REPLACE FUNCTION on_delete_treenode_connector_update_edges() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$ BEGIN
+      DELETE FROM treenode_connector_edge
+          WHERE id = OLD.id;
+      RETURN OLD;
+  END;
+  $$;
+
+  CREATE OR REPLACE FUNCTION on_delete_connector_update_geom() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$ BEGIN
+      DELETE FROM connector_geom
+          WHERE id = OLD.id;
+      RETURN OLD;
+  END;
+  $$;
+
+
+  CREATE OR REPLACE FUNCTION on_edit_treenode_connector_update_edges() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$ BEGIN
+      IF OLD.treenode_id IS DISTINCT FROM NEW.treenode_id OR
+         OLD.connector_id IS DISTINCT FROM NEW.connector_ID THEN
+
+          UPDATE treenode_connector_edge
+              SET
+                  id = NEW.id,
+                  edge = ST_MakeLine(
+                      ST_MakePoint(t.location_x, t.location_y, t.location_z),
+                      ST_MakePoint(c.location_x, c.location_y, c.location_z))
+              FROM treenode t, connector c
+              WHERE id = OLD.id
+                AND t.id = NEW.treenode_id
+                AND c.id = NEW.connector_id;
+      END IF;
+      RETURN NEW;
+  END;
+  $$;
+
+
+  CREATE OR REPLACE FUNCTION on_edit_treenode_update_treenode_connector_edges() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$ BEGIN
+      IF OLD.location_x != NEW.location_x OR
+         OLD.location_y != NEW.location_y OR
+         OLD.location_z != NEW.location_z THEN
+          UPDATE treenode_connector_edge
+              SET edge = q.edge
+              FROM (SELECT
+                      tc.id,
+                      ST_MakeLine(
+                          ST_MakePoint(NEW.location_x, NEW.location_y, NEW.location_z),
+                          ST_MakePoint(c.location_x, c.location_y, c.location_z))
+                  FROM
+                      treenode_connector tc,
+                      connector c
+                  WHERE tc.treenode_id = NEW.id
+                    AND c.id = tc.connector_id) AS q(tcid, edge)
+              WHERE id = q.tcid;
+      END IF;
+      RETURN NEW;
+  END;
+  $$;
+
+
+  CREATE OR REPLACE FUNCTION on_edit_connector_update_treenode_connector_edges() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$ BEGIN
+      IF OLD.location_x != NEW.location_x OR
+         OLD.location_y != NEW.location_y OR
+         OLD.location_z != NEW.location_z THEN
+          UPDATE treenode_connector_edge
+              SET edge = q.edge
+              FROM (SELECT
+                      tc.id,
+                      ST_MakeLine(
+                          ST_MakePoint(t.location_x, t.location_y, t.location_z),
+                          ST_MakePoint(NEW.location_x, NEW.location_y, NEW.location_z))
+                  FROM treenode_connector tc, treenode t
+                  WHERE tc.connector_id = NEW.id
+                    AND t.id = tc.treenode_id) AS q(tcid, edge)
+              WHERE id = q.tcid;
+
+          UPDATE connector_geom
+              SET geom = ST_MakePoint(NEW.location_x, NEW.location_y, NEW.location_z)
+              WHERE id = NEW.id;
+      END IF;
+      RETURN NEW;
+  END;
+  $$;
+
+
+  CREATE OR REPLACE FUNCTION on_insert_treenode_connector_update_edges() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$ BEGIN
+      INSERT INTO treenode_connector_edge (
+              id,
+              project_id,
+              edge)
+          (SELECT
+              NEW.id,
+              NEW.project_id,
+              ST_MakeLine(
+                  ST_MakePoint(t.location_x, t.location_y, t.location_z),
+                  ST_MakePoint(c.location_x, c.location_y, c.location_z))
+          FROM treenode t, connector c
+          WHERE t.id = NEW.treenode_id
+            AND c.id = NEW.connector_id);
+      RETURN NEW;
+  END;
+  $$;
+
+
+  CREATE OR REPLACE FUNCTION on_insert_connector_update_connector_geom() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$ BEGIN
+      INSERT INTO connector_geom (
+              id,
+              project_id,
+              geom)
+          VALUES (
+              NEW.id,
+              NEW.project_id,
+              ST_MakePoint(NEW.location_x, NEW.location_y, NEW.location_z));
+      RETURN NEW;
+  END;
+  $$;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catmaid', '0058_add_pg_trgm_ext_and_class_instance_name_index'),
+    ]
+
+    operations = [
+      migrations.RunSQL(forward, backward, [
+          migrations.CreateModel(
+              name='NodeGridCache',
+              fields=[
+                  ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                  ('orientation', models.IntegerField(default=0)),
+                  ('cell_width', models.IntegerField()),
+                  ('cell_height', models.IntegerField()),
+                  ('cell_depth', models.IntegerField()),
+                  ('n_largest_skeletons_limit', models.IntegerField(null=True)),
+                  ('n_last_edited_skeletons_limit', models.IntegerField(null=True)),
+                  ('project', models.ForeignKey(on_delete=django.db.models.deletion.DO_NOTHING, to='catmaid.Project')),
+              ],
+              options={
+                  'db_table': 'node_grid_cache',
+              },
+          ),
+          migrations.CreateModel(
+              name='NodeGridCacheCell',
+              fields=[
+                  ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                  ('x_index', models.IntegerField()),
+                  ('y_index', models.IntegerField()),
+                  ('z_index', models.IntegerField()),
+                  ('update_time', models.DateTimeField(default=django.utils.timezone.now)),
+                  ('json_data', django.contrib.postgres.fields.jsonb.JSONField(blank=True, null=True)),
+                  ('json_text_data', models.TextField(blank=True, null=True)),
+                  ('msgpack_data', models.BinaryField(null=True)),
+                  ('grid', models.ForeignKey(on_delete=django.db.models.deletion.DO_NOTHING, to='catmaid.NodeGridCache')),
+              ],
+              options={
+                  'db_table': 'node_grid_cache_cell',
+              },
+          ),
+          migrations.CreateModel(
+              name='DirtyNodeGridCacheCell',
+              fields=[
+                  ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                  #('grid_cell', models.OneToOneField(on_delete=django.db.models.deletion.DO_NOTHING, primary_key=True, serialize=False, to='catmaid.NodeGridCacheCell')),
+                  ('grid', models.ForeignKey(on_delete=django.db.models.deletion.DO_NOTHING, to='catmaid.NodeGridCache')),
+                  ('x_index', models.IntegerField()),
+                  ('y_index', models.IntegerField()),
+                  ('z_index', models.IntegerField()),
+                  ('invalidation_time', models.DateTimeField(default=django.utils.timezone.now)),
+              ],
+              options={
+                  'db_table': 'dirty_node_grid_cache_cell',
+              },
+          ),
+          migrations.AlterUniqueTogether(
+              name='nodegridcachecell',
+              unique_together={('grid', 'x_index', 'y_index', 'z_index')},
+          ),
+          migrations.AlterUniqueTogether(
+              name='dirtynodegridcachecell',
+              unique_together={('grid', 'x_index', 'y_index', 'z_index')},
+          ),
+          migrations.AlterUniqueTogether(
+              name='nodegridcache',
+              unique_together={('project', 'orientation', 'cell_width', 'cell_height', 'cell_depth')},
+          ),
+          migrations.AddField(
+              model_name='nodegridcache',
+              name='enabled',
+              field=models.BooleanField(default=True),
+          ),
+          migrations.AddField(
+              model_name='nodegridcache',
+              name='allow_empty',
+              field=models.BooleanField(default=False),
+          ),
+          migrations.AddField(
+              model_name='nodegridcache',
+              name='has_json_data',
+              field=models.BooleanField(default=False),
+          ),
+          migrations.AddField(
+              model_name='nodegridcache',
+              name='has_json_text_data',
+              field=models.BooleanField(default=False),
+          ),
+          migrations.AddField(
+              model_name='nodegridcache',
+              name='has_msgpack_data',
+              field=models.BooleanField(default=False),
+          ),
+          migrations.AddField(
+              model_name='nodegridcache',
+              name='hidden_last_editor',
+              field=models.ForeignKey(on_delete=models.deletion.DO_NOTHING, to=settings.AUTH_USER_MODEL),
+          ),
+          migrations.AddField(
+              model_name='nodegridcache',
+              name='lod_min_bucket_size',
+              field=models.IntegerField(default=500),
+          ),
+          migrations.AddField(
+              model_name='nodegridcache',
+              name='lod_strategy',
+              field=models.TextField(default='quadratic'),
+          ),
+          migrations.AddField(
+              model_name='nodegridcache',
+              name='n_lod_levels',
+              field=models.IntegerField(default=1),
+          ),
+        ]),
+    ]

--- a/django/applications/catmaid/models.py
+++ b/django/applications/catmaid/models.py
@@ -1342,6 +1342,59 @@ class NodeQueryCache(models.Model):
         unique_together = (('project', 'orientation', 'depth'),)
 
 
+class NodeGridCache(models.Model):
+    project = models.ForeignKey(Project, on_delete=models.DO_NOTHING)
+    orientation = models.IntegerField(default=0, null=False)
+    cell_width = models.IntegerField(null=False)
+    cell_height = models.IntegerField(null=False)
+    cell_depth = models.IntegerField(null=False)
+    n_lod_levels = models.IntegerField(null=False, default=1)
+    lod_strategy = models.TextField(null=False, default='quadratic')
+    lod_min_bucket_size = models.IntegerField(null=False, default=500)
+    n_largest_skeletons_limit = models.IntegerField(null=True)
+    n_last_edited_skeletons_limit = models.IntegerField(null=True)
+    hidden_last_editor = models.ForeignKey(User, on_delete=models.DO_NOTHING)
+    allow_empty = models.BooleanField(default=False, null=False)
+    has_json_data = models.BooleanField(default=False, null=False)
+    has_json_text_data = models.BooleanField(default=False, null=False)
+    has_msgpack_data = models.BooleanField(default=False, null=False)
+    enabled = models.BooleanField(default=True, null=False)
+
+    class Meta:
+        db_table = "node_grid_cache"
+        unique_together = (('project', 'orientation', 'cell_width', 'cell_height', 'cell_depth'),)
+
+
+class NodeGridCacheCell(models.Model):
+    grid = models.ForeignKey(NodeGridCache, on_delete=models.DO_NOTHING)
+    x_index = models.IntegerField(null=False)
+    y_index = models.IntegerField(null=False)
+    z_index = models.IntegerField(null=False)
+    update_time = models.DateTimeField(default=timezone.now, null=False)
+    json_data = JSONField(blank=True, null=True)
+    json_text_data = models.TextField(blank=True, null=True)
+    msgpack_data = models.BinaryField(null=True)
+
+    class Meta:
+        db_table = "node_grid_cache_cell"
+        unique_together = (('grid', 'x_index', 'y_index', 'z_index'),)
+
+
+class DirtyNodeGridCacheCell(models.Model):
+    """A dirty cache grid cell. Referential integrety is taken care of on the
+    database level.
+    """
+    #grid_cell = models.OneToOneField(NodeGridCacheCell, on_delete=models.DO_NOTHING, primary_key=True)
+    grid = models.ForeignKey(NodeGridCache, on_delete=models.DO_NOTHING)
+    x_index = models.IntegerField(null=False)
+    y_index = models.IntegerField(null=False)
+    z_index = models.IntegerField(null=False)
+    invalidation_time = models.DateTimeField(default=timezone.now, null=False)
+
+    class Meta:
+        db_table = "dirty_node_grid_cache_cell"
+        unique_together = (('grid', 'x_index', 'y_index', 'z_index'),)
+
 initial_colors = ((1, 0, 0, 1),
                   (0, 1, 0, 1),
                   (0, 0, 1, 1),

--- a/django/applications/catmaid/spatial.py
+++ b/django/applications/catmaid/spatial.py
@@ -1,0 +1,35 @@
+from django.db import connection
+
+def enable_spatial_update_events(ignore_missing_fn=False):
+    """Enable history tracking globally.
+    """
+    cursor = connection.cursor()
+    if ignore_missing_fn:
+        cursor.execute("""
+            SELECT EXISTS(SELECT * FROM pg_proc
+            WHERE proname = 'enable_spatial_update_events');""")
+        result = cursor.fetchone()
+        if not result[0]:
+            # If the function does not exist, return silently if the missing
+            # function shouldn't be reported
+            return False
+    cursor.execute("SELECT enable_spatial_update_events()")
+    return True
+
+
+def disable_spatial_update_events(ignore_missing_fn=False):
+    """Disable history tracking globally.
+    """
+    cursor = connection.cursor()
+    if ignore_missing_fn:
+        cursor.execute("""
+            SELECT EXISTS(SELECT * FROM pg_proc
+            WHERE proname = 'disable_spatial_update_events');""")
+        result = cursor.fetchone()
+        if not result[0]:
+            # If the function does not exist, return silently if the missing
+            # function shouldn't be reported
+            return False
+    cursor.execute("SELECT disable_spatial_update_events()")
+    return True
+

--- a/django/applications/catmaid/static/js/dom.js
+++ b/django/applications/catmaid/static/js/dom.js
@@ -174,7 +174,7 @@
           type: 'radio',
           name: name,
           id: val.id,
-          value: val.id
+          value: val.value !== undefined ? val.value : val.id
       }, helptext).prop('checked', val.checked).change(handler)));
     }, $('<div />'));
   };

--- a/django/applications/catmaid/static/js/layers/tracing-layer.js
+++ b/django/applications/catmaid/static/js/layers/tracing-layer.js
@@ -117,6 +117,15 @@
         this.tracingOverlay.updateWhilePanning = value;
       }
     });
+
+    Object.defineProperty(this, 'levelOfDetail', {
+      get: function() {
+        return this.tracingOverlay.levelOfDetail;
+      },
+      set: function(value) {
+        this.tracingOverlay.levelOfDetail = value;
+      }
+    });
   }
 
   TracingLayer.prototype = Object.create(CATMAID.PixiLayer.prototype);
@@ -195,6 +204,14 @@
       type: 'checkbox',
       value: this.updateWhilePanning,
       help: 'Whether or not to update the visible tracing data while panning the view.'
+    }, {
+      name: 'levelOfDetail',
+      displayName: 'Level of detail',
+      type: 'number',
+      step: 1,
+      min: 0,
+      value: this.levelOfDetail,
+      help: 'Level-of-detail, use 0 for all levels (most detail)',
     }, {
       name: 'applyTracingWindow',
       displayName: 'Apply and show tracing window',
@@ -297,6 +314,9 @@
       this.tracingOverlay.updateNodes(this.tracingOverlay.redraw.bind(this.tracingOverlay, true));
     } else if ('updateWhilePanning' === name) {
       this.updateWhilePanning = value;
+    } else if ('levelOfDetail' === name) {
+      this.levelOfDetail = value;
+      this.tracingOverlay.updateNodes(this.tracingOverlay.redraw.bind(this.tracingOverlay, true));
     }
   };
 

--- a/django/applications/catmaid/static/js/widgets/settings.js
+++ b/django/applications/catmaid/static/js/widgets/settings.js
@@ -1111,6 +1111,48 @@
           'read_only_mirror_index',
           SETTINGS_SCOPE));
 
+      ds.append(wrapSettingsControl(
+          CATMAID.DOM.createCheckboxSetting(
+              "Adaptive LOD",
+              CATMAID.TracingOverlay.Settings[SETTINGS_SCOPE].adaptive_lod,
+              "If level of detail (LOD) information is available for a request, " +
+              "adaptive LOD will choose the LOD value based on the current zoom level.",
+              function() {
+                CATMAID.TracingOverlay.Settings
+                    .set(
+                      'adaptive_lod',
+                      this.checked,
+                      SETTINGS_SCOPE);
+              }),
+          CATMAID.TracingOverlay.Settings,
+          'adaptive_lod',
+          SETTINGS_SCOPE));
+
+      ds.append(wrapSettingsControl(
+          CATMAID.DOM.createInputSetting(
+              "Adaptive LOD zoom range",
+              CATMAID.TracingOverlay.Settings[SETTINGS_SCOPE].adaptive_lod_scale_range.join(', '),
+              "Define two numbers A and B, separated by a comma. This settings defines " +
+              "a range of zoom level percentages to which available level of detail (LOD) " +
+              "information is mapped.",
+              function() {
+                let newValues = this.value.split(',')
+                    .map(s => s.trim()).filter(s => s.length > 0).map(Number);
+
+                if (newValues.length != 2) {
+                  CATMAID.warn("Invalid LOD range");
+                  return;
+                }
+                CATMAID.TracingOverlay.Settings
+                    .set(
+                      'adaptive_lod_scale_range',
+                      newValues,
+                      SETTINGS_SCOPE);
+              }),
+          CATMAID.TracingOverlay.Settings,
+          'adaptive_lod_scale_range',
+          SETTINGS_SCOPE));
+
 
       var dsNodeColors = CATMAID.DOM.addSettingsContainer(ds, "Skeleton colors", true);
       dsNodeColors.append(CATMAID.DOM.createCheckboxSetting(

--- a/django/applications/catmaid/tests/test_history_tables.py
+++ b/django/applications/catmaid/tests/test_history_tables.py
@@ -253,6 +253,7 @@ class HistoryTableTests(TransactionTestCase):
         'taggit_taggeditem__tracking',
 
         # Regular unversioned CATMAID tables
+        'dirty_node_grid_cache_cell',
         'node_query_cache',
         'log',
         'treenode_edge',
@@ -260,6 +261,8 @@ class HistoryTableTests(TransactionTestCase):
         'treenode_connector_edge',
         'connector_geom',
         'nblast_skeleton_source_type',
+        'node_grid_cache_cell',
+        'node_grid_cache',
         'catmaid_transaction_info',
         'catmaid_stats_summary',
         'catmaid_skeleton_summary',

--- a/django/projects/mysite/settings_base.py
+++ b/django/projects/mysite/settings_base.py
@@ -418,3 +418,13 @@ CREATE_DEFAULT_DATAVIEWS = True
 # NBLAST support
 NBLAST_ALL_BY_ALL_MIN_SIZE = 10
 MAX_PARALLEL_ASYNC_WORKERS = 1
+
+# Intersection grid settings, dimensions in project coordinates (nm)
+DEFAULT_CACHE_GRID_CELL_WIDTH = 25000
+DEFAULT_CACHE_GRID_CELL_HEIGHT = 25000
+DEFAULT_CACHE_GRID_CELL_DEPTH = 40
+
+# Whether Postgres should emit "catmaid.spatial-update" events on changes of
+# spatial data (e.g. inserts, updates and deletions of treenodes, connectors and
+# connector links).
+SPATIAL_UPDATE_NOTIFICATIONS = False

--- a/sphinx-doc/source/administration.rst
+++ b/sphinx-doc/source/administration.rst
@@ -368,6 +368,13 @@ CATMAID
   the ``DATA_UPLOAD_MAX_MEMORY_SIZE`` setting, which is the maximum allowed
   request body size in bytes. It defaults to 10 MB (83886080).
 
+* Consider using node grid cache for large tracing data set, which can speed up
+  loading and supports level-of-detail as well as dynamic updates based on
+  database events. Automatic cache updates require ``SPATIAL_UPDATE_NOTIFICATIONS``
+  to be set to true in ``settings.py`` (default). If caching is not an option,
+  make sure to set ``SPATIAL_UPDATE_NOTIFICATIONS = False`` if you deal with
+  large skeletons (>50k nodes) to make operations like joins faster.
+
 Making CATMAID available through SSL
 ------------------------------------
 

--- a/sphinx-doc/source/administrator.rst
+++ b/sphinx-doc/source/administrator.rst
@@ -12,6 +12,7 @@ Administrator Documentation
    permissions
    celery
    websockets
+   tracing-caches
    history_tables
    docker
    userprofiles

--- a/sphinx-doc/source/options.rst
+++ b/sphinx-doc/source/options.rst
@@ -53,3 +53,10 @@ overridden in ``settings.py``. Below is an explanation of all available settings
      This option controls the maximum allowed requests size that the client
      application is allowed to send in bytes. By default this is set to 10 MB.
      If a requests exceeds this limit, error code 400 is returned.
+
+.. glossary::
+   ``SPATIAL_UPDATE_NOTIFICATIONS``
+      If enabled, each spatial update (e.g placing, updating or deleting
+      treenodes, connectors, connector links) will trigger a PostgreSQL event
+      named "catmaid.spatial-update". This allows cache update workers to update
+      caches quickly after a change. Disabled by default.

--- a/sphinx-doc/source/tracing-caches.rst
+++ b/sphinx-doc/source/tracing-caches.rst
@@ -1,0 +1,188 @@
+.. _tracing-caches:
+
+Tracing data caching
+====================
+
+For setups with a large amount of tracing data it can be helpful to setup
+intersection caching, especially for larger fields of view (FOV). Such caches
+store precomputed results to spatial queries for the respective container. There
+currently two types of node caches (as they are called) available:
+``node-query-cache`` and ``node-query-grid-cache``. The former stores
+intersection results for whole sections and the latter one allows to specify a
+regular grid for which results will be precomputed. They are generally populated
+using the Django management command ``catmaid_update_cache_tables``. It allows
+to specify the type of cache using the ``--cache`` option, which can be
+``section`` or ``grid``.
+
+Caches can be automatically updated on data changes as long as the variable
+``SPATIAL_UPDATE_NOTIFICATIONS`` is set to ``True`` (disabled by default). If
+caches are not used on a CATMAID instance with a large amount of tracing data,
+it might make sense to disable this setting to improve the speed of operations
+like skeleton joins.
+
+Both cache types support level of detail (LOD) configurations. This allows to
+access cached data in terms of a set of an ordered set of buckets. Being able to
+access only a part of all caches consistently, allows for quicker browsing of
+larger data sets and maintaining more detail on lower zoom levels.
+
+All caches can store the data in either simple *JSON text*, as *JSON database
+object* or a binary *msgpack* representation. The ``msgpack`` version seems to
+be the fastest in most situations.
+
+Node Query Cache
+----------------
+
+For a given orientation this cache stores the intersections with a full section,
+i.e. all nodes intersecting the plane at a given depth (Z for XY, etc.). To
+enable this cache for look-up, add a section like this to your
+``NODE_PROVIDERS`` array in the ``settings.py`` file::
+
+  ('cached_msgpack', {
+        'enabled': True,
+        'orientation': 'xy',
+        'step': 40
+  }),
+
+This will make the back-end look for a msgpack format section cache. If nothing
+is found, the next available node provider will be checked. Besides
+``cached_msgpack`` there is also ``cached_json`` and ``cached_json_text``. The
+regular node provider options like ``min_x``, ``max_z``, etc. are supported as
+well. Also this entry indicates the cache is only defined for the XY orientation
+and assumes a section thickness of ``40 nm``. These values are also used as
+defaults for the refresh of the cache.
+
+This cache is fast for large field of views that cover most of a section or has
+to be limited clearly for limit the node count. Otherwise it can cause too many
+nodes to be loaded.
+
+To populate the cache, the ``catmaid_update_cache_tables`` command can be used
+for instance like this::
+
+  ./manage.py catmaid_update_cache_tables --type msgpack --orientation xy \
+      --step 40 --node-limit 0 --min-z 80000 --max-z 8400 --noclean \
+      --n-largest-skeletons-limit 1000
+
+This will ask interactively for the project you want to the create the cache
+for. With this done a whole section query for each Z in XY orientation is
+created. The distance between to sections is set to be ``40 nm``. Also, only a
+range of Z values is computed, which is sometimes useful for testing different
+configurations. The ``--noclean`` option ensures CATMAID isn't removing existing
+cached data. Additionally, only the 1000 largest skeletons are displayed.
+
+There are more options available, which can be read on using::
+
+  ./manage.py catmaid_update_cache_tables --help
+
+Node Query Grid Cache
+---------------------
+
+The ``grid`` cache option for the ``catmaid_update_cache_tables`` populates a
+grid made out of cells, each with the same height, width and depth. For each of
+these cells a separate spatial query is cached, which also allows independent
+updates. In its simplest form, the cache can be enabled for lookup by adding an
+entry like the following to the ``NODE_PROVIDERS`` array in ``settings.py``::
+
+  ('cached_msgpack_grid', {
+        'enabled': True,
+        'orientation': 'xy',
+  }),
+
+This will make node queries look for grid caches for the XY orientation. Like
+with the section cache, there are options like ``min_x``, ``max_x``, etc. can be
+used to limit for which volume the cache should be defined.
+
+To create this cache, the ``catmaid_update_cache_tables`` management command can
+be used like this::
+
+  ./manage.py catmaid_update_cache_tables --project=1 --cache grid \
+      --type msgpack --cell-width 20000 --cell-height 20000 --cell-depth 40
+
+As a result a uniform msgpack encoded grid cache with cells with the dimensions
+20um x 20um x 40 nm (w x h x d).
+
+The optional settings parameter ``DEFAULT_CACHE_GRID_CELL_WIDTH``,
+``DEFAULT_CACHE_GRID_CELL_HEIGHT`` and ``DEFAULT_CACHE_GRID_CELL_DEPTH`` allow
+to define defaults for the above management command.
+
+Updating caches
+---------------
+
+Functionality to update cells automatically is available as well. CATMAID uses
+Postgres' ``NOTIFY``/``LISTEN`` feature, which allows for asynchronous event
+following the *pubsub* model. To lower the impact on regular tracing operations
+(especially joining), an insert/update/delete trigger for treenode and connector
+will execute a conditional trigger function, which is set on CATMAID startup.
+
+These events ("catmaid.spatial-update" and "catmaid.dirty-cache") are disabled by
+default, because they add slightly to the query time, even if not used. To
+enable these database events and allow automatic cache updates, set the
+``settings.py`` variable `SPATIAL_UPDATE_NOTIFICATIONS = True`. Once enabled,
+these events can be consumed by third party clients as well.
+
+Cache updates work by running two additional worker processes in the form of
+management commands: `catmaid_spatial_update_worker` and
+`catmaid_cache_update_worker`. The former is responsible for listening to the
+"catmaid.spatial-update" Postgres event and adds entries to the table
+`dirty_node_grid_cache_cell` for each intersected cache cell in an enabled grid
+cache. Upon inserts and updates this table issues the "catmaid-dirty" cache
+event, which the second management command will listen to. It's its
+responsibility to update the respective cache cells and remove entries from the
+dirty table. If single worker processes aren't enough, more workers need to be
+started.
+
+When treenodes are created, moved or deleted the database emits the event
+"catmaid.spatial-update" along with the start and end node coordinates. The same
+happens with changed connectors and connector links. Other processes can use
+this to asynchronously react to those events without writing to another table or
+blocking trigger processing in other ways.
+
+Alternatively, it is possible to monitor the ``catmaid_transaction_info`` table
+and see which entries caused spatial changes and recompute selectively.
+
+Level of detail
+---------------
+
+The node query result for either a whole section or a single grid cell is not
+stores as a single big entry in the cache. Instead it is stored in level of
+detail (LOD) buckets, each one only allowing a maximum amount of nodes except
+for the last one, which takes all remaining nodes. This allows requests that
+make use of this cache declare they are only interested in e.g. 5 nodes per grid
+cell. With small enough grid size dimensions this allows for a uniform control
+of reasonable node distributions for each zoom level in the front-end.
+
+To configure LOD relevant parameters during cache constructions the options
+``--lod-levels``, ``--lod-bucket-size`` and ``--lod-strategy`` can be used with
+the ``catmaid_update_cache_tables`` management command. The options are optional
+and have defined defaults.
+
+The first option defines how many LOD levels there should be. By default only one
+level is defined, which effectively means there are no levels of detail.
+
+The second option defines how many nodes are allowed in every bucket (except the
+last one). The default here is a bucket size of ``500``.
+
+The last option allows to select between the strategies ``linear``,
+``quadratic`` and ``exponential``. Each one defines a way how the bucket size of
+every bucket will be computed based on the last one. In linear mode, each bucket
+has the same size, the one defined with ``--lod-bucket-size``. In quadratic
+mode, the first bucket has the passed in size, the following are computed by
+multiplying the initial bucket size with ``lod-level ** 2``, i.e. the second
+bucket allows for the square of the initial bucket size. This mode is also the
+default. In exponential mode, the initial bucket size is multiplied with ``2 **
+lod-level``, i.e. buckets grow faster.
+
+To create a usable LOD configuration for a grid cache, the command line could
+look like this::
+
+  ./manage.py catmaid_update_cache_tables --project=1 --cache grid \
+      --type msgpack --cell-width 20000 --cell-height 20000 --cell-depth 40 \
+      --lod-levels 50 --lod-bucket-size 5 --lod-strategy quadratic
+
+This will start with the first level of detail with a bucket of size 5, then 25,
+125 and so on up to 12,500 in bucket 50.
+
+The front-end allows to set a "Level of detail" (LOD) value in the tracing layer
+settings. By default, this is set to "max", which causes all LOD levels to be
+included. Setting this to 1, will include only the first level. The font-end
+also allows to map zoom levels to particular LOD levels. This allows flexible
+zooming behavior with adaptive display limits using cached data.


### PR DESCRIPTION
I add this feature as PR mainly for documentation purposes and to potentially get some feedback if someone has concerns regarding these changes. Otherwise I will probably merge this in the next few days. Most of the changes don't affect setups without any of these caches and I mainly need them for more flexible control on what to display if there are large amounts of neurons per section (~500k in my case), where is seems to work well.

Similar to the simple `node_query_cache` table and node providers, there is now also a `node_grid_query_cache` table and node provider. Together with the `node_grid_query_cache_cell` table, a cache for spatial data in individual AABB bounding boxes in a uniform grid can be be stored and queried with this. The management command `catmaid_update_cache` has
been updated so that it can work with grid caches, too. A typical call to create new grid cache cells could look like this:
```
./manage.py catmaid_update_cache_tables --project=1 --cache grid \
    --type msgpack --cell-width 50000 --cell-height 50000 --cell-depth 40
```
This will create a uniform grid with cells of size 50000x50000x40 nm. Other general node provider parameters like `--min-z`/`--max-z` or `--orientation` can be used as well.

The optional settings parameter `DEFAULT_CACHE_GRID_CELL_WIDTH`, `DEFAULT_CACHE_GRID_CELL_HEIGHT` and `DEFAULT_CACHE_GRID_CELL_DEPTH` allow to define defaults for the above management command.

Functionality to update cells automatically is included as well. This uses Postgres' `NOTIFY`/`LISTEN` feature, which allows for asynchronous events in a pubsub way. To lower the impact on regular tracing operations (especially joining), an insert/update/delete trigger for treenode and connector will trigger the update event conditionally, based on which handler is set during CATMAID startup, which in turns is controlled by `SPATIAL_UPDATE_NOTIFICATIONS` in the `settings.py` file. Surprisingly, there doesn't seem to be a big impact of `pg_notify` as long as it is done in a separate function. In case these events (`catmaid.spatial-update` and `catmaid.dirty-cache`) should have an impact, it is possible to disable them by setting `SPATIAL_UPDATE_NOTIFICATIONS = False` in `settings.py`. It is enabled by default, because no large differences could be measured. If the events are enabled, other processes can use this to asynchronously react to those events without writing to another table or blocking trigger processing in other ways.

Performance-wise I had to try various implementations until I found one with barely any impact on the common tracing actions like splits and joins. The plot below shows a few benchmarks on the different implementations using `pg_notify`, this branch is the last column, titled "concat, events on, latest" and the current `dev` branch is represented by the second column.

![image](https://user-images.githubusercontent.com/112226/50946222-64179e80-1466-11e9-8819-a74ffbd5897b.png)

These tests provide also useful information for updates of cached NBLAST data with similar techniques.  

Cache updates work by running two additional worker process in the form of management commands: `catmaid_spatial_update_worker` and `catmaid_cache_update_worker`. The former is responsible for listening to the "catmaid.spatial-update" Postgres event and adds entries to the
table `dirty_node_grid_cache_cell` for each intersected cache cell in an enabled grid cache. Upon inserts and updates this table issues the "catmaid-dirty" cache event, which the second managment command will listen to. It's its responsibility to update the respective cache cells and remove entries from the dirty table. Based on the table `dirty_node_grid_cache_cell` cache based node queries can check if a particular cell is marked dirty without running into locking issues.

The node query result for either a whole section or a single grid cell is not stores as a single big entry in the cache. Instead it is stored in level of detail (LOD) buckets, each one only allowing a maximum amount of nodes except for the last one, which takes all remaining nodes. This allows requests that make use of this cache declare they are only interested in e.g. 5 nodes per grid
cell. With small enough grid size dimensions this allows for a uniform control of reasonable node distributions for each zoom level in the front-end.

The front-end allows to set a "Level of detail" (LOD) value in the tracing layer settings. By default, this is set to "max", which causes all LOD levels to be included. Setting this to 1, will include only the first level. The font-end also allows to map zoom levels to particular LOD levels. This allows flexible zooming behavior with adaptive display limits using cached dat

To use levels of detail, the command line options are available:
```
--lod-levels      to configures over how many levels the data should be
                  spread, default 1.
--lod-bucket-size to configure the how many nodes fit into the first LOD
                  level. The size of Additional buckets/levels depends
                  on the selected LOD strategy. Default: 500.
--lod-strategy    to configure whether the increase of visible data per LOD
                  level should be "linear" or "quadratic". If the former,
                  each LOD level will have "lod-bucket-size" more data per
                  level. For quadratic, each level has space for
                  "lod-bucket-size" to the power of (LOD level) node
                  available. Default is "quadratic".
```
These settings can be used e.g. like this:
```
./manage.py catmaid_update_cache_tables --project=1 --cache grid \
    --type msgpack --cell-width 50000 --cell-height 50000 --cell-depth 40 \
    --lod-levels 50 --lod-bucket-size 5 --lod-strategy quadratic
```