### PR TITLE
Convert much string formatting to f-strings

### DIFF
--- a/django/applications/catmaid/admin.py
+++ b/django/applications/catmaid/admin.py
@@ -65,9 +65,8 @@ def export_project_json_action(modeladmin, request, queryset) -> HttpResponse:
     result = export_project_data(projects)
 
     response = HttpResponse(json.dumps(result), content_type='application/json')
-    filename = "catmaid-projects-{}.json".format(
-            "-".join([str(p.id) for p in projects]))
-    response['Content-Disposition'] = u'attachment; filename={}'.format(filename)
+    filename = f"catmaid-projects-{'-'.join([str(p.id) for p in projects])}.json"
+    response['Content-Disposition'] = f'attachment; filename={filename}'
 
     return response
 
@@ -84,9 +83,8 @@ def export_project_yaml_action(modeladmin, request, queryset) -> HttpResponse:
     result = export_project_data(projects)
 
     response = HttpResponse(yaml.dump(result), content_type='application/yaml')
-    filename = "catmaid-projects-{}.yaml".format(
-            "-".join([str(p.id) for p in projects]))
-    response['Content-Disposition'] = u'attachment; filename={}'.format(filename)
+    filename = f"catmaid-projects-{'-'.join([str(p.id) for p in projects])}.yaml"
+    response['Content-Disposition'] = f'attachment; filename={filename}'
 
     return response
 
@@ -109,7 +107,7 @@ def delete_projects_and_data(modeladmin, request, queryset) -> HttpResponseRedir
     """
     project_ids = list(map(str, queryset.values_list('id', flat=True)))
     return HttpResponseRedirect(reverse("catmaid:delete-projects-with-data") +
-            "?ids={}".format(",".join(project_ids)))
+            f"?ids={','.join(project_ids)}")
 delete_projects_and_data.short_description = "Delete selected" # type: ignore # https://github.com/python/mypy/issues/2087
 
 

--- a/django/applications/catmaid/apps.py
+++ b/django/applications/catmaid/apps.py
@@ -149,7 +149,7 @@ def check_client_settings(app_configs, **kwargs):
     """Reset the default client settings for a catmaid instance.
     """
     from catmaid.control import client
-    messages = []
+    messages:List[str] = []
 
     instance_settings = getattr(settings, 'CLIENT_SETTINGS', None)
     if not instance_settings:
@@ -168,7 +168,7 @@ def check_client_settings(app_configs, **kwargs):
                 "Could not parse CLIENT_SETTINGS as JSON: " + instance_settings))
     except Exception as e:
         messages.append(Warning(
-            "Could not reset client instance settings: " + str(e)))
+            f"Could not reset client instance settings: {e}"))
 
     return messages;
 
@@ -193,7 +193,7 @@ class CATMAIDConfig(AppConfig):
 
     def ready(self) -> None:
         """Perform initialization for back-end"""
-        logger.info("CATMAID version {}".format(settings.VERSION))
+        logger.info(f"CATMAID version {settings.VERSION}")
 
         # Make sure all settings variables are of the type we expect.
         self.validate_configuration()

--- a/django/applications/catmaid/consumers.py
+++ b/django/applications/catmaid/consumers.py
@@ -17,17 +17,17 @@ def ws_update_connect(message) -> None:
     # Accept connection
     message.reply_channel.send({"accept": True})
     # Add user to the matching user group
-    Group("updates-{}".format(message.user.id)).add(message.reply_channel)
+    Group(f"updates-{message.user.id}").add(message.reply_channel)
 
 @channel_session_user
 def ws_update_disconnect(message) -> None:
     """Remove channel from group when user disconnects."""
-    Group("updates-{}".format(message.user.id)).discard(message.reply_channel)
+    Group(f"updates-{message.user.id}").discard(message.reply_channel)
 
 @channel_session_user
 def ws_update_message(message) -> None:
     """Handle client messages."""
-    logger.info("WebSockets message received: {}".format(message))
+    logger.info(f"WebSockets message received: {message}")
 
 def msg_user(user_id, event_name, data:str="", data_type:str="text", is_raw_data:bool=False,
         ignore_missing:bool=True) -> None:
@@ -44,7 +44,7 @@ def msg_user(user_id, event_name, data:str="", data_type:str="text", is_raw_data
         })
     # Broadcast to listening sockets
     try:
-        Group("updates-{}".format(user_id)).send({
+        Group(f"updates-{user_id}").send({
             data_type: payload
         })
     except KeyError as e:

--- a/django/applications/catmaid/control/analytics.py
+++ b/django/applications/catmaid/control/analytics.py
@@ -62,7 +62,7 @@ def check_broken_section(project_id:int, skeleton_ids=None, cursor=None) -> List
         skid_constraint = ''
 
     cursor = cursor or connection.cursor()
-    cursor.execute("""
+    cursor.execute(f"""
         WITH broken_project_slice AS (
             SELECT p.id AS project_id,
                 s.id AS stack_id,
@@ -107,8 +107,8 @@ def check_broken_section(project_id:int, skeleton_ids=None, cursor=None) -> List
                 AND t.location_x >= bps.broken_z
                 AND t.location_x < bps.next_z
             ))
-            {}
-    """.format(skid_constraint), params)
+            {skid_constraint}
+    """, params)
 
     return cursor.fetchall()
 

--- a/django/applications/catmaid/control/authentication.py
+++ b/django/applications/catmaid/control/authentication.py
@@ -210,8 +210,8 @@ def requires_user_role(roles):
                 # The user can execute the function.
                 return f(request, *args, **kwargs)
             else:
-                msg = "User '{}' with ID {} does not have the required permissions in " \
-                      "project {}".format(u.username, u.id, int(kwargs['project_id']))
+                msg = f"User '{u.username}' with ID {u.id} does not have the required permissions in " + \
+                      f"project {int(kwargs['project_id'])}"
                 raise PermissionError(msg)
 
         return wraps(f)(inner_decorator)
@@ -250,8 +250,8 @@ def requires_user_role_for_any_project(roles):
                 # The user can execute the function.
                 return f(request, *args, **kwargs)
             else:
-                msg = "User '{}' with ID {} does not have the required permissions " \
-                      "in any project".format(u.username, u.id)
+                msg = f"User '{u.username}' with ID {u.id} does not have the required permissions " + \
+                      f"in any project"
                 raise PermissionError(msg)
 
         return wraps(f)(inner_decorator)

--- a/django/applications/catmaid/control/clustering.py
+++ b/django/applications/catmaid/control/clustering.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import numpy as np
+from typing import List
 
 logger = logging.getLogger(__name__)
 
@@ -11,8 +13,6 @@ except ImportError:
     logger.warning("CATMAID was unable to load the scipy module. "
         "Ontology clustering will not be available")
 
-import numpy as np
-from typing import List
 
 from django import forms
 from django.forms.formsets import formset_factory
@@ -200,7 +200,7 @@ class ClusteringWizard(SessionWizardView):
             'dst_matrix': dst_matrix.tolist(),
             'dendrogram': dendrogram,
         })
-        logger.debug("Clustering: returning response of {} characters".format(len(response.content)))
+        logger.debug(f"Clustering: returning response of {len(response.content)} characters")
         return response
 
 def setup_clustering(request, workspace_pid=None):

--- a/django/applications/catmaid/control/common.py
+++ b/django/applications/catmaid/control/common.py
@@ -162,7 +162,7 @@ def insert_into_log(project_id:Union[int, str], user_id, op_type:str, location=N
     ]
 
     if not op_type in operation_type_array:
-        return {'error': 'Operation type {0} not valid'.format(op_type)}
+        return {'error': f'Operation type {op_type} not valid'}
 
     new_log = Log()
     new_log.user_id = user_id
@@ -390,7 +390,7 @@ def is_valid_host(host:str, auth=None) -> Tuple[bool, str]:
         return (False, 'URL is missing protocol (http://...)')
     reachable, reason = is_reachable(host, auth)
     if not reachable:
-        return (False, 'URL not reachable: {}'.format(reason))
+        return (False, f'URL not reachable: {reason}')
     return (True, "Ok")
 
 

--- a/django/applications/catmaid/control/graph2.py
+++ b/django/applications/catmaid/control/graph2.py
@@ -458,14 +458,14 @@ def _skeleton_graph(project_id, skeleton_ids, confidence_threshold, bandwidth,
                 tc1.relation_id, tc2.relation_id,
                 LEAST(tc1.confidence, tc2.confidence)
             FROM treenode_connector tc1
-            JOIN (VALUES {}) skeleton(id)
+            JOIN (VALUES {skeleton_id_template}) skeleton(id)
                 ON tc1.skeleton_id = skeleton.id
             JOIN treenode_connector tc2
                 ON tc1.connector_id = tc2.connector_id
             WHERE tc1.id != tc2.id
                 AND tc1.relation_id IN (%s, %s)
                 AND tc2.relation_id IN (%s, %s)
-            '''.format(skeleton_id_template), query_params)
+            ''', query_params)
 
             query_skeleton_ids = set(skeleton_ids)
             overall_counts:DefaultDict = defaultdict(partial(defaultdict, make_new_synapse_count_array))

--- a/django/applications/catmaid/control/importer.py
+++ b/django/applications/catmaid/control/importer.py
@@ -76,8 +76,8 @@ class PreStackGroup():
         self.relation = info_object.get('relation', None)
         valid_relations = ("view", "channel")
         if self.relation and self.relation not in valid_relations:
-            raise ValueError("Unsupported stack group relation: {}. Plese use "
-                    "one of: {}.".format(self.relation, ", ".join(valid_relations)))
+            raise ValueError(f"Unsupported stack group relation: {self.relation}. Please use " + \
+                    f"one of: {', '.join(valid_relations)}.")
 
 
 class PreMirror(object):
@@ -154,7 +154,7 @@ class PreStack(object):
         self.orientation = info_object.get('orientation', 0)
         # Make sure this dimension can be matched
         if not Double3D.tuple_pattern.match(self.project_translation):
-            raise ValueError("Couldn't read translation value")
+            raise ValueError("Could not read translation value")
         # Collect stack group information
         self.stackgroups:List = []
         if 'stackgroups' in info_object:
@@ -235,7 +235,7 @@ class PreProject:
             raise ValueError("Can only merge into unknown pre projects")
 
         if self.title != other.title:
-            self.title = "{}, {}".format(self.title, other.title)
+            self.title = f"{self.title}, {other.title}"
 
         self.stacks.extend(other.stacks)
         self.ontology.extend(other.ontology)
@@ -284,7 +284,7 @@ def find_project_folders(image_base:str, path:str, filter_term) -> Tuple[List, D
                         new_key_index = 1
                         while key in projects:
                             new_key_index += 1
-                            key = "{} #{}".format(current_file, new_key_index)
+                            key = f"{current_file} #{new_key_index}"
                         # Remember this project if it isn't available yet
                         projects[key] = project
                         index.append((key, short_name))
@@ -303,7 +303,7 @@ def get_projects_from_raw_data(data, filter_term, base_url=None) -> Tuple[List, 
         if filter_term and not fnmatch.fnmatch(project.title, filter_term):
             continue;
         short_name = project.title
-        key = "{}-{}".format('File', short_name)
+        key = f"File-{short_name}"
         projects[key] = project
         index.append((key, short_name))
 
@@ -337,7 +337,7 @@ def get_projects_from_url(url, filter_term, headers=None, auth=None,
             if filter_term and not fnmatch.fnmatch(project.title, filter_term):
                 continue;
             short_name = project.title
-            key = "{}-{}".format(url, short_name)
+            key = f"{url}-{short_name}"
             projects[key] = project
             index.append((key, short_name))
     elif 'yaml' in content_type:
@@ -347,7 +347,7 @@ def get_projects_from_url(url, filter_term, headers=None, auth=None,
             if filter_term and not fnmatch.fnmatch(project.title, filter_term):
                 continue;
             short_name = project.title
-            key = "{}-{}".format(url, short_name)
+            key = f"{url}-{short_name}"
             if merge_same and key in projects:
                 # Merge newly found and existing projects
                 existing_project = projects[key]
@@ -356,8 +356,8 @@ def get_projects_from_url(url, filter_term, headers=None, auth=None,
                 projects[key] = project
                 index.append((key, short_name))
     else:
-        raise ValueError("Unrecognized content type in response of remote "
-                "'{}\': {}, Content: {}".format( url, content_type, r.content))
+        raise ValueError("Unrecognized content type in response of remote " + \
+                f"'{url}\': {content_type}, Content: {r.content}")
 
     return (index, projects, not_readable)
 
@@ -398,12 +398,12 @@ class ProjectSelector(object):
                 for pi in project_index:
                     ip_data.append(pi[0])
                     ip_data.append(projects[pi[0]].title)
-                cursor.execute("""
+                cursor.execute(f"""
                     SELECT p.id, ip.key, ip.name
                     FROM project p
-                    JOIN (VALUES {}) ip(key, name)
+                    JOIN (VALUES {ip_template}) ip(key, name)
                         ON p.title = ip.name
-                """.format(ip_template), ip_data)
+                """, ip_data)
                 for row in cursor.fetchall():
                     known_project = row[1]
                     p = projects[known_project]
@@ -510,7 +510,7 @@ class ImportingWizard(SessionWizardView):
                 headers = None
                 if len(api_key) > 0:
                     headers = {
-                        'X-Authorization': 'Token {}'.format(api_key)
+                        'X-Authorization': f'Token {api_key}'
                     }
                 project_index, projects, not_readable = get_projects_from_url(
                         complete_catmaid_host, filter_term, headers, auth)
@@ -1394,8 +1394,7 @@ def import_projects(user, pre_projects, tags, permissions,
             import traceback
             not_imported.append((
                 pp,
-                Exception("Couldn't import project: {} {}".format(str(e),
-                        str(traceback.format_exc())))
+                Exception(f"Could not import project: {e} {traceback.format_exc()}")
             ))
 
     return (imported, not_imported)

--- a/django/applications/catmaid/control/ontology.py
+++ b/django/applications/catmaid/control/ontology.py
@@ -48,10 +48,7 @@ class Feature:
         else:
             raise ValueError("A feature needs at least one element")
 
-    def __str__(self):
-        return self.__unicode__()
-
-    def __unicode__(self):
+    def __str__(self) -> str:
         return self.name
 
     def __len__(self):
@@ -64,13 +61,11 @@ class FeatureLink:
         self.relation = relation
         self.super_class = super_class
 
-    def __str__(self):
-        return self.__unicode__()
-
-    def __unicode__(self) -> str:
-        return "[CA {}: {} R {}: {} CB {}: SC {}: {}]".format(self.class_a.id,
-                self.class_a, self.relation.id, self.relation, self.class_b.id,
-                self.class_b, self.super_class.id, self.super_class)
+    def __str__(self) -> str:
+        return f"[CA {self.class_a.id}: {self.class_a} " + \
+               f"R {self.relation.id}: {self.relation} " + \
+               f"CB {self.class_b.id}: {self.class_b} " + \
+               f"SC {self.super_class.id}: {self.super_class}]"
 
 def get_known_ontology_roots(request:HttpRequest) -> JsonResponse:
     """ Returns an array of all known root class names.
