### PR TITLE
Add rigid and similarity transformations for landmarks

### DIFF
--- a/django/applications/catmaid/static/js/widgets/landmark-widget.js
+++ b/django/applications/catmaid/static/js/widgets/landmark-widget.js
@@ -409,7 +409,7 @@
    */
   LandmarkWidget.prototype.selectLandmark = function(landmarkId) {
     if (this.mode === 'landmarks') {
-      
+
     }
   };
 
@@ -692,7 +692,7 @@
     if (this.editLandmarkGroup) {
 
     } else {
-      
+
     }
   };
 
@@ -878,9 +878,9 @@
    * @returns new LandmarkSkeletonTransformation instance
    */
   LandmarkWidget.prototype.addDisplayTransformation = function(projectId,
-      skeletons, mapping, api) {
+      skeletons, mapping, api, modelClass) {
     let lst = new CATMAID.LandmarkSkeletonTransformation(projectId, skeletons,
-        mapping, api);
+        mapping, api, undefined, modelClass);
     this.displayTransformations.push(lst);
 
     // Announce that there is a new display tranformation available
@@ -895,7 +895,7 @@
    * source group. Only links with the passed in relation ID will be respected.
    */
   LandmarkWidget.prototype.addDisplayTransformationRule = function(getSkeletonModels,
-      fromGroupId, relationId) {
+      fromGroupId, relationId, modelClass) {
     // Get all transitively linked target groups from back-end. Add a
     // transformation for each.
     var self = this;
@@ -908,7 +908,7 @@
             throw new CATMAID.Warning("Could not find source skeletons");
           }
           let lst = new CATMAID.LandmarkSkeletonTransformation(projectId,
-            skeletons, [[fromGroupId, toGroupId]]);
+            skeletons, [[fromGroupId, toGroupId]], undefined, undefined, modelClass);
           self.displayTransformations.push(lst);
         }
         CATMAID.Landmarks.trigger(CATMAID.Landmarks.EVENT_DISPLAY_TRANSFORM_ADDED);
@@ -3251,6 +3251,19 @@
                 })
                 .catch(CATMAID.handleError);
 
+              let transformModelSelect = CATMAID.DOM.createSelect(undefined,
+                  ['Affine', 'Similarity'], 'Affine');
+              let transformModelSelectLabel = CATMAID.DOM.createLabeledControl(
+                  'Transform model', transformModelSelect,
+                  'Model used to fit the transformation between landmarks.');
+              $(newDTForm).append(transformModelSelectLabel);
+              let selectedTransformModel = function () {
+                return {
+                  'Affine': CATMAID.transform.AffineModel3D,
+                  'Similarity': CATMAID.transform.SimilarityModel3D
+                }[transformModelSelect.value];
+              };
+
               // Add button
               let buttonContainer = document.createElement('div');
               buttonContainer.classList.add('clear');
@@ -3299,7 +3312,8 @@
                         throw new CATMAID.Warning("No source skeletons found");
                       }
                       widget.addDisplayTransformation(sourceProject,
-                          skeletonModels, mappings, api);
+                          skeletonModels, mappings, api,
+                          selectedTransformModel());
                       CATMAID.msg("Success", "Transformation added");
                       widget.updateDisplay();
                       widget.update();
@@ -3319,7 +3333,7 @@
                   if (displayTargetRelation) {
                     let getSkeletonModels = source.getSelectedSkeletonModels.bind(source);
                     widget.addDisplayTransformationRule(getSkeletonModels, fromGroup,
-                        displayTargetRelation)
+                        displayTargetRelation, selectedTransformModel())
                       .then(function() {
                         CATMAID.msg("Success", "Transformation rule applied");
                       })
@@ -3343,7 +3357,7 @@
                     }
 
                     widget.addDisplayTransformation(sourceProject, skeletonModels,
-                        mappings, displayTargetRelation);
+                        mappings, displayTargetRelation, selectedTransformModel());
                     CATMAID.msg("Success", "Transformation added");
                     widget.updateDisplay();
                     widget.update();

--- a/django/applications/catmaid/static/js/widgets/landmark-widget.js
+++ b/django/applications/catmaid/static/js/widgets/landmark-widget.js
@@ -3252,7 +3252,7 @@
                 .catch(CATMAID.handleError);
 
               let transformModelSelect = CATMAID.DOM.createSelect(undefined,
-                  ['Affine', 'Similarity'], 'Affine');
+                  ['Affine', 'Rigid', 'Similarity'], 'Affine');
               let transformModelSelectLabel = CATMAID.DOM.createLabeledControl(
                   'Transform model', transformModelSelect,
                   'Model used to fit the transformation between landmarks.');
@@ -3260,6 +3260,7 @@
               let selectedTransformModel = function () {
                 return {
                   'Affine': CATMAID.transform.AffineModel3D,
+                  'Rigid': CATMAID.transform.RigidModel3D,
                   'Similarity': CATMAID.transform.SimilarityModel3D
                 }[transformModelSelect.value];
               };

--- a/django/applications/catmaid/static/libs/catmaid/models/landmarks.js
+++ b/django/applications/catmaid/static/libs/catmaid/models/landmarks.js
@@ -405,16 +405,17 @@
       }
 
       var mls = new CATMAID.transform.MovingLeastSquaresTransform();
-      var model = new CATMAID.transform.AffineModel3D();
+      var model = new transformation.modelClass();
       mls.setModel(model);
 
       var invMls = new CATMAID.transform.MovingLeastSquaresTransform();
-      var invModel = new CATMAID.transform.AffineModel3D();
+      var invModel = new transformation.modelClass();
       invMls.setModel(invModel);
 
       try {
         mls.setMatches(matches);
       } catch (error) {
+        console.warn(error);
         throw new CATMAID.ValueError("Could not fit model for " +
             (i+1) + ". transformation");
       }
@@ -422,6 +423,7 @@
       try {
         invMls.setMatches(invMatches);
       } catch (error) {
+        console.warn(error);
         throw new CATMAID.ValueError("Could not fit inverse model for " +
             (i+1) + ". transformation");
       }
@@ -790,7 +792,8 @@
    *
    */
   let LandmarkSkeletonTransformation = function(projectId, skeletons,
-      mappings, fromApi = null, color = undefined) {
+      mappings, fromApi = null, color = undefined,
+      modelClass = CATMAID.transform.AffineModel3D) {
     this.projectId = projectId;
     this.skeletons = skeletons;
     let seenSourceIds = new Set(), seenTargetIds = new Set();
@@ -806,6 +809,7 @@
     this.id = CATMAID.tools.uuidv4();
     this.fromApi = fromApi;
     this.color = new THREE.Color(color);
+    this.modelClass = modelClass;
   };
 
   // Provide some basic events


### PR DESCRIPTION
As discussed in #1856.

Note this only adds the models to the landmark widget, not yet to the similarity widget.

While these models are directly reproduced from the MPICBG libraries like the affine model, the results are not very good for the tests I've done with the left/right hemispheres. However, for simple toy examples the results are what one would expect. Either these models are not particularly suited for this domain, or there is some limitation in the implementation for complex transforms. The MPICBG implementation doesn't seem to exactly match any of the published methods I found, so I will follow up with the implementation authors.

PRing until that follow up is done.