@@ -234,7 +229,7 @@ def list_ontology(request:HttpRequest, project_id=None) -> JsonResponse:
                         return JsonResponse(warning)
                 else:
                     if root_class not in class_map:
-                        raise Exception('Root class "{0}" not found'.format( root_class ))
+                        raise Exception(f'Root class "{root_class}" not found')
                     root_class_ids = [ class_map[root_class] ]
 
                 root_node_q = Class.objects.filter(id__in=root_class_ids,

--- a/django/applications/catmaid/control/pointcloud.py
+++ b/django/applications/catmaid/control/pointcloud.py
@@ -366,16 +366,15 @@ class PointCloudList(APIView):
         n_images = len(request.FILES)
 
         if image_names and len(image_names) != n_images:
-            raise ValueError("If image names are passed in, there need to be exactly as many as passed in files ({})".format(n_images))
+            raise ValueError(f"If image names are passed in, there must be exactly as many as passed in files ({n_images})")
 
         if image_descriptions and len(image_descriptions) != n_images:
-            raise ValueError("If image descriptions are passed in, there need to be exactly as many as passed in files ({})".format(n_images))
+            raise ValueError(f"If image descriptions are passed in, there must be exactly as many as passed in files ({n_images})")
 
         cursor = connection.cursor()
         for n, image in enumerate(request.FILES.values()):
             if image.size > settings.IMPORTED_IMAGE_FILE_MAXIMUM_SIZE:
-                raise ValueError("Image {} is bigger than IMPORTED_IMAGE_FILE_MAXIMUM_SIZE ({} MB)".format(
-                        image.name, settings.IMPORTED_IMAGE_FILE_MAXIMUM_SIZE / 1024**2))
+                raise ValueError(f"Image {image.name} is bigger than IMPORTED_IMAGE_FILE_MAXIMUM_SIZE ({settings.IMPORTED_IMAGE_FILE_MAXIMUM_SIZE / 1024**2} MB)")
 
             # Transform into JPEG
             img = Image.open(image)
@@ -472,8 +471,7 @@ class PointCloudImageDetail(APIView):
         # everyone can read.
         if 'can_read' not in get_perms(request.user, pointcloud) and \
                 len(get_users_with_perms(pointcloud)) > 0:
-            raise PermissionError('User "{}" not allowed to read point cloud #{}'.format(
-                    request.user.username, pointcloud.id))
+            raise PermissionError(f'User "{request.user.username}" not allowed to read point cloud #{pointcloud.id}')
 
         cursor = connection.cursor()
         cursor.execute("""
@@ -501,7 +499,7 @@ class PointCloudImageDetail(APIView):
         name = rows[0][2]
 
         response = HttpResponse(image_data.tobytes(), content_type=content_type)
-        response['Content-Disposition'] = 'attachment; filename={}'.format(name)
+        response['Content-Disposition'] = f'attachment; filename={name}'
         return response
 
 
@@ -547,8 +545,7 @@ class PointCloudDetail(APIView):
         # everyone can read.
         if 'can_read' not in get_perms(request.user, pointcloud) and \
                 len(get_users_with_perms(pointcloud)) > 0:
-            raise PermissionError('User "{}" not allowed to read point cloud #{}'.format(
-                    request.user.username, pointcloud.id))
+            raise PermissionError(f'User "{request.user.username}" not allowed to read point cloud #{pointcloud.id}')
 
         if with_images:
             images = [serialize_image_data(i) for i in pointcloud.images.all()]

--- a/django/applications/catmaid/control/similarity.py
+++ b/django/applications/catmaid/control/similarity.py
@@ -314,7 +314,7 @@ class ConfigurationList(APIView):
             has_role = check_user_role(request.user, p, UserRole.QueueComputeTask)
             if not has_role:
                 raise PermissionError("User " + str(request.user.id) +
-                        " doesn't have permission to queue computation tasks.")
+                        " does not have permission to queue computation tasks.")
 
         source = request.data.get('source', 'backend-random')
         tangent_neighbors = int(request.data.get('tangent_neighbors', '20'))
@@ -359,7 +359,7 @@ class ConfigurationList(APIView):
             for pointset_id in matching_pointset_ids:
                 pointset_data = matching_meta.get(str(pointset_id))
                 if not pointset_data:
-                    raise ValueError("Could not find data for pointset {}".format(pointset_id))
+                    raise ValueError(f"Could not find data for pointset {pointset_id}")
                 flat_points = list(chain.from_iterable(pointset_data['points']))
                 pointset = PointSet.objects.create(project_id=project_id,
                         user=request.user, name=pointset_data['name'],
@@ -414,7 +414,7 @@ class ConfigurationList(APIView):
             has_role = check_user_role(request.user, p, UserRole.QueueComputeTask)
             if not has_role:
                 raise PermissionError("User " + str(request.user.id) +
-                        " doesn't have permission to queue computation tasks.")
+                        " does not have permission to queue computation tasks.")
 
             config = self.compute_random_and_add_delayed(project_id, user_id, name,
                     matching_skeleton_ids, matching_pointset_ids,
@@ -609,7 +609,7 @@ def compute_nblast_config(config_id, user_id, use_cache=True) -> str:
             'config_status': config.status,
         })
 
-        return "Recomputed NBLAST configuration {}".format(config.id)
+        return f"Recomputed NBLAST configuration {config.id}"
     except:
         configs = NblastConfig.objects.filter(pk=config_id)
         if configs:
@@ -708,8 +708,8 @@ def compute_nblast(project_id, user_id, similarity_id, remove_target_duplicates,
 
         # Make sure we have a scoring matrix
         if not config.scoring:
-            raise ValueError("NBLAST config #" + config.id +
-                " doesn't have a computed scoring.")
+            raise ValueError(f"NBLAST config #{config.id}" +
+                " does not have a computed scoring.")
 
         scoring_info = nblast(project_id, user_id, config.id,
                 query_object_ids, target_object_ids,
@@ -757,7 +757,7 @@ def compute_nblast(project_id, user_id, similarity_id, remove_target_duplicates,
             'similarity_status': similarity.status,
         })
 
-        return "Computed new NBLAST similarity for config {}".format(config.id)
+        return f"Computed new NBLAST similarity for config {config.id}"
     except Exception as ex:
         duration = timer() - start_time
         similarities = NblastSimilarity.objects.filter(pk=similarity_id)
@@ -892,7 +892,7 @@ def compare_skeletons(request:HttpRequest, project_id) -> JsonResponse:
     if not name:
         n_similarity_tasks = NblastSimilarity.objects.filter(
                 project_id=project_id).count()
-        name = 'Task {}'.format(n_similarity_tasks + 1)
+        name = f'Task {n_similarity_tasks + 1}'
 
     config_id = request.POST.get('config_id', None)
     if not config_id:
@@ -908,11 +908,11 @@ def compare_skeletons(request:HttpRequest, project_id) -> JsonResponse:
 
     query_type_id = request.POST.get('query_type_id', 'skeleton')
     if query_type_id not in valid_type_ids:
-        raise ValueError("Need valid query type id ({})".format(', '.join(valid_type_ids)))
+        raise ValueError(f"Need valid query type id ({', '.join(valid_type_ids)})")
 
     target_type_id = request.POST.get('target_type_id', 'skeleton')
     if target_type_id not in valid_type_ids:
-        raise ValueError("Need valid target type id ({})".format(', '.join(valid_type_ids)))
+        raise ValueError(f"Need valid target type id ({', '.join(valid_type_ids)})")
 
     # Read potential query and target IDs. In case of skeletons and point
     # clouds, no IDs need to be provided, in which case all skeletons and point
@@ -928,22 +928,22 @@ def compare_skeletons(request:HttpRequest, project_id) -> JsonResponse:
     config = NblastConfig.objects.get(project_id=project_id, pk=config_id)
 
     if not config.status == 'complete':
-        raise ValueError("NBLAST config #{} isn't marked as complete".format(config.id))
+        raise ValueError(f"NBLAST config #{config.id} isn't marked as complete")
 
     # Make sure we have a scoring matrix
     if not config.scoring:
-        raise ValueError("NBLAST config #{}  doesn't have a computed scoring.".format(config.id))
+        raise ValueError(f"NBLAST config #{config.id} does not have a computed scoring.")
 
     # Load potential query or target meta data
     query_meta = request.POST.get('query_meta')
     if query_meta:
         if not query_type_id == 'pointset':
-            raise ValueError("Did not expect 'query_meta' parameter with {} query type".format(query_type_id))
+            raise ValueError(f"Did not expect 'query_meta' parameter with {query_type_id} query type")
         query_meta = json.loads(query_meta)
     target_meta = request.POST.get('target_meta')
     if target_meta:
         if not target_type_id == 'pointset':
-            raise ValueError("Did not expect 'target_meta' parameter with {} target type".format(target_type_id))
+            raise ValueError(f"Did not expect 'target_meta' parameter with {target_type_id} target type")
         target_meta = json.loads(target_meta)
 
     # Other parameters
@@ -962,7 +962,7 @@ def compare_skeletons(request:HttpRequest, project_id) -> JsonResponse:
             for pointset_id in query_ids:
                 pointset_data = query_meta.get(str(pointset_id))
                 if not pointset_data:
-                    raise ValueError("Could not find data for pointset {}".format(pointset_id))
+                    raise ValueError(f"Could not find data for pointset {pointset_id}")
                 flat_points = list(chain.from_iterable(pointset_data['points']))
                 pointset = PointSet.objects.create(project_id=project_id,
                         user=request.user, name=pointset_data['name'],
@@ -976,7 +976,7 @@ def compare_skeletons(request:HttpRequest, project_id) -> JsonResponse:
             for pointset_id in target_ids:
                 pointset_data = target_meta.get(str(pointset_id))
                 if not pointset_data:
-                    raise ValueError("Could not find data for pointset {}".format(pointset_id))
+                    raise ValueError(f"Could not find data for pointset {pointset_id}")
                 flat_points = list(chain.from_iterable(pointset_data['points']))
                 pointset = PointSet.objects.create(project_id=project_id,
                         user=request.user, name=pointset_data['name'],

--- a/django/applications/catmaid/control/stats.py
+++ b/django/applications/catmaid/control/stats.py
@@ -67,7 +67,7 @@ def stats_cable_length(request:HttpRequest, project_id=None) -> JsonResponse:
             name_pattern = name_pattern[1:]
             name_match_where = 'AND ci.name ~ %(name_pattern)s AND cici.relation_id = %(model_of)s'
         else:
-            name_pattern = '%{}%'.format(name_pattern)
+            name_pattern = f'%{name_pattern}%'
             name_match_where = 'AND ci.name ~~* %(name_pattern)s AND cici.relation_id = %(model_of)s'
 
     cursor.execute("""

--- a/django/applications/catmaid/control/transaction.py
+++ b/django/applications/catmaid/control/transaction.py
@@ -87,12 +87,12 @@ def transaction_collection(request:Request, project_id) -> Response:
             params.append(range_length)
 
         cursor = connection.cursor()
-        cursor.execute("""
+        cursor.execute(f"""
             SELECT row_to_json(cti), COUNT(*) OVER() AS full_count
             FROM catmaid_transaction_info cti
             WHERE project_id = %s
-            ORDER BY execution_time DESC {}
-        """.format(" ".join(constraints)), params)
+            ORDER BY execution_time DESC {" ".join(constraints)}
+        """, params)
         result = cursor.fetchall()
         json_data = [row[0] for row in result]
         total_count = result[0][1] if len(json_data) > 0 else 0
@@ -156,8 +156,8 @@ def get_location(request:Request, project_id) -> Response:
             """, (transaction_id, execution_time))
             result = cursor.fetchone()
             if not result:
-                raise ValueError("Couldn't find label for transaction {} and "
-                        "execution time {}".format(transaction_id, execution_time))
+                raise ValueError(f"Could not find label for transaction {transaction_id} and "
+                        "execution time {execution_time}")
             label = result[0]
 
         # Look first in live table and then in history table. Use only
@@ -177,11 +177,11 @@ def get_location(request:Request, project_id) -> Response:
                     location = (loc[0], loc[1], loc[2])
                     query = None
                 else:
-                    raise ValueError("Couldn't read location information, "
-                        "expected 3 columns, got {}".format(len(loc)))
+                    raise ValueError(f"Could not read location information, "
+                        "expected 3 columns, got {len(loc)}")
 
         if not location or len(location) != 3:
-            raise ValueError("Couldn't find location for transaction {}".format(transaction_id))
+            raise ValueError(f"Could not find location for transaction {transaction_id}")
 
         return Response({
             'x': location[0],

--- a/django/applications/catmaid/control/useranalytics.py
+++ b/django/applications/catmaid/control/useranalytics.py
@@ -157,14 +157,14 @@ def eventTimes(user_id, project_id, start_date, end_date, all_writes=True) -> Di
         # Query transaction log. This makes this feature only useful of history
         # tracking is available.
         cursor = connection.cursor()
-        cursor.execute("""
+        cursor.execute(f"""
             SELECT execution_time
             FROM catmaid_transaction_info
             WHERE execution_time >= %s
             AND execution_time <= %s
             AND user_id = %s
-            {}
-        """.format(project_filter), params)
+            {project_filter}
+        """, params)
         events['write_events'] = [r[0] for r in cursor.fetchall()]
 
     return events

--- a/django/applications/catmaid/history.py
+++ b/django/applications/catmaid/history.py
@@ -1,5 +1,6 @@
-import re
+
 import functools
+import re
 
 from django.db import connection
 from django.db.transaction import TransactionManagementError
@@ -13,8 +14,7 @@ def fail_on_wrong_format_label(label) -> None:
     """Check the passed in label if it matches the expected format and raise an
     error if not."""
     if not transaction_label_pattern.match(label):
-        raise ValueError('Label "{}" doesn\'t follow convention '
-                         '"<resources>.<action>"'.format(label))
+        raise ValueError(f'Label "{label}" does not follow convention "<resources>.<action>"')
 
 def add_log_entry(user_id, label, project_id=None) -> None:
     """Give a label to the current transaction and time, executed by a

--- a/django/applications/catmaid/management/commands/catmaid_cache_update_worker.py
+++ b/django/applications/catmaid/management/commands/catmaid_cache_update_worker.py
@@ -72,8 +72,7 @@ class GridWorker():
                 DirtyNodeGridCacheCell.objects.filter(grid_id=g.id, x_index=w_i,
                         y_index=h_i, z_index=d_i).delete()
 
-        logger.debug('Updated {} grid cell(s) in {} grid cache(s)'.format(
-            updated_cells, len(referenced_grid_ids)))
+        logger.debug(f'Updated {updated_cells} grid cell(s) in {len(referenced_grid_ids)} grid cache(s)')
 
 
 class Command(BaseCommand):
@@ -132,7 +131,7 @@ class Command(BaseCommand):
 
     def listen(self):
         with connection.cursor() as cur:
-            cur.execute('LISTEN "{}"'.format(self.notify_channel))
+            cur.execute(f'LISTEN "{self.notify_channel}"')
 
 
     def filter_notifies(self):
@@ -171,7 +170,7 @@ class Command(BaseCommand):
                     data = json.loads(n.payload)
                     updates.append(data)
                 except json.decoder.JSONDecodeError:
-                    logger.warn('Could not parse Postgres NOTIFY message: {}'.format(n.payload))
+                    logger.warn(f'Could not parse Postgres NOTIFY message: {n.payload}')
                     continue
 
             for worker in self.workers:

--- a/django/applications/catmaid/management/commands/catmaid_check_db_integrity.py
+++ b/django/applications/catmaid/management/commands/catmaid_check_db_integrity.py
@@ -170,8 +170,7 @@ class Command(BaseCommand):
         non_triangles = list(cursor.fetchall())
         n_non_triangles = len(non_triangles)
         if n_non_triangles > 0:
-            self.stdout.write('FAILED: found {} non-triangle meshes in project {}'.format(
-                    n_non_triangles, project_id))
+            self.stdout.write(f'FAILED: found {n_non_triangles} non-triangle meshes in project {project_id}')
             self.stdout.write('\tThe following volumes contain those geometries: {}'.format(
                     ', '.join(nt[0] for nt in non_triangles)))
             passed = False
@@ -230,8 +229,7 @@ class Command(BaseCommand):
 
             if volumes_with_inconsistent_winding:
                 self.stdout.write('FAILED: The following volumes have an ' +
-                        'inconsistent winding: {}'.format(', '.join(
-                                volumes_with_inconsistent_winding)))
+                        f'inconsistent winding: {", ".join(volumes_with_inconsistent_winding)}')
             else:
                 self.stdout.write('OK')
 

--- a/django/applications/catmaid/management/commands/catmaid_export_data.py
+++ b/django/applications/catmaid/management/commands/catmaid_export_data.py
@@ -67,7 +67,7 @@ class Exporter():
             self.target_file = self.target_file.format(project.id)
         else:
             now = datetime.now().strftime('%Y-%m-%d-%H-%M')
-            self.target_file = 'catmaid-export-pid-{}-{}.json'.format(project.id, now)
+            self.target_file = f'catmaid-export-pid-{project.id}-{now}.json'
 
         self.show_traceback = True
         self.format = 'json'
@@ -107,8 +107,7 @@ class Exporter():
             neuron_info, num_total_records = get_annotated_entities(self.project.id,
                     query_params, relations, classes, ['neuron'], with_skeletons=True)
 
-            logger.info("Found {} neurons with the following exclusion annotations: {}".format(
-                    num_total_records, ", ".join(self.excluded_annotations)))
+            logger.info(f"Found {num_total_records} neurons with the following exclusion annotations: {', '.join(self.excluded_annotations)}")
 
             exclude_skeleton_id_constraints = set(chain.from_iterable(
                     [n['skeleton_ids'] for n in neuron_info]))
@@ -130,8 +129,7 @@ class Exporter():
             neuron_info, num_total_records = get_annotated_entities(self.project.id,
                     query_params, relations, classes, ['neuron'], with_skeletons=True)
 
-            logger.info("Found {} neurons with the following annotations: {}".format(
-                    num_total_records, ", ".join(self.required_annotations)))
+            logger.info(f"Found {num_total_records} neurons with the following annotations: {', '.join(self.required_annotations)}")
 
             skeleton_id_constraints:Optional[List] = list(chain.from_iterable([n['skeleton_ids'] for n in neuron_info]))
             neuron_ids = [n['id'] for n in neuron_info]
@@ -307,13 +305,11 @@ class Exporter():
                 if all_annotation_links:
                     self.to_serialize.append(all_annotation_links)
 
-                logger.info("Exporting {} annotations and {} annotation links: {}".format(
-                        len(all_annotations), len(all_annotation_links),
-                        ", ".join([a.name for a in all_annotations])))
+                logger.info(f"Exporting {len(all_annotations)} annotations " + \
+                            f"and {len(all_annotation_links)} annotation links: {', '.join([a.name for a in all_annotations])}")
                 if self.annotation_annotations:
-                    logger.info("Only annotations in hierarchy of the following "
-                            "annotations are exported: {}".format(
-                            ', '.join(self.annotation_annotations)))
+                    logger.info(f"Only annotations in hierarchy of the following " + \
+                                f"annotations are exported: {', '.join(self.annotation_annotations)}")
 
             # Export tags
             if self.export_tags and 'labeled_as' in relations:
@@ -328,8 +324,7 @@ class Exporter():
                 self.to_serialize.append(tags)
                 self.to_serialize.append(tag_links)
 
-                logger.info("Exporting {n_tags} tags, part of {n_links} links: {tags}".format(
-                    n_tags=len(tags), n_links=tag_links.count(), tags=', '.join(tag_names)))
+                logger.info(f"Exporting {len(tags)} tags, part of {tag_links.count()} links: {', '.join(tag_names)}")
 
             # TODO: Export reviews
         else:
@@ -377,8 +372,7 @@ class Exporter():
             neurons = set([l.class_instance_b_id for l in neuron_links])
 
             exported_tids = set(treenodes.values_list('id', flat=True))
-            logger.info("Exporting {} treenodes in {} skeletons and {} neurons".format(
-                    len(exported_tids), n_skeletons, len(neurons)))
+            logger.info(f"Exporting {len(exported_tids)} treenodes in {n_skeletons} skeletons and {len(neurons)} neurons")
 
         # Get current maximum concept ID
         cursor = connection.cursor()

--- a/django/applications/catmaid/management/commands/catmaid_find_node_provider_config.py
+++ b/django/applications/catmaid/management/commands/catmaid_find_node_provider_config.py
@@ -1,11 +1,12 @@
-import ujson
-import msgpack
-import psycopg2
-import progressbar
-import time
 
 from collections import defaultdict
+import msgpack
+import progressbar
+import psycopg2
+import time
 from timeit import default_timer as timer
+import ujson
+
 
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
@@ -92,25 +93,24 @@ class Command(BaseCommand):
         unavailable_node_providers = list(filter(lambda x: x not in AVAILABLE_NODE_PROVIDERS,
                 options['providers']))
         if unavailable_node_providers:
-            raise CommandError("Unknown node providers: {}".format(
-                    str(unavailable_node_providers)))
+            raise CommandError(f"Unknown node providers: {unavailable_node_providers}")
         node_providers = options['providers']
 
-        self.stdout.write("Using the following providers: {}".format(", ".join(node_providers)))
+        self.stdout.write(f"Using the following providers: {', '.join(node_providers)}")
 
         project_results = {}
 
         for p in projects:
-            self.stdout.write("Sampling project {}".format(p.id))
+            self.stdout.write(f"Sampling project {p.id}")
             # Find tracing bounding box
             self.stdout.write(' -> Finding tracing data bounding box')
             bb_data = get_tracing_bounding_box(p.id, cursor)
             bb = [bb_data[0], bb_data[1]]
             if None in bb[0] or None in bb[1]:
-                self.stdout.write(' -> Found no valid bounding box, skipping project: {}'.format(bb))
+                self.stdout.write(f' -> Found no valid bounding box, skipping project: {bb}')
                 continue
             else:
-                self.stdout.write(' -> Found bounding box: {}'.format(bb))
+                self.stdout.write(f' -> Found bounding box: {bb}')
 
             # Apply bounding box limits to it
             if bb_limits:
@@ -120,7 +120,7 @@ class Command(BaseCommand):
                 bb[1][0] = min(bb[1][0], bb_limits[1][0])
                 bb[1][1] = min(bb[1][1], bb_limits[1][1])
                 bb[1][2] = min(bb[1][2], bb_limits[1][2])
-                self.stdout.write(' -> Applied limits to bounding box: {}'.format(bb))
+                self.stdout.write(f' -> Applied limits to bounding box: {bb}')
 
             params = {
                 'left': bb[0][0],
@@ -151,9 +151,9 @@ class Command(BaseCommand):
             # section thickness <step> and <sample-interval>.
             for o, step, sample_interval in zip(orientations, steps, sample_intervals):
                 orientation_id = ORIENTATIONS[o]
-                self.stdout.write(' -> Sampling tracing data in orientation {} ' \
-                        'with depth resolution {} and interval {} for type(s) {}'.format(
-                        o, step, sample_interval, types))
+                self.stdout.write(f' -> Sampling tracing data in orientation {o} ' + \
+                                  f'with depth resolution {step} and interval {sample_interval} ' + \
+                                  f'for type(s) {types}')
 
                 with progressbar.ProgressBar(min_value=min_z, max_value=max_z, redirect_stdout=True) as pbar:
                     z = min_z
@@ -211,7 +211,7 @@ class Command(BaseCommand):
 
         self.stdout.write('Sorting data')
         for pid, data in project_results.items():
-            self.stdout.write('Top 2 queries with nodes per zoom and extent in project {}'.format(pid))
+            self.stdout.write(f'Top 2 queries with nodes per zoom and extent in project {pid}')
             nonzero_data = list(filter(lambda x: x['n_nodes'] > 0, data))
             sorted_data = sorted(nonzero_data, key=lambda x: (-x['width'], -x['height'], -x['n_nodes'], x['time']))
             depth_count = defaultdict(float)

--- a/django/applications/catmaid/management/commands/catmaid_import_data.py
+++ b/django/applications/catmaid/management/commands/catmaid_import_data.py
@@ -45,7 +45,7 @@ def ask_a_b(a, b, title):
         d = ask()
         if d is not None:
             return d
-        print("Please answer only '{}' or '{}'".format(a, b))
+        print(f"Please answer only '{a}' or '{b}'")
 
 def ask_yes_no(title):
     """Return true if yes, False if no.
@@ -134,14 +134,14 @@ class FileImporter:
                             mapped_user_ids.add(obj_user_ref_id)
                             mapped_user_target_ids.add(existing_user_id)
                         elif import_user:
-                            raise CommandError("Referenced user \"{}\" ".format(obj_username) +
+                            raise CommandError(f"Referenced user \"{obj_username}\" " +
                                     "exists both in database and in import data. If the " +
                                     "existing user should be used, please use the " +
                                     "--map-users option to map all users or "
                                     "--username-mapping=\"import-user=target-user\" " +
                                     "for individual users")
                         else:
-                            raise CommandError("Referenced user \"{}\"".format(obj_username) +
+                            raise CommandError(f"Referenced user \"{obj_username}\"" +
                                     "exists in database, but not in import data. If the " +
                                     " existing user should be used, please use the " +
                                     "--map-users option")
@@ -163,7 +163,7 @@ class FileImporter:
                             created_users[obj_username] = user
                         setattr(obj, ref, user)
                     else:
-                        raise CommandError("User \"{}\" is not ".format(obj_username) +
+                        raise CommandError(f"User \"{obj_username}\" is not " +
                                 "found in existing data or import data. Please use " +
                                 "--user or --create-unknown-users")
                 elif map_user_ids and existing_user_same_id is not None:
@@ -174,15 +174,15 @@ class FileImporter:
                     if not user:
                         if self.auto_name_unknown_users:
                             logger.info("Creating new inactive user for imported " +
-                                    "user ID {}. No name information was ".format(obj_user_ref_id) +
+                                    f"user ID {obj_user_ref_id}. No name information was " +
                                     "available and CATMAID will generate a name.")
                         else:
                             logger.info("Creating new inactive user for imported " +
-                                    "user ID {}. No name information was ".format(obj_user_ref_id) +
+                                    f"user ID {obj_user_ref_id}. No name information was " +
                                     "available, please enter a new username.")
                         while True:
                             if self.auto_name_unknown_users:
-                                new_username = "User {}".format(self.next_auto_name_id)
+                                new_username = f"User {self.next_auto_name_id}"
                                 self.next_auto_name_id += 1
                                 if not self.user_map.get(new_username):
                                     break
@@ -191,7 +191,7 @@ class FileImporter:
                                 if not new_username:
                                     logger.info("Please enter a valid username")
                                 elif self.user_map.get(new_username):
-                                    logger.info("The username '{}' ".format(new_username) +
+                                    logger.info(f"The username '{new_username}' " +
                                             "exists already, choose a different one")
                                 else:
                                     break
@@ -203,8 +203,12 @@ class FileImporter:
                         self.created_unknown_users[obj_user_ref_id] = user
                     setattr(obj, ref, user)
                 else:
-                    raise ValueError("Could not find referenced user " +
-                            "\"{}\" in imported. Try using --map-users or ".format(obj_user_ref_id))
+                    raise CommandError(f'Could not find referenced user "{obj_user_ref_id}" ' +
+                        'in imported data. Try using the --map-users option to map all users ' +
+                        'or --username-mapping="import-user=target-user" for individual ' +
+                        'users. Additionally --create-unknown-users can be used to create ' +
+                        'missing users, optionally naming them automatically using ' +
+                        '--auto-name-unknown-users.')
 
     def reset_ids(self, target_classes, import_objects,
             import_objects_by_type_and_id, existing_classes,
@@ -252,7 +256,7 @@ class FileImporter:
 
             imported_parent_nodes = []
 
-            bar_prefix = "- {}: ".format(object_type.__name__)
+            bar_prefix = f"- {object_type.__name__}: "
             for deserialized_object in progressbar.progressbar(objects,
                     max_value=len(objects), redirect_stdout=True,
                     prefix=bar_prefix):
@@ -276,8 +280,7 @@ class FileImporter:
                             if object_type == Treenode and fk_type == Treenode:
                                 imported_parent_nodes.append((obj, current_ref))
                             elif ref_obj.id is None:
-                                raise ValueError("The referenced {} object '{}' with import ID {} wasn't stored yet".format(
-                                        fk_type, str(ref_obj), current_ref))
+                                raise ValueError(f"The referenced {fk_type} object '{ref_obj}' with import ID {current_ref} wasn't stored yet")
                             setattr(obj, fk_field, ref_obj.id)
                             updated_fk_ids += 1
                         else:
@@ -299,7 +302,7 @@ class FileImporter:
                         redirect_stdout=True, prefix="- Mapping parent treenodes: "):
                     new_parent = imported_objects_by_id.get(parent_id)
                     if not new_parent:
-                        raise ValueError("Could not find imported treenode {}".format(parent_id))
+                        raise ValueError(f"Could not find imported treenode {parent_id}")
                     obj.parent_id = new_parent.id
                     if save:
                         obj.save()
@@ -326,9 +329,8 @@ class FileImporter:
                                 skeleton_id=obj.id, defaults={'last_editor': last_editor})
                         explicitly_created_summaries += 1
 
-        logger.info("".join(["{} foreign key references updated, {} did not ",
-                "require change, {} skeleton summaries were created"]).format(
-                updated_fk_ids, unchanged_fk_ids, explicitly_created_summaries))
+        logger.info("".join([f"{updated_fk_ids} foreign key references updated, {unchanged_fk_ids} did not ",
+                f"require change, {explicitly_created_summaries} skeleton summaries were created"]))
 
     def override_fields(self, obj):
         # Override project to match target project
@@ -370,7 +372,7 @@ class FileImporter:
         n_objects = 0
 
         # Read the file and sort by type
-        logger.info("Loading data from {}".format(self.source))
+        logger.info(f"Loading data from {self.source}")
         with open(self.source, "r") as data:
             loaded_data = serializers.deserialize(self.format, data)
             for deserialized_object in progressbar.progressbar(loaded_data,
@@ -385,7 +387,7 @@ class FileImporter:
         created_users:Dict = dict()
         if import_data.get(User):
             import_users = dict((u.object.id, u) for u in import_data.get(User))
-            logger.info("Found {} referenceable users in import data".format(len(import_users)))
+            logger.info(f"Found {len(import_users)} referenceable users in import data")
         else:
             import_users = dict()
             logger.info("Found no referenceable users in import data")
@@ -393,14 +395,14 @@ class FileImporter:
         username_mapping = {}
         for m in self.options['username_mapping'] or []:
             username_mapping[m[0]] = m[1]
-            logger.info('Mapping import user "{}" to target user "{}"'.format(m[0], m[1]))
+            logger.info(f'Mapping import user "{m[0]}" to target user "{m[1]}"')
 
         # Get CATMAID model classes, which are the ones we want to allow
         # optional modification of user, project and ID fields.
         app = apps.get_app_config('catmaid')
         user_updatable_classes = set(app.get_models())
 
-        logger.info("Adjusting {} import objects to target database".format(n_objects))
+        logger.info(f"Adjusting {n_objects} import objects to target database")
 
         # Needed for name uniquness of classes, class_instances and relations
         existing_classes = dict(Class.objects.filter(project_id=self.target.id) \
@@ -513,8 +515,7 @@ class FileImporter:
             logger.info("No unmapped users imported")
 
         # Finally save all objects. Make sure they are saved in order:
-        logger.info("Storing {} database objects including {} moved objects, reusing additional {} existing objects" \
-                .format(n_objects - n_reused, n_moved, n_reused))
+        logger.info(f"Storing {n_objects - n_reused} database objects including {n_moved} moved objects, reusing additional {n_reused} existing objects")
 
         # In append-only mode, the foreign keys to objects with changed IDs have
         # to be updated. In preserve-ids mode only IDs to classes and relations
@@ -599,7 +600,7 @@ class FileImporter:
 
         if self.options.get('update_project_materializations'):
             if n_imported_connectors or n_imported_connectors:
-                logger.info("Updating edge tables for project {}".format(self.target.id))
+                logger.info(f"Updating edge tables for project {self.target.id}")
                 rebuild_edge_tables(project_ids=[self.target.id], log=lambda msg: logger.info(msg))
             else:
                 logger.info("No edge table update needed")
@@ -650,8 +651,8 @@ class FileImporter:
                         skeleton_ids.append(ci.id)
 
             if skeleton_ids or connector_ids:
-                logger.info("Updating edge tables for {} skeleton(s) and {} " \
-                        "connector(s)".format(len(skeleton_ids), len(connector_ids)))
+                logger.info(f"Updating edge tables for {len(skeleton_ids)} skeleton(s) " + \
+                            f"and {len(connector_ids)} connector(s)")
                 rebuild_edges_selectively(skeleton_ids, connector_ids, log=lambda msg: logger.info(msg))
             else:
                 logger.info("No materialization to update: no skeleton IDs or " \
@@ -805,8 +806,7 @@ class Command(BaseCommand):
         override_user = None
         if options['user']:
             override_user = User.objects.get(pk=options['user'])
-            logger.info("All imported objects will be owned by user \"{}\"".format(
-                    override_user.username))
+            logger.info(f'All imported objects will be owned by user "{override_user.username}"')
         else:
             if options['map_users']:
                 logger.info("Users referenced in import will be mapped to "

--- a/django/applications/catmaid/management/commands/catmaid_refresh_node_statistics.py
+++ b/django/applications/catmaid/management/commands/catmaid_refresh_node_statistics.py
@@ -35,4 +35,4 @@ class Command(BaseCommand):
         incremental = not clean
         for p in projects:
             populate_stats_summary(p.id, delete, incremental)
-            self.stdout.write('Computed statistics for project {}'.format(p.id))
+            self.stdout.write(f'Computed statistics for project {p.id}')

--- a/django/applications/catmaid/management/commands/catmaid_reset_canary_locations.py
+++ b/django/applications/catmaid/management/commands/catmaid_reset_canary_locations.py
@@ -30,5 +30,5 @@ class Command(BaseCommand):
             else:
                 location = (0, 0, 0)
             s.canary_location = location
-            print("Canary location of stack {}: {}".format(s.id, s.canary_location))
+            print(f"Canary location of stack {s.id}: {s.canary_location}")
             s.save()

--- a/django/applications/catmaid/management/commands/catmaid_setup_nblast_environment.py
+++ b/django/applications/catmaid/management/commands/catmaid_setup_nblast_environment.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 import os
 
 from django.core.management.base import BaseCommand, CommandError
@@ -12,14 +13,14 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if hasattr(settings, 'R_LIBS_USER'):
             if not os.path.exists(settings.R_LIBS_USER):
-                raise CommandError('The path defined by R_LIBS_USER in '
-                        'settings.py ({}) does not exist.'.format(settings.R_LIBS_USER))
+                raise CommandError(f'The path defined by R_LIBS_USER in ' + \
+                        'settings.py ({settings.R_LIBS_USER}) does not exist.')
             if not os.access(settings.R_LIBS_USER, os.W_OK):
-                raise CommandError('The path defined by R_LIBS_USER in '
-                        'settings.py ({}) is not writable.'.format(settings.R_LIBS_USER))
+                raise CommandError(f'The path defined by R_LIBS_USER in ' + \
+                        f'settings.py ({settings.R_LIBS_USER}) is not writable.')
             install_dependencies()
         else:
-            raise CommandError('Please define the R_LIBS_USER setting in '
-                    'settings.py and set it to a path writable and readable '
+            raise CommandError('Please define the R_LIBS_USER setting in ' + \
+                    'settings.py and set it to a path writable and readable ' + \
                     'by the user running CATMAID and the user running this command.')
 

--- a/django/applications/catmaid/management/commands/catmaid_setup_tracing_for_project.py
+++ b/django/applications/catmaid/management/commands/catmaid_setup_tracing_for_project.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
         if not user:
             from catmaid.apps import get_system_user
             user = get_system_user()
-            logger.info("Using system user account {} (ID: {})".format(user, user.id))
+            logger.info(f"Using system user account {user} (ID: {user.id})")
 
         # Set up tracing for the requested project
         setup_tracing(options['project_id'], user)

--- a/django/applications/catmaid/management/commands/catmaid_update_cache_tables.py
+++ b/django/applications/catmaid/management/commands/catmaid_update_cache_tables.py
@@ -1,6 +1,6 @@
-import ujson
 import msgpack
 import psycopg2
+import ujson
 
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
@@ -178,7 +178,7 @@ class Command(BaseCommand):
 
         lod_strategy = options['lod_strategy']
         if lod_strategy not in ('linear', 'quadratic', 'exponential'):
-            raise ValueError("Unknown LOD strategy: {}".format(lod_strategy))
+            raise ValueError(f"Unknown LOD strategy: {lod_strategy}")
 
         jobs = options['jobs']
         if jobs > 1 and cache_type != 'grid':
@@ -194,7 +194,7 @@ class Command(BaseCommand):
 
 
         for p in projects:
-            self.stdout.write('Updating {} cache for project {}'.format(cache_type, p.id))
+            self.stdout.write(f'Updating {cache_type} cache for project {p.id}')
             if cache_type == 'section':
                 update_cache(p.id, data_type, orientations, steps, node_limit,
                         n_largest_skeletons_limit, n_last_edited_skeletons_limit,
@@ -210,4 +210,4 @@ class Command(BaseCommand):
                         lod_strategy=lod_strategy, jobs=jobs,
                         depth_steps=depth_steps, chunksize=chunksize,
                         ordering=ordering)
-            self.stdout.write('Updated {} cache for project {}'.format(cache_type, p.id))
+            self.stdout.write(f'Updated {cache_type} cache for project {p.id}')

--- a/django/applications/catmaid/management/commands/catmaid_update_project_configuration.py
+++ b/django/applications/catmaid/management/commands/catmaid_update_project_configuration.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import logging
+logger = logging.getLogger(__name__)
+
 from django.core.management.base import BaseCommand, CommandError
 
 from catmaid.models import Project, User
@@ -8,8 +11,6 @@ from catmaid.apps import get_system_user
 from .common import set_log_level
 
 
-import logging
-logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -37,7 +38,7 @@ class Command(BaseCommand):
         for p in projects:
             try:
                 validate_project_setup(p.id, user.id, True)
-                logger.info("Validated project {} (ID: {})".format(p, p.id))
+                logger.info(f"Validated project {p} (ID: {p.id})")
             except Exception as e:
-                logger.error("Could not validate project setup of project " +
-                        "{} (ID: {}): {}".format(p, p.id, e))
+                logger.error(f"Could not validate project setup of project " + \
+                             f"{p} (ID: {p.id}): {e}")

--- a/django/applications/catmaid/migrations/0018_add_stack_mirrors_and_groups.py
+++ b/django/applications/catmaid/migrations/0018_add_stack_mirrors_and_groups.py
@@ -43,7 +43,7 @@ def forward_update_stack_groups(apps, schema_editor):
 
     for sg in existing_stackgroups:
         if sg.name in sg_names:
-            name = "{} ({})".format(sg.name, sg.project.id)
+            name = f"{sg.name} ({sg.project.id})"
         else:
             name = sg.name
 
@@ -53,19 +53,19 @@ def forward_update_stack_groups(apps, schema_editor):
     if not sg_id_mapping:
         return
 
-    sg_pattern = ','.join(["({}, {})".format(k, v) for k,v in sg_id_mapping.items()])
+    sg_pattern = ','.join([f"({k}, {v})" for k,v in sg_id_mapping.items()])
     cursor = connection.cursor()
-    cursor.execute("""
+    cursor.execute(f"""
         INSERT INTO stack_stack_group (stack_id, stack_group_id, group_relation_id, position)
         SELECT sci.stack_id, sg_mapping.new_id, sgr.id, 0
         FROM stack_class_instance sci
-        JOIN (VALUES {}) sg_mapping(old_id, new_id)
+        JOIN (VALUES {sg_pattern}) sg_mapping(old_id, new_id)
         ON sci.class_instance_id = sg_mapping.old_id
         JOIN relation r
         ON sci.relation_id = r.id
         JOIN stack_group_relation sgr
         ON 'has_' || sgr.name = r.relation_name
-    """.format(sg_pattern))
+    """)
 
 
 def forward_migrate_overlays(apps, schema_editor):
@@ -122,7 +122,7 @@ def forward_migrate_overlays(apps, schema_editor):
         FROM stack s
         JOIN (VALUES {}) AS sgim (s_id, sg_id) ON sgim.s_id = s.id
     """.format(
-        ','.join(['({}, {})'.format(k, v) for k, v in stack_id_mapping.items()])))
+        ','.join([f'({k}, {v})' for k, v in stack_id_mapping.items()])))
 
     # Create stacks for each overlay.
     # Note stack is still the old stack model at this point.

--- a/django/applications/catmaid/models.py
+++ b/django/applications/catmaid/models.py
@@ -6,10 +6,9 @@ import logging
 from random import random
 import re
 import sys
+from typing import Any, Dict, Tuple
 import urllib
 import urllib.parse
-
-from typing import Any, Dict, Tuple
 
 from django import forms
 from django.conf import settings
@@ -303,7 +302,7 @@ class ClassInstance(models.Model):
                         'id': neuron_of_skeleton[skeleton_id]['neuroid'],
                         'id__count': 1, # connectivity count
                         'skeleton_id': skeleton_id,
-                        'name': '{0} / skeleton {1}'.format(neuron_of_skeleton[skeleton_id]['neuroname'], skeleton_id)}
+                        'name': f'{neuron_of_skeleton[skeleton_id]["neuroname"]} / skeleton {skeleton_id}'}
 
         # sort by count
         from operator import itemgetter
@@ -379,7 +378,7 @@ class BrokenSlice(models.Model):
         db_table = "broken_slice"
 
     def __str__(self) -> str:
-        return "Broken section {} in stack {}".format(self.index, self.stack)
+        return f"Broken section {self.index} in stack {self.stack}"
 
 
 class InterpolatableSection(models.Model):
@@ -391,6 +390,8 @@ class InterpolatableSection(models.Model):
     kept in the stack. The client can the for instance interpolate skeletons in
     the 3D Viewer for this particular section.
     """
+    # Spelling of this class is unusual but is based on a Java class that does something
+    # similar, with the same spelling
     project = models.ForeignKey(Project, on_delete=models.CASCADE, db_index=True)
     location_coordinate = models.FloatField(db_index=True)
     orientation = models.SmallIntegerField(choices=((0, 'z'), (1, 'y'), (2, 'x')))
@@ -399,9 +400,7 @@ class InterpolatableSection(models.Model):
         db_table = "interpolatable_section"
 
     def __str__(self) -> str:
-        return "Interpoaltable location {} in orientation {}".format(
-                self.location_coordinate, self.orientation)
-
+        return f"Interpolable location {self.location_coordinate} in orientation {self.orientation}"
 
 class ClassClass(models.Model):
     # Repeat the columns inherited from 'relation_instance'
@@ -1252,7 +1251,7 @@ class Sampler(UserFocusedModel):
     merge_limit = models.FloatField(default=0)
 
     def __str__(self) -> str:
-        return "Sampler for {}".format(self.skeleton_id)
+        return f"Sampler for {self.skeleton_id}"
 
 
 class SamplerIntervalState(models.Model):
@@ -1275,7 +1274,7 @@ class SamplerInterval(UserFocusedModel):
             related_name="sampler_interval_end_node_set")
 
     def __str__(self) -> str:
-        return "({}, {})".format(self.start_node_id, self.end_node_id)
+        return f"({self.start_node_id}, {self.end_node_id})"
 
 
 class SamplerConnectorState(models.Model):
@@ -1292,7 +1291,7 @@ class SamplerConnector(UserFocusedModel):
     connector_state = models.ForeignKey(SamplerConnectorState, db_index=True, on_delete=models.CASCADE)
 
     def __str__(self) -> str:
-        return "({}, {})".format(self.start_node_id, self.end_node_id)
+        return f"({self.start_node_id}, {self.end_node_id})"
 
 
 class SamplerDomainType(models.Model):
@@ -1310,7 +1309,7 @@ class SamplerDomain(UserFocusedModel):
     parent_interval = models.ForeignKey(SamplerInterval, null=True, db_index=True, on_delete=models.CASCADE)
 
     def __str__(self) -> str:
-        return "Start: {}".format(self.start_node_id)
+        return f"Start: {self.start_node_id}"
 
 
 class SamplerDomainEnd(models.Model):
@@ -1318,7 +1317,7 @@ class SamplerDomainEnd(models.Model):
     end_node = models.ForeignKey(Treenode, on_delete=models.CASCADE)
 
     def __str__(self) -> str:
-        return "End: {}".format(self.end_node_id)
+        return f"End: {self.end_node_id}"
 
 class SkeletonSummary(models.Model):
     """Holds summary information on individual skeletons. Data insertion and
@@ -1342,9 +1341,7 @@ class SkeletonSummary(models.Model):
     cable_length = models.FloatField(null=False, default=0)
 
     def __str__(self) -> str:
-        return "Skeleton {} summary ({} nodes, {} nm)".format(
-                self.skeleton_id, self.num_nodes, self.cable_length)
-
+        return f"Skeleton {self.skeleton_id} summary ({self.num_nodes} nodes, {self.cable_length} nm)"
 
 class DataSource(NonCascadingUserFocusedModel):
     """A simple object representing a data source, which are mainly used to
@@ -1380,9 +1377,7 @@ class SkeletonOrigin(NonCascadingUserFocusedModel):
     source_type = models.TextField()
 
     def __str__(self) -> str:
-        return "Skeleton {} from {} ({})".format(
-                self.skeleton_id, self.data_source_id, self.source_id)
-
+        return f"Skeleton {self.skeleton_id} from {self.data_source_id} ({self.source_id})"
 
 class StatsSummary(models.Model):
     class Meta:
@@ -1402,8 +1397,7 @@ class StatsSummary(models.Model):
     cable_length = models.FloatField(null=False, default=0)
 
     def __str__(self) -> str:
-        return "Stats summary for {} on {}".format(
-                    self.user, self.date)
+        return f"Stats summary for {self.user} on {self.date}"
 
 class NodeQueryCache(models.Model):
     project = models.ForeignKey(Project, on_delete=models.CASCADE)

--- a/django/applications/catmaid/objects.py
+++ b/django/applications/catmaid/objects.py
@@ -374,11 +374,11 @@ def compartmentalize_skeletongroup( skeleton_id_list, project_id, **kwargs ):
                 skeleton.graph.node[nodeid]['compartment_index'] = i
 
             if len(skeleton.neuron.name) > 30:
-                neuronname = skeleton.neuron.name[:30] + '...' + ' [{0}]'.format(i)
+                neuronname = f'{skeleton.neuron.name[:30]}... [{i}]'
             else:
-                neuronname = skeleton.neuron.name + ' [{0}]'.format(i)
+                neuronname = f'{skeleton.neuron.name} [{i}]'
 
-            resultgraph.add_node( '{0}_{1}'.format(skeleton_id, i), {
+            resultgraph.add_node(f'{skeleton_id}_{i}', {
                     'neuronname': neuronname,
                     'skeletonid': str(skeleton_id),
                     'compartment_index': i,
@@ -397,16 +397,12 @@ def compartmentalize_skeletongroup( skeleton_id_list, project_id, **kwargs ):
                 # add the skeleton id for each treenode that is in v['presynaptic_to']
                 # This can duplicate skeleton id entries which is correct
                 for e in v['presynaptic_to']:
-                    skeleton_compartment_id = '{0}_{1}'.format(
-                        skeleton_id,
-                        skeleton.graph.node[e]['compartment_index'])
+                    skeleton_compartment_id = f'{skeleton_id}_{skeleton.graph.node[e]["compartment_index"]}'
                     connectors[connector_id]['pre'].append( skeleton_compartment_id )
 
             if len(v['postsynaptic_to']):
                 for e in v['postsynaptic_to']:
-                    skeleton_compartment_id = '{0}_{1}'.format(
-                        skeleton_id,
-                        skeleton.graph.node[e]['compartment_index'])
+                    skeleton_compartment_id = f'{skeleton_id}_{skeleton.graph.node[e]["compartment_index"]}'
                     connectors[connector_id]['post'].append( skeleton_compartment_id )
 
     # merge connectors into graph

--- a/django/applications/catmaid/tasks.py
+++ b/django/applications/catmaid/tasks.py
@@ -53,4 +53,4 @@ def deactivate_inactive_users() -> str:
     the user account is set to inactive.
     """
     inactive_users = deactivate_inactive_users_impl()
-    return "Deactivated inactive users ({} in total)".format(len(inactive_users))
+    return f"Deactivated inactive users ({len(inactive_users)} in total)"

--- a/django/applications/catmaid/tests/apis/test_labels.py
+++ b/django/applications/catmaid/tests/apis/test_labels.py
@@ -112,7 +112,7 @@ class LabelsApiTests(CatmaidApiTestCase):
 
     def get_successful_stats_response(self):
         self.fake_authentication()
-        url = '/{}/labels/stats'.format(self.test_project_id)
+        url = f'/{self.test_project_id}/labels/stats'
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 200)
@@ -150,4 +150,4 @@ class LabelsApiTests(CatmaidApiTestCase):
         response = self.get_successful_stats_response()
 
         for row in response:
-            self.assertFalse(row[1] == 'skeleton {}'.format(row[0]) and row[2] == 1, msg=msg.format(row[0], row[1]))
+            self.assertFalse(row[1] == f'skeleton {row[0]}' and row[2] == 1, msg=msg.format(row[0], row[1]))

--- a/django/applications/catmaid/tests/apis/test_links.py
+++ b/django/applications/catmaid/tests/apis/test_links.py
@@ -21,7 +21,7 @@ class LinksApiTests(CatmaidApiTestCase):
                  'state': make_nocheck_state()})
         self.assertEqual(response.status_code, 200)
         parsed_response = json.loads(response.content.decode('utf-8'))
-        expected_result = {'error': 'Couldn\'t find link between connector {0} and node {0}'.format(connector_id)}
+        expected_result = {'error': f'Could not find link between connector {connector_id} and node {treenode_id}'}
         self.assertIn('error', parsed_response)
         self.assertEqual(expected_result['error'], parsed_response['error'])
         self.assertEqual(tc_count, TreenodeConnector.objects.all().count())

--- a/django/applications/catmaid/tests/apis/test_messages.py
+++ b/django/applications/catmaid/tests/apis/test_messages.py
@@ -12,7 +12,7 @@ class MessagesApiTests(CatmaidApiTestCase):
         self.fake_authentication()
         message_id = 5050
 
-        response = self.client.post('/messages/{}/mark_read'.format(message_id))
+        response = self.client.post(f'/messages/{message_id}/mark_read')
         self.assertEqual(response.status_code, 200)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertIn('error', parsed_response)
@@ -24,7 +24,7 @@ class MessagesApiTests(CatmaidApiTestCase):
         self.fake_authentication()
         message_id = 3
 
-        response = self.client.post('/messages/{}/mark_read'.format(message_id))
+        response = self.client.post(f'/messages/{message_id}/mark_read')
         self.assertEqual(response.status_code, 200)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
@@ -36,7 +36,7 @@ class MessagesApiTests(CatmaidApiTestCase):
         self.fake_authentication()
         message_id = 1
 
-        response = self.client.post('/messages/{}/mark_read'.format(message_id))
+        response = self.client.post(f'/messages/{message_id}/mark_read')
         self.assertEqual(response.status_code, 302)
 
         message = Message.objects.filter(id=message_id)[0]

--- a/django/applications/catmaid/tests/apis/test_skeletons.py
+++ b/django/applications/catmaid/tests/apis/test_skeletons.py
@@ -1210,7 +1210,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
 
     def assert_skeletons_by_node_labels(self, label_ids, expected_response):
         self.fake_authentication()
-        url = '/{}/skeletons/node-labels'.format(self.test_project_id)
+        url = f'/{self.test_project_id}/skeletons/node-labels'
 
         response = self.client.post(url, {'label_ids': label_ids})
 

--- a/django/applications/catmaid/tests/apis/test_stats.py
+++ b/django/applications/catmaid/tests/apis/test_stats.py
@@ -771,7 +771,7 @@ class StatsApiTests(CatmaidApiTestCase):
             """, {
                 "project_id": self.test_project_id,
                 "skeleton_class_id": skeleton_class_id,
-                "name": "Test skeleton %s ".format(i),
+                "name": f"Test skeleton {i} ",
                 "user_id": self.test_user_id,
                 "creation_time": datetime.datetime(2017, 7, 5, 16, 20, 10),
             })
@@ -921,16 +921,16 @@ class StatsApiTests(CatmaidApiTestCase):
         ]
         link_data = list(chain.from_iterable(connector_links))
         link_template = ','.join('(%s,%s,%s,%s,%s)' for _ in connector_links)
-        cursor.execute("""
+        cursor.execute(f"""
             INSERT INTO treenode_connector (project_id, treenode_id, skeleton_id,
                 relation_id, connector_id, user_id, creation_time)
             SELECT %s, link.treenode_id, t.skeleton_id, link.relation_id,
                 link.connector_id, link.user_id, link.creation_time::timestamptz
             FROM treenode t
-            JOIN (VALUES {}) link(treenode_id, relation_id, connector_id,
+            JOIN (VALUES {link_template}) link(treenode_id, relation_id, connector_id,
                 user_id, creation_time)
             ON t.id = link.treenode_id
-        """.format(link_template), [self.test_project_id] + link_data)
+        """, [self.test_project_id] + link_data)
 
     def _test_setup_connector_summary(self, time_zone, start_date_utc,
             end_date_utc, expected_stats):
@@ -983,15 +983,15 @@ class StatsApiTests(CatmaidApiTestCase):
         node_data = list(chain.from_iterable(reviews))
         node_template = ','.join('(%s,%s,%s)' for _ in reviews)
         cursor = connection.cursor()
-        cursor.execute("""
+        cursor.execute(f"""
             INSERT INTO review (project_id, reviewer_id, review_time,
                  skeleton_id, treenode_id)
             SELECT %s, node.reviewer_id, node.review_time::timestamptz,
                 t.skeleton_id, t.id
             FROM treenode t
-            JOIN (VALUES {}) node(treenode_id, reviewer_id, review_time)
+            JOIN (VALUES {node_template}) node(treenode_id, reviewer_id, review_time)
             ON t.id = node.treenode_id
-        """.format(node_template), [self.test_project_id] + node_data)
+        """, [self.test_project_id] + node_data)
 
     def _test_setup_review_summary(self, time_zone, start_date_utc,
             end_date_utc, expected_stats):

--- a/django/applications/catmaid/tests/apis/test_treenodes.py
+++ b/django/applications/catmaid/tests/apis/test_treenodes.py
@@ -1058,7 +1058,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
     def test_compact_detail_simple(self):
         self.fake_authentication()
         response = self.client.post(
-                '/{}/treenodes/compact-detail'.format(self.test_project_id),
+                f'/{self.test_project_id}/treenodes/compact-detail',
                 {
                     'treenode_ids': [261, 417, 415]
                 })
@@ -1075,7 +1075,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
     def test_compact_detail_label_names_and_treenode_set(self):
         self.fake_authentication()
         response = self.client.post(
-                '/{}/treenodes/compact-detail'.format(self.test_project_id),
+                f'/{self.test_project_id}/treenodes/compact-detail',
                 {
                     'treenode_ids': [261, 417, 415],
                     'label_names': ['TODO']
@@ -1091,7 +1091,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
     def test_compact_detail_label_names(self):
         self.fake_authentication()
         response = self.client.post(
-                '/{}/treenodes/compact-detail'.format(self.test_project_id),
+                f'/{self.test_project_id}/treenodes/compact-detail',
                 {
                     'label_names': ['TODO']
                 })
@@ -1107,7 +1107,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
     def test_compact_detail_label_id_and_treenode_set(self):
         self.fake_authentication()
         response = self.client.post(
-                '/{}/treenodes/compact-detail'.format(self.test_project_id),
+                f'/{self.test_project_id}/treenodes/compact-detail',
                 {
                     'treenode_ids': [261, 417, 415],
                     'label_ids': [351]
@@ -1123,7 +1123,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
     def test_compact_detail_label_ids(self):
         self.fake_authentication()
         response = self.client.post(
-                '/{}/treenodes/compact-detail'.format(self.test_project_id),
+                f'/{self.test_project_id}/treenodes/compact-detail',
                 {
                     'label_ids': [351]
                 })
@@ -1139,7 +1139,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
     def test_compact_detail_skeleton_ids(self):
         self.fake_authentication()
         response = self.client.post(
-                '/{}/treenodes/compact-detail'.format(self.test_project_id),
+                f'/{self.test_project_id}/treenodes/compact-detail',
                 {
                     'skeleton_ids': [235]
                 })
@@ -1181,7 +1181,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
     def test_compact_detail_skeleton_ids_and_label(self):
         self.fake_authentication()
         response = self.client.post(
-                '/{}/treenodes/compact-detail'.format(self.test_project_id),
+                f'/{self.test_project_id}/treenodes/compact-detail',
                 {
                     'skeleton_ids': [235],
                     'label_names': ['TODO']

--- a/django/applications/catmaid/tests/apis/test_volume.py
+++ b/django/applications/catmaid/tests/apis/test_volume.py
@@ -122,7 +122,7 @@ class VolumeTests(CatmaidApiTestCase):
         assign_perm('can_import', self.test_user, self.test_project)
         with open(CUBE_PATH, 'rb') as f:
             response = self.client.post(
-                "/{}/volumes/import".format(self.test_project_id),
+                f"/{self.test_project_id}/volumes/import",
                 {"cube.stl": f}
             )
 
@@ -133,7 +133,7 @@ class VolumeTests(CatmaidApiTestCase):
 
         cube_id = parsed_response["cube.stl"]
 
-        response = self.client.get("/{}/volumes/{}/".format(self.test_project_id, cube_id))
+        response = self.client.get(f"/{self.test_project_id}/volumes/{cube_id}/")
 
         self.assertEqual(response.status_code, 200)
         parsed_response = json.loads(response.content.decode('utf-8'))
@@ -148,7 +148,7 @@ class VolumeTests(CatmaidApiTestCase):
         assign_perm('can_import', self.test_user, self.test_project)
         with open(CUBE_PATH, 'rb') as f:
             response = self.client.post(
-                "/{}/volumes/import".format(self.test_project_id),
+                f"/{self.test_project_id}/volumes/import",
                 {"cube.stl": f}
             )
 
@@ -160,7 +160,7 @@ class VolumeTests(CatmaidApiTestCase):
         cube_id = parsed_response["cube.stl"]
 
         response = self.client.get(
-            "/{}/volumes/{}/export.stl".format(self.test_project_id, cube_id),
+            f"/{self.test_project_id}/volumes/{cube_id}/export.stl",
             HTTP_ACCEPT="model/x.stl-ascii,model/stl")
 
         self.assertEqual(response.status_code, 200)

--- a/django/applications/catmaid/tests/gui/test_basic_gui.py
+++ b/django/applications/catmaid/tests/gui/test_basic_gui.py
@@ -88,9 +88,7 @@ class BasicUITest(StaticLiveServerTestCase):
                     "captureHtml": True,
                     "webdriverRemoteQuietExceptions": False,
                     "tunnel-identifier": os.environ["TRAVIS_JOB_NUMBER"],
-                    "name": "Job: {} Commit {}".format(
-                            os.environ["TRAVIS_JOB_NUMBER"],
-                            os.environ["TRAVIS_COMMIT"]),
+                    "name": f"Job: {os.environ['TRAVIS_JOB_NUMBER']} Commit {os.environ['TRAVIS_COMMIT']}",
                     "build": os.environ["TRAVIS_BUILD_NUMBER"],
                     "tags": [os.environ["TRAVIS_PYTHON_VERSION"], "CI"]
                 }
@@ -120,7 +118,7 @@ class BasicUITest(StaticLiveServerTestCase):
             if settings.GUI_TESTS_REMOTE:
                 # Let saucelabs.com know about the outcome of this test
                 id = self.selenium.session_id
-                logger.info('Link to remote Selenium GUI test job: https://saucelabs.com/jobs/{}'.format(id))
+                logger.info(f'Link to remote Selenium GUI test job: https://saucelabs.com/jobs/{id}')
 
                 from sauceclient import SauceClient
                 username = os.environ["SAUCE_USERNAME"]
@@ -170,7 +168,7 @@ class BasicUITest(StaticLiveServerTestCase):
         for log_entry in browser_log:
             self.assertIn('message', log_entry)
             if 'SyntaxError' in log_entry['message']:
-                print("Syntax error: {}".format(log_entry['message']))
+                print(f"Syntax error: {log_entry['message']}")
 
                 # If there is a syntax error, try to parse the message to load
                 # the respective source file and print the relevant lines.
@@ -185,7 +183,7 @@ class BasicUITest(StaticLiveServerTestCase):
                         print("Relevant source code:")
                         c = 2
                         for l in range(max(0, line - c - 1), min(len(lines) - 1, line + c)):
-                            print("{}: {}".format(str(l + 1), lines[l]))
+                            print(f"{l+1}: {lines[l]}")
 
                 # Let test fail
                 self.assertNotIn('SyntaxError', log_entry['message'])

--- a/django/applications/catmaid/tests/test_skeleton_summary_tables.py
+++ b/django/applications/catmaid/tests/test_skeleton_summary_tables.py
@@ -167,7 +167,7 @@ class SkeletonSummaryTableTests(TransactionTestCase):
         neuron_id = parsed_response[str(skeleton_id)]
 
         response = self.client.post(
-                '/{}/neuron/{}/delete'.format(self.project_id, neuron_id))
+                f'/{self.project_id}/neuron/{neuron_id}/delete')
         self.assertEqual(response.status_code, 200)
         parsed_response = json.loads(response.content.decode('utf-8'))
 

--- a/django/applications/catmaid/tests/test_transaction_log.py
+++ b/django/applications/catmaid/tests/test_transaction_log.py
@@ -88,9 +88,9 @@ class TransactionLogTests(TransactionTestCase):
         """Format one or two timestamps to represent a half-open Postgres range
         """
         if timestamp2:
-            return "[\"{}\",\"{}\")".format(timestamp1, timestamp2)
+            return f"[\"{timestamp1}\",\"{timestamp2}\")"
         else:
-            return "[\"{}\",)".format(timestamp1)
+            return f"[\"{timestamp1}\",)"
 
     def get_location(self, txid, exec_time, label):
         """ Get location based on the transaction ID and time"""

--- a/django/applications/catmaid/urls.py
+++ b/django/applications/catmaid/urls.py
@@ -19,9 +19,9 @@ from catmaid.control import (authentication, user, group, log, message, client,
         graph2, circles, analytics, review, wiringdiagram, object, sampler,
         similarity, nat, point, landmarks, pointcloud, pointset)
 
+from catmaid.history import record_request_action as record_view
 from catmaid.views import CatmaidView
 from catmaid.views.admin import ProjectDeletion
-from catmaid.history import record_request_action as record_view
 
 
 # A regular expression matching floating point and integer numbers
@@ -426,35 +426,35 @@ urlpatterns += [
 
 # Classification
 urlpatterns += [
-    url(r'^(?P<project_id>{0})/classification/(?P<workspace_pid>{0})/roots/$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/classification/(?P<workspace_pid>{integer})/roots/$',
         classification.get_classification_roots),
-    url(r'^(?P<project_id>{0})/classification/(?P<workspace_pid>{0})/setup/test$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/classification/(?P<workspace_pid>{integer})/setup/test$',
         classification.check_classification_setup_view, name='test_classification_setup'),
-    url(r'^(?P<project_id>{0})/classification/(?P<workspace_pid>{0})/setup/rebuild$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/classification/(?P<workspace_pid>{integer})/setup/rebuild$',
         record_view("classifications.rebuild_env")(classification.rebuild_classification_setup_view), name='rebuild_classification_setup'),
-    url(r'^(?P<project_id>{0})/classification/(?P<workspace_pid>{0})/new$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/classification/(?P<workspace_pid>{integer})/new$',
         record_view("classifications.add_graph")(classification.add_classification_graph), name='add_classification_graph'),
-    url(r'^(?P<project_id>{0})/classification/(?P<workspace_pid>{0})/list$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/classification/(?P<workspace_pid>{integer})/list$',
         classification.list_classification_graph, name='list_classification_graph'),
-    url(r'^(?P<project_id>{0})/classification/(?P<workspace_pid>{0})/list/(?P<link_id>\d+)$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/classification/(?P<workspace_pid>{integer})/list/(?P<link_id>\d+)$',
         classification.list_classification_graph, name='list_classification_graph'),
-    url(r'^(?P<project_id>{0})/classification/(?P<workspace_pid>{0})/(?P<link_id>\d+)/remove$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/classification/(?P<workspace_pid>{integer})/(?P<link_id>\d+)/remove$',
         record_view("classifications.remove_graph")(classification.remove_classification_graph), name='remove_classification_graph'),
-    url(r'^(?P<project_id>{0})/classification/(?P<workspace_pid>{0})/instance-operation$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/classification/(?P<workspace_pid>{integer})/instance-operation$',
         record_view("classifications.update_graph")(classification.classification_instance_operation), name='classification_instance_operation'),
-    url(r'^(?P<project_id>{0})/classification/(?P<workspace_pid>{0})/(?P<link_id>\d+)/autofill$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/classification/(?P<workspace_pid>{integer})/(?P<link_id>\d+)/autofill$',
         record_view("classifications.autofill_graph")(classification.autofill_classification_graph), name='autofill_classification_graph'),
-    url(r'^(?P<project_id>{0})/classification/(?P<workspace_pid>{0})/link$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/classification/(?P<workspace_pid>{integer})/link$',
         record_view("classifications.link_graph")(classification.link_classification_graph), name='link_classification_graph'),
-    url(r'^(?P<project_id>{0})/classification/(?P<workspace_pid>{0})/stack/(?P<stack_id>{0})/linkroi/(?P<ci_id>{0})/$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/classification/(?P<workspace_pid>{integer})/stack/(?P<stack_id>{integer})/linkroi/(?P<ci_id>{integer})/$',
         record_view("classifications.link_roi")(classification.link_roi_to_classification), name='link_roi_to_classification'),
-    url(r'^classification/(?P<workspace_pid>{0})/export$'.format(integer),
+    url(rf'^classification/(?P<workspace_pid>{integer})/export$',
         classification.export, name='export_classification'),
-    url(r'^classification/(?P<workspace_pid>{0})/export/excludetags/(?P<exclusion_tags>{1})/$'.format(integer, wordlist),
+    url(rf'^classification/(?P<workspace_pid>{integer})/export/excludetags/(?P<exclusion_tags>{wordlist})/$',
         classification.export, name='export_classification'),
-    url(r'^classification/(?P<workspace_pid>{0})/search$'.format(integer),
+    url(rf'^classification/(?P<workspace_pid>{integer})/search$',
         classification.search, name='search_classifications'),
-    url(r'^classification/(?P<workspace_pid>{0})/export_ontology$'.format(integer),
+    url(rf'^classification/(?P<workspace_pid>{integer})/export_ontology$',
         classification.export_ontology, name='export_ontology'),
 ]
 
@@ -467,40 +467,40 @@ urlpatterns += [
 
 # Regions of interest
 urlpatterns += [
-    url(r'^(?P<project_id>{0})/roi/(?P<roi_id>{0})/info$'.format(integer), roi.get_roi_info, name='get_roi_info'),
-    url(r'^(?P<project_id>{0})/roi/link/(?P<relation_id>{0})/stack/(?P<stack_id>{0})/ci/(?P<ci_id>{0})/$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/roi/(?P<roi_id>{integer})/info$', roi.get_roi_info, name='get_roi_info'),
+    url(rf'^(?P<project_id>{integer})/roi/link/(?P<relation_id>{integer})/stack/(?P<stack_id>{integer})/ci/(?P<ci_id>{integer})/$',
         record_view("rois.create_link")(roi.link_roi_to_class_instance), name='link_roi_to_class_instance'),
-    url(r'^(?P<project_id>{0})/roi/(?P<roi_id>{0})/remove$'.format(integer), record_view("rois.remove_link")(roi.remove_roi_link), name='remove_roi_link'),
-    url(r'^(?P<project_id>{0})/roi/(?P<roi_id>{0})/image$'.format(integer), roi.get_roi_image, name='get_roi_image'),
-    url(r'^(?P<project_id>{0})/roi/add$'.format(integer), record_view("rois.create")(roi.add_roi), name='add_roi'),
+    url(rf'^(?P<project_id>{integer})/roi/(?P<roi_id>{integer})/remove$', record_view("rois.remove_link")(roi.remove_roi_link), name='remove_roi_link'),
+    url(rf'^(?P<project_id>{integer})/roi/(?P<roi_id>{integer})/image$', roi.get_roi_image, name='get_roi_image'),
+    url(rf'^(?P<project_id>{integer})/roi/add$', record_view("rois.create")(roi.add_roi), name='add_roi'),
 ]
 
 # General points
 urlpatterns += [
-    url(r'^(?P<project_id>{0})/points/$'.format(integer), point.PointList.as_view()),
-    url(r'^(?P<project_id>{0})/points/(?P<point_id>[0-9]+)/$'.format(integer), point.PointDetail.as_view()),
+    url(rf'^(?P<project_id>{integer})/points/$', point.PointList.as_view()),
+    url(rf'^(?P<project_id>{integer})/points/(?P<point_id>[0-9]+)/$', point.PointDetail.as_view()),
 ]
 
 # Landmarks
 urlpatterns += [
-    url(r'^(?P<project_id>{0})/landmarks/$'.format(integer), landmarks.LandmarkList.as_view()),
-    url(r'^(?P<project_id>{0})/landmarks/(?P<landmark_id>[0-9]+)/$'.format(integer), landmarks.LandmarkDetail.as_view()),
-    url(r'^(?P<project_id>{0})/landmarks/(?P<landmark_id>[0-9]+)/locations/$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/landmarks/$', landmarks.LandmarkList.as_view()),
+    url(rf'^(?P<project_id>{integer})/landmarks/(?P<landmark_id>[0-9]+)/$', landmarks.LandmarkDetail.as_view()),
+    url(rf'^(?P<project_id>{integer})/landmarks/(?P<landmark_id>[0-9]+)/locations/$',
             landmarks.LandmarkLocationList.as_view()),
-    url(r'^(?P<project_id>{0})/landmarks/(?P<landmark_id>[0-9]+)/locations/(?P<location_id>[0-9]+)/$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/landmarks/(?P<landmark_id>[0-9]+)/locations/(?P<location_id>[0-9]+)/$',
             landmarks.LandmarkLocationDetail.as_view()),
-    url(r'^(?P<project_id>{0})/landmarks/(?P<landmark_id>[0-9]+)/groups/(?P<group_id>[0-9]+)/$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/landmarks/(?P<landmark_id>[0-9]+)/groups/(?P<group_id>[0-9]+)/$',
             landmarks.LandmarkAndGroupkLocationDetail.as_view()),
-    url(r'^(?P<project_id>{0})/landmarks/groups/$'.format(integer), landmarks.LandmarkGroupList.as_view()),
-    url(r'^(?P<project_id>{0})/landmarks/groups/import$'.format(integer), landmarks.LandmarkGroupImport.as_view()),
-    url(r'^(?P<project_id>{0})/landmarks/groups/materialize$'.format(integer), landmarks.LandmarkGroupMaterializer.as_view()),
-    url(r'^(?P<project_id>{0})/landmarks/groups/links/$'.format(integer), landmarks.LandmarkGroupLinks.as_view()),
-    url(r'^(?P<project_id>{0})/landmarks/groups/links/(?P<link_id>[0-9]+)/$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/landmarks/groups/$', landmarks.LandmarkGroupList.as_view()),
+    url(rf'^(?P<project_id>{integer})/landmarks/groups/import$', landmarks.LandmarkGroupImport.as_view()),
+    url(rf'^(?P<project_id>{integer})/landmarks/groups/materialize$', landmarks.LandmarkGroupMaterializer.as_view()),
+    url(rf'^(?P<project_id>{integer})/landmarks/groups/links/$', landmarks.LandmarkGroupLinks.as_view()),
+    url(rf'^(?P<project_id>{integer})/landmarks/groups/links/(?P<link_id>[0-9]+)/$',
             landmarks.LandmarkGroupLinkDetail.as_view()),
-    url(r'^(?P<project_id>{0})/landmarks/groups/(?P<landmarkgroup_id>[0-9]+)/$'.format(integer), landmarks.LandmarkGroupDetail.as_view()),
-    url(r'^(?P<project_id>{0})/landmarks/groups/(?P<landmarkgroup_id>[0-9]+)/transitively-linked$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/landmarks/groups/(?P<landmarkgroup_id>[0-9]+)/$', landmarks.LandmarkGroupDetail.as_view()),
+    url(rf'^(?P<project_id>{integer})/landmarks/groups/(?P<landmarkgroup_id>[0-9]+)/transitively-linked$',
         landmarks.LandmarkGroupLinkage.as_view()),
-    url(r'^(?P<project_id>{0})/landmarks/groups/(?P<landmarkgroup_id>[0-9]+)/locations/(?P<location_id>[0-9]+)/$'.format(integer),
+    url(rf'^(?P<project_id>{integer})/landmarks/groups/(?P<landmarkgroup_id>[0-9]+)/locations/(?P<location_id>[0-9]+)/$',
             landmarks.LandmarkGroupLocationList.as_view()),
 ]
 

--- a/django/applications/catmaid/util.py
+++ b/django/applications/catmaid/util.py
@@ -18,7 +18,7 @@ class Point3D:
         self.x, self.y, self.z = x, y, z
 
     def __str__(self):
-        return "({}, {}, {})".format(self.x, self.y, self.z)
+        return f"({self.x}, {self.y}, {self.z})"
 
 def is_collinear(a, b, c, between=False, eps=epsilon) -> bool:
     """Return true if all three points are collinear, i.e. on one line. If

--- a/django/applications/catmaid/views/__init__.py
+++ b/django/applications/catmaid/views/__init__.py
@@ -101,10 +101,10 @@ class GroupMembershipHelper(TemplateView):
             users = User.objects.filter(id=target_user)
             n_user_instances = len(users)
             if 0 == n_user_instances:
-                messages.warning(request, 'Could not find user with ID {}'.format(target_user))
+                messages.warning(request, f'Could not find user with ID {target_user}')
                 continue
             if 1 < n_user_instances:
-                messages.warning(request, 'Found more than one user with ID {}'.format(target_user))
+                messages.warning(request, f'Found more than one user with ID {target_user}')
                 continue
 
             user = users[0]
@@ -117,5 +117,5 @@ class GroupMembershipHelper(TemplateView):
                 group.user_set.remove(*source_users)
                 updated += 1
 
-        messages.success(request, 'Successfully updated {} permissions'.format(updated))
+        messages.success(request, f'Successfully updated {updated} permissions')
         return HttpResponseRedirect(redirect_url)

--- a/django/applications/catmaid/views/admin.py
+++ b/django/applications/catmaid/views/admin.py
@@ -30,5 +30,5 @@ class ProjectDeletion(ListView):
             raise ValueError("No project IDs specified")
         delete_projects(project_ids)
         messages.add_message(self.request, messages.INFO,
-                "{} project(s) plus all their linked data have been deleted".format(len(project_ids)))
+                f"{len(project_ids)} project(s) plus all their linked data have been deleted")
         return HttpResponseRedirect(reverse('admin:index') + 'catmaid/project')

--- a/django/applications/catmaid/views/dataexporter.py
+++ b/django/applications/catmaid/views/dataexporter.py
@@ -84,7 +84,7 @@ class CatmaidDataExportWizard(SessionWizardView):
         try:
             source_project = Project.objects.get(id=int(source_project_id))
         except:
-            raise Exception('Could not retrieve project with id {}'.format(source_project_id))
+            raise Exception(f'Could not retrieve project with id {source_project_id}')
 
         values = self.get_cleaned_data_for_step('server')
 
@@ -92,7 +92,7 @@ class CatmaidDataExportWizard(SessionWizardView):
 
         exported_fname = os.path.join(settings.MEDIA_ROOT,
             settings.MEDIA_EXPORT_SUBDIRECTORY,
-            'catmaid-export-pid-{}-{}.json'.format(values['source_project_id'], now))
+            f'catmaid-export-pid-{values["source_project_id"]}-{now}.json')
 
         options = {
             "export_treenodes": values["export_treenodes"],
@@ -116,6 +116,6 @@ class CatmaidDataExportWizard(SessionWizardView):
         logger.info("Export project data finished.")
 
         messages.add_message(self.request, messages.SUCCESS,
-                "CATMAID Project exported to: {}".format(exported_fname))
+                f"CATMAID Project exported to: {exported_fname}")
 
         return redirect('admin:index')

--- a/django/applications/catmaid/views/userimporter.py
+++ b/django/applications/catmaid/views/userimporter.py
@@ -42,7 +42,7 @@ def get_remote_users(url, api_key, auth=None, with_passwords=False):
 
     # Prepare headers
     headers = {
-        'X-Authorization': 'Token {}'.format(api_key)
+        'X-Authorization': f'Token {api_key}'
     }
 
     user_list_url = "{}/user-list".format(url[:-1] if url.endswith('/') else url)
@@ -51,12 +51,10 @@ def get_remote_users(url, api_key, auth=None, with_passwords=False):
     r = requests.get(user_list_url, headers=headers, auth=auth, params=({
         'with_passwords': 'true' if with_passwords else 'false'}))
     if r.status_code != 200:
-        raise ValueError("Unexpected status code ({}) for {}".format(
-                r.status_code, user_list_url))
+        raise ValueError(f"Unexpected status code ({r.status_code}) for {user_list_url}")
 
     if 'json' not in r.headers['content-type']:
-        raise ValueError("Unexpected content type ({}) for {}".format(
-                r.content_type, user_list_url))
+        raise ValueError(f"Unexpected content type ({r.status_code}) for {user_list_url}")
 
     return r.json()
 
@@ -97,7 +95,7 @@ class ServerForm(forms.Form):
         try:
             form_data['users'] = get_remote_users(host, api_key, auth, with_passwords=False)
         except Exception as e:
-            raise ValidationError('Could not retrieve user information: {}'.format(e))
+            raise ValidationError(f'Could not retrieve user information: {e}')
 
         return form_data
 
@@ -168,7 +166,7 @@ class UserImportWizard(SessionWizardView):
         try:
             users = get_remote_users(host, api_key, auth, with_passwords=True)
         except Exception as e:
-            raise ValidationError('Could not retrieve user information: {}'.format(e))
+            raise ValidationError(f'Could not retrieve user information: {e}')
 
         for u in users:
             if not 'password' in u:
@@ -187,5 +185,5 @@ class UserImportWizard(SessionWizardView):
             new_user.userprofile.save()
 
         messages.add_message(self.request, messages.SUCCESS,
-                "{} new user(s) have been imported".format(len(users_to_import)))
+                f"{len(users_to_import)} new user(s) have been imported")
         return redirect('admin:index')


### PR DESCRIPTION
This converts many of the string.format calls in the codebase to use f-strings. I went with the metric of:
1) If it's a simple static substitution I'll do it
2) If it's an expression, but it's not complex enough that it distracts from the string I'll do it (like a join).
3) If it uses a list comprehension or anything more complex I left it as a string.format(), on the basis that having those inline would be harder to read than the substitution
I took a shot at simplifying any other string handling I came across while doing this.

It also fixes some typos, turns a few contractions into non-contractions, and fixes a few things that look like bugs (these will be marked with comments).

It's worth looking carefully at this (I will, in the days to come) to make sure I didn't miss any "f" markers at the start of strings or incorrectly translate some code.