### PR TITLE
Return HTTP status 400 and 500 errors on back-end errors

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -46,6 +46,11 @@ included in this changelog.
 
 ### Modifications
 
+- All APIs: errors during a request are now indicated with a more useful HTTP
+  status code than 200: errors related to the request, input data and the client
+  will result in status 400, permission errors in status 403, unavailable
+  resources in status 404 and internal server errors in status 500.
+
 - `POST|GET /{project_id}/node/list`:
   Offers a new optional parameter
   "ordering", which can be used to order the result set of nodes. The values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@
   the tracing tool is now enabled for new users, because it seems in many setups
   users want to have this enabled by default.
 
+- Back-end errors result now in actual HTTP error status codes. Third-party
+  clients need possibly some adjustments to handle API errors. In case of an
+  error, status 400 is returned if an input data or parameter problem, 401 for
+  permission problems and 500 otherwise.
+
 ### Features and enhancements
 
 Node filters:

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -9,6 +9,11 @@ and other administration related changes are listed in order.
   PostGIS first and run `ALTER EXTENSION postgis UPDATE;` in every database. For
   docker-compose setups this database update is performed automatically.
 
+- Back-end errors result now in actual HTTP error status codes. Third-party
+  clients need possibly some adjustments to handle API errors. In case of an
+  error, status 400 is returned if an input data or parameter problem, 401 for
+  permission problems and 500 otherwise.
+
 ## 2019.06.20
 
 - A virtualenv update is required.

--- a/django/applications/catmaid/control/authentication.py
+++ b/django/applications/catmaid/control/authentication.py
@@ -121,6 +121,7 @@ def user_context_response(user, additional_fields=None) -> JsonResponse:
         'userid': user.id,
         'username': user.username,
         'is_superuser': user.is_superuser,
+        'is_authenticated': user != get_anonymous_user(),
         'userprofile': user.userprofile.as_dict(),
         'permissions': tuple(user.get_all_permissions()),
         'domain': list(user_domain(cursor, user.id))

--- a/django/applications/catmaid/control/authentication.py
+++ b/django/applications/catmaid/control/authentication.py
@@ -28,21 +28,22 @@ from django.shortcuts import _get_queryset, render
 from rest_framework.authtoken import views as auth_views
 from rest_framework.authtoken.serializers import AuthTokenSerializer
 
+from catmaid.error import ClientError
 from catmaid.models import Project, UserRole, ClassInstance, \
         ClassInstanceClassInstance
 
 
-class PermissionError(Exception):
+class PermissionError(ClientError):
     """Indicates the lack of permissions for a particular action."""
-    pass
+    status_code = 403
 
 
-class InvalidLoginError(Exception):
+class InvalidLoginError(ClientError):
     """Indicates an unsuccessful login."""
-    pass
+    status_code = 400
 
 
-class InactiveLoginError(Exception):
+class InactiveLoginError(ClientError):
     """Indicates some sort of configuration error"""
     def __init__(self, message, meta=None):
         super().__init__(message)
@@ -386,7 +387,7 @@ def can_edit_class_instance_or_fail(user, ci_id, name='object') -> bool:
                     locked_by_other[0].user_id):
                 return True
 
-            raise Exception('User %s with id #%s cannot edit %s #%s' % \
+            raise PermissionError('User %s with id #%s cannot edit %s #%s' % \
                 (user.username, user.id, name, ci_id))
         # The class instance is locked by user or not locked at all
         return True
@@ -419,7 +420,7 @@ def can_edit_or_fail(user, ob_id:int, table_name) -> bool:
             if user_can_edit(cursor, user.id, owner_id):
                 return True
 
-        raise Exception('User %s with id #%s cannot edit object #%s (from user #%s) from table %s' % (user.username, user.id, ob_id, rows[0][0], table_name))
+        raise PermissionError('User %s with id #%s cannot edit object #%s (from user #%s) from table %s' % (user.username, user.id, ob_id, rows[0][0], table_name))
     raise ObjectDoesNotExist('Object #%s not found in table %s' % (ob_id, table_name))
 
 
@@ -448,7 +449,7 @@ def can_edit_all_or_fail(user, ob_ids, table_name) -> bool:
         if set(row[0] for row in rows).issubset(user_domain(cursor, user.id)):
             return True
 
-        raise Exception('User %s cannot edit all of the %s unique objects from table %s' % (user.username, len(ob_ids), table_name))
+        raise PermissionError('User %s cannot edit all of the %s unique objects from table %s' % (user.username, len(ob_ids), table_name))
     raise ObjectDoesNotExist('One or more of the %s unique objects were not found in table %s' % (len(ob_ids), table_name))
 
 def user_can_edit(cursor, user_id, other_user_id) -> bool:

--- a/django/applications/catmaid/control/pointcloud.py
+++ b/django/applications/catmaid/control/pointcloud.py
@@ -17,7 +17,7 @@ from rest_framework.views import APIView
 from rest_framework.decorators import api_view
 
 from catmaid.control.authentication import (requires_user_role,
-        can_edit_or_fail, check_user_role)
+        can_edit_or_fail, check_user_role, PermissionError)
 from catmaid.control.common import (insert_into_log, get_class_to_id_map,
         get_relation_to_id_map, _create_relation, get_request_bool,
         get_request_list)

--- a/django/applications/catmaid/control/similarity.py
+++ b/django/applications/catmaid/control/similarity.py
@@ -20,7 +20,7 @@ from rest_framework.decorators import api_view
 
 from catmaid.consumers import msg_user
 from catmaid.control.authentication import (requires_user_role,
-        can_edit_or_fail, check_user_role)
+        can_edit_or_fail, check_user_role, PermissionError)
 from catmaid.control.common import (insert_into_log, get_class_to_id_map,
         get_relation_to_id_map, _create_relation, get_request_bool,
         get_request_list)

--- a/django/applications/catmaid/control/textlabel.py
+++ b/django/applications/catmaid/control/textlabel.py
@@ -51,7 +51,7 @@ def update_textlabel(request:HttpRequest, project_id=None) -> HttpResponse:
         return HttpResponse(' ')
 
     except Exception as e:
-        raise Exception(response_on_error + ':' + str(e))
+        raise ValueError(response_on_error + ':' + str(e))
 
 
 @requires_user_role(UserRole.Annotate)

--- a/django/applications/catmaid/control/transaction.py
+++ b/django/applications/catmaid/control/transaction.py
@@ -3,6 +3,7 @@
 from typing import Dict
 from django.db import connection
 
+from catmaid.error import ClientError
 from catmaid.control.authentication import requires_user_role
 from catmaid.models import UserRole
 
@@ -11,7 +12,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 
-class LocationLookupError(Exception):
+class LocationLookupError(ClientError):
     pass
 
 

--- a/django/applications/catmaid/control/treenode.py
+++ b/django/applications/catmaid/control/treenode.py
@@ -422,7 +422,7 @@ def _create_treenode(project_id, creator, editor, x, y, z, radius, confidence,
 
     except Exception as e:
         import traceback
-        raise Exception("%s: %s %s" % (response_on_error, str(e),
+        raise ValueError("%s: %s %s" % (response_on_error, str(e),
                                        str(traceback.format_exc())))
 
 
@@ -441,7 +441,7 @@ def update_parent(request:HttpRequest, project_id=None, treenode_id=None) -> Jso
     parent = get_object_or_404(Treenode, pk=parent_id, project_id=project_id)
 
     if child.skeleton_id != parent.skeleton_id:
-        raise Exception("Child node %s is in skeleton %s but parent node %s is in skeleton %s!", \
+        raise ValueError("Child node %s is in skeleton %s but parent node %s is in skeleton %s!", \
                         treenode_id, child.skeleton_id, parent_id, parent.skeleton_id)
 
     child.parent_id = parent_id
@@ -531,7 +531,7 @@ def update_radius(request:HttpRequest, project_id=None, treenode_id=None) -> Jso
     treenode_id = int(treenode_id)
     radius = float(request.POST.get('radius', -1))
     if math.isnan(radius):
-        raise Exception("Radius '%s' is not a number!" % request.POST.get('radius'))
+        raise ValueError("Radius '%s' is not a number!" % request.POST.get('radius'))
     option = int(request.POST.get('option', 0))
     cursor = connection.cursor()
     # Make sure the back-end is in the expected state
@@ -697,7 +697,7 @@ def delete_treenode(request:HttpRequest, project_id=None) -> JsonResponse:
             if n_children > 0:
                 # TODO yes you can, the new root is the first of the children,
                 # and other children become independent skeletons
-                raise Exception("You can't delete the root node when it "
+                raise ValueError("You can't delete the root node when it "
                                 "has children.")
             # Get the neuron before the skeleton is deleted. It can't be
             # accessed otherwise anymore.
@@ -768,7 +768,7 @@ def delete_treenode(request:HttpRequest, project_id=None) -> JsonResponse:
         })
 
     except Exception as e:
-        raise Exception(response_on_error + ': ' + str(e))
+        raise ValueError(response_on_error + ': ' + str(e))
 
 def _compact_detail_list(project_id, treenode_ids=None, label_ids=None,
         label_names=None, skeleton_ids=None):
@@ -1020,7 +1020,7 @@ def find_children(request:HttpRequest, project_id=None, treenode_id=None) -> Jso
         children = [[row] for row in cursor.fetchall()]
         return JsonResponse(children, safe=False)
     except Exception as e:
-        raise Exception('Could not obtain next branch node or leaf: ' + str(e))
+        raise ValueError('Could not obtain next branch node or leaf: ' + str(e))
 
 
 @api_view(['POST'])
@@ -1176,7 +1176,7 @@ def _find_first_interesting_node(sequence):
     Otherwise return the last node.
     """
     if not sequence:
-        raise Exception('No nodes ahead!')
+        raise ValueError('No nodes ahead!')
 
     if 1 == len(sequence):
         return sequence[0]
@@ -1201,7 +1201,7 @@ def _find_first_interesting_node(sequence):
             if props[1] < 5 or props[2] or props[3]:
                 return node_id
         else:
-            raise Exception('Nodes of this skeleton changed while inspecting them.')
+            raise ValueError('Nodes of this skeleton changed while inspecting them.')
 
     return sequence[-1]
 
@@ -1231,7 +1231,7 @@ def find_previous_branchnode_or_root(request:HttpRequest, project_id=None, treen
 
         return JsonResponse(_fetch_location(project_id, tnid), safe=False)
     except Exception as e:
-        raise Exception('Could not obtain previous branch node or root:' + str(e))
+        raise ValueError('Could not obtain previous branch node or root:' + str(e))
 
 
 @requires_user_role([UserRole.Annotate, UserRole.Browse])
@@ -1275,4 +1275,4 @@ def find_next_branchnode_or_end(request:HttpRequest, project_id=None, treenode_i
         branches = [[node_locations[node_id] for node_id in branch] for branch in branches]
         return JsonResponse(branches, safe=False)
     except Exception as e:
-        raise Exception('Could not obtain next branch node or leaf: ' + str(e))
+        raise ValueError('Could not obtain next branch node or leaf: ' + str(e))

--- a/django/applications/catmaid/control/user.py
+++ b/django/applications/catmaid/control/user.py
@@ -12,7 +12,7 @@ from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib.auth.models import User
 import django.contrib.auth.views as django_auth_views
 
-from catmaid.control.authentication import access_check
+from catmaid.control.authentication import (access_check, PermissionError)
 from catmaid.control.common import get_request_bool
 
 

--- a/django/applications/catmaid/error.py
+++ b/django/applications/catmaid/error.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+
+class ClientError(ValueError):
+    """Client errors are the result of bad values or requests by the client. In
+    the general case this will result in a status 400 error.
+    """
+    status_code = 400

--- a/django/applications/catmaid/state.py
+++ b/django/applications/catmaid/state.py
@@ -7,8 +7,10 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from django.db import connection
 
+from catmaid.error import ClientError
 
-class StateMatchingError(Exception):
+
+class StateMatchingError(ClientError):
     """Indicates that a state check wasn't successful"""
     def __init__(self, message, state):
         super().__init__(message)

--- a/django/applications/catmaid/static/js/CATMAID.js
+++ b/django/applications/catmaid/static/js/CATMAID.js
@@ -185,49 +185,6 @@
   CATMAID.warn = CATMAID.msg.bind(window, "Warning");
 
   /**
-   * Creates a generic JSON response handler that complains when the response
-   * status is different from 200 or a JSON error is set.
-   *
-   * @param success Called on success
-   * @param error Called on error
-   * @param silent No error dialogs are shown, if true
-   */
-  CATMAID.jsonResponseHandler = function(success, error, silent)
-  {
-    return function(status, text, xml) {
-      if (status >= 200 && status <= 204 &&
-          (typeof text === 'string' || text instanceof String)) {
-        // `text` may be empty for no content responses.
-        var json = text.length ? JSON.parse(text) : {};
-        if (json.error) {
-          // Call error handler, if any, and force silence if it returned true.
-          if (CATMAID.tools.isFn(error)) {
-            silent = error(json) || silent;
-          }
-          if (!silent) {
-            CATMAID.error(json.error, json.detail);
-          }
-        } else {
-          CATMAID.tools.callIfFn(success, json);
-        }
-      } else {
-        var e = {
-          error: "An error occured",
-          detail: "The server returned an unexpected status: " + status,
-          status: status
-        };
-        // Call error handler, if any, and force silence if it returned true.
-        if (CATMAID.tools.isFn(error)) {
-          silent = error(e) || silent;
-        }
-        if (!silent) {
-          CATMAID.error(e.msg, e.detail);
-        }
-      }
-    };
-  };
-
-  /**
    * Convenience function to show an error dialog.
    */
   CATMAID.error = function(msg, detail)

--- a/django/applications/catmaid/static/js/widgets/overlay.js
+++ b/django/applications/catmaid/static/js/widgets/overlay.js
@@ -4062,7 +4062,7 @@ var SkeletonAnnotations = {};
           }
 
           return Promise.all(requests);
-        })
+        }, e => true /* Tell submitter we handle error */)
         .then(function(responses) {
           // Bail if the overlay was destroyed or suspended before this callback.
           if (self.suspended) {
@@ -4143,7 +4143,8 @@ var SkeletonAnnotations = {};
 
       // Return a proper promise to the caller (i.e. no submitter instance).
       return work.promise();
-    });
+    })
+    .catch(CATMAID.handleError);
   };
 
   CATMAID.TracingOverlay.prototype.createSubViewNodeListFromCache = function(params) {

--- a/django/applications/catmaid/static/libs/catmaid/error.js
+++ b/django/applications/catmaid/static/libs/catmaid/error.js
@@ -143,4 +143,9 @@
    */
   CATMAID.ReplacedRequestError = class ReplacedRequestError extends CATMAID.Error {};
 
+  /**
+   * Indicate a missing (remote) resource.
+   */
+  CATMAID.MissingResourceError = class MissingResourceError extends CATMAID.Error {};
+
 })(CATMAID);

--- a/django/applications/catmaid/tests/apis/test_datastores.py
+++ b/django/applications/catmaid/tests/apis/test_datastores.py
@@ -9,14 +9,14 @@ class DatastoresApiTests(CatmaidApiTestCase):
     def test_client_datastores(self):
         url = '/client/datastores/'
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 403)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertIn('error', parsed_response)
         self.assertIn('type', parsed_response)
         self.assertEquals('PermissionError', parsed_response['type'])
 
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 403)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertIn('error', parsed_response)
         self.assertIn('type', parsed_response)
@@ -26,7 +26,7 @@ class DatastoresApiTests(CatmaidApiTestCase):
         self.fake_authentication()
         name = 'test-  %% datastore'
         response = self.client.post(url, {'name': name})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 500)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertTrue('error' in parsed_response)
         name = 'test-datastore'

--- a/django/applications/catmaid/tests/apis/test_links.py
+++ b/django/applications/catmaid/tests/apis/test_links.py
@@ -19,7 +19,7 @@ class LinksApiTests(CatmaidApiTestCase):
                 '/%d/link/delete' % self.test_project_id,
                 {'connector_id': connector_id, 'treenode_id': treenode_id,
                  'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 400)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {'error': f'Could not find link between connector {connector_id} and node {treenode_id}'}
         self.assertIn('error', parsed_response)

--- a/django/applications/catmaid/tests/apis/test_messages.py
+++ b/django/applications/catmaid/tests/apis/test_messages.py
@@ -13,7 +13,7 @@ class MessagesApiTests(CatmaidApiTestCase):
         message_id = 5050
 
         response = self.client.post(f'/messages/{message_id}/mark_read')
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 404)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertIn('error', parsed_response)
         self.assertIn('type', parsed_response)

--- a/django/applications/catmaid/tests/apis/test_neurons.py
+++ b/django/applications/catmaid/tests/apis/test_neurons.py
@@ -50,7 +50,7 @@ class NeuronsApiTests(CatmaidApiTestCase):
 
         url = '/%d/neurons/%s/rename' % (self.test_project_id, neuron_id)
         response = self.client.post(url, {'name': new_name})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 403)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertTrue('error' in parsed_response)
         self.assertTrue(parsed_response['error'])

--- a/django/applications/catmaid/tests/apis/test_nodes.py
+++ b/django/applications/catmaid/tests/apis/test_nodes.py
@@ -157,7 +157,7 @@ class NodesApiTests(CatmaidApiTestCase):
         response = self.client.post( '/%d/nodes/location' % (self.test_project_id + 1), {
             'node_ids': treenode_ids
         })
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 403)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertTrue('error' in parsed_response)
 
@@ -246,7 +246,7 @@ class NodesApiTests(CatmaidApiTestCase):
                         't[0][1]': x,
                         't[0][2]': y,
                         't[0][3]': z})
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 400)
             parsed_response = json.loads(response.content.decode('utf-8'))
             self.assertIn('error', parsed_response)
             cursor = connection.cursor()
@@ -351,7 +351,7 @@ class NodesApiTests(CatmaidApiTestCase):
 
         response = self.client.post(
                 '/%d/node/update' % self.test_project_id, param_dict)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 403)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {'error': 'User test2 cannot edit all of the 4 '
                            'unique objects from table treenode'}

--- a/django/applications/catmaid/tests/apis/test_textlabels.py
+++ b/django/applications/catmaid/tests/apis/test_textlabels.py
@@ -101,7 +101,7 @@ class TextlabelsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/textlabel/update' % self.test_project_id,
                 params)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 400)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = 'Failed to find Textlabel with id %s.' % textlabel_id
         self.assertIn('error', parsed_response)

--- a/django/applications/catmaid/tests/apis/test_treenodes.py
+++ b/django/applications/catmaid/tests/apis/test_treenodes.py
@@ -32,7 +32,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenodes/%d/confidence' % (self.test_project_id, treenode_id),
                 {'new_confidence': '4'})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 400)
         expected_result = 'No skeleton and neuron for treenode %s' % treenode_id
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(expected_result, parsed_response['error'])
@@ -288,7 +288,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
             'parent_id': parent_id,
             'radius': 2,
             'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 400)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {'error': 'Parent treenode %d does not exist' % parent_id}
         self.assertIn(expected_result['error'], parsed_response['error'])
@@ -335,7 +335,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenode/delete' % self.test_project_id,
                 {'treenode_id': treenode_id, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 400)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = "Could not delete root node: You can't delete the " \
                           "root node when it has children."
@@ -497,7 +497,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
             'child_id': child_id,
             'parent_id': parent_id})
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 403)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertTrue('error' in parsed_response)
 
@@ -539,7 +539,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
             'child_id': child_id,
             'parent_id': parent_id})
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 400)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertTrue('error' in parsed_response)
 
@@ -635,7 +635,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
 
         response = self.client.get(
                 '/%d/treenodes/%s/info' % (self.test_project_id, treenode_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 400)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = 'No skeleton and neuron for treenode %s' % treenode_id
         self.assertIn('error', parsed_response)

--- a/django/applications/catmaid/tests/gui/test_basic_gui.py
+++ b/django/applications/catmaid/tests/gui/test_basic_gui.py
@@ -188,9 +188,14 @@ class BasicUITest(StaticLiveServerTestCase):
                 # Let test fail
                 self.assertNotIn('SyntaxError', log_entry['message'])
 
-            # Fail on any severe errors
+            # Fail on any severe errors that aren't expected. Expected are 403
+            # errors for settings loading for the anonymous user if not linked
+            # to any project.
             self.assertIn('level', log_entry)
-            self.assertNotIn('SEVERE', log_entry['level'], log_entry['message'])
+            unexpected_error = 'SEVERE' in log_entry['level'] and \
+                    '403 (Forbidden)' not in log_entry['message']
+            if unexpected_error:
+                self.assertNotIn('SEVERE', log_entry['level'], log_entry['message'])
 
         # Check title
         self.assertTrue("CATMAID" in self.selenium.title)

--- a/django/applications/catmaid/tests/test_common_apis.py
+++ b/django/applications/catmaid/tests/test_common_apis.py
@@ -328,7 +328,7 @@ class ViewPageTests(TestCase):
             'with_passwords': True,
         })
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 403)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         self.assertTrue('error' in parsed_response)
@@ -693,7 +693,7 @@ class PermissionTests(TestCase):
         for api in self.can_browse_get_api:
             msg = "GET %s" % api
             response = self.client.get(api)
-            self.assertEqual(response.status_code, 200, msg)
+            self.assertNotIn(response.status_code, (401, 403), msg)
             try:
                 parsed_response = json.loads(response.content.decode('utf-8'))
                 missing_permissions = ('error' in parsed_response and
@@ -709,7 +709,7 @@ class PermissionTests(TestCase):
         for api in self.can_browse_post_api:
             msg = "POST %s" % api
             response = self.client.post(api)
-            self.assertEqual(response.status_code, 200, msg)
+            self.assertNotIn(response.status_code, (401, 403), msg)
             try:
                 parsed_response = json.loads(response.content.decode('utf-8'))
                 missing_permissions = ('error' in parsed_response and

--- a/django/lib/custom_testrunner.py
+++ b/django/lib/custom_testrunner.py
@@ -2,8 +2,16 @@
 
 from django.conf import settings
 from django.test.runner import DiscoverRunner
+from pipeline.conf import settings as pipeline_settings
 
 class TestSuiteRunner(DiscoverRunner):
+
     def __init__(self, *args, **kwargs):
         settings.TESTING_ENVIRONMENT = True
         super(TestSuiteRunner, self).__init__(*args, **kwargs)
+
+    def setup_test_environment(self, **kwargs):
+        '''Override STATICFILES_STORAGE and pipeline DEBUG.'''
+        super().setup_test_environment(**kwargs)
+        settings.STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineStorage'
+        pipeline_settings.DEBUG = True


### PR DESCRIPTION
This changes CATMAID's error handling middleware so that it returns returns either status 400, 500 or custom error status code, depending on the exception. Until in basically all cases status 200 was returned. If the back-end error is an instance of the new `ClientError` type, it is expected to have a `status_code` field, which is set to 400 by default. Permission related errors override this to return status 403 (Forbidden).

If an error is not an instance of `ClientError`, but still a `ValueError`, status 400 is returned, because it is assumemd that a `ValueError` is the result of some bad/wrong input data. DRF errors and basic Django exception are handled. Otherwise status 500 is returned. Since many errors that were only declared as `Exception` were actually the result of bad requests, I changed many of those into `ValueError` instances.

This also fixes also a handful tests for which the wrong response code masked errors before. It also fixes the attempt to write settings for the anonymous users on page load (resulting now in 401 errors, which broke the GUI tests).

This might require changes in third-party clients. Once merged, I will post a note on the mailing list.

This was talked about in a bit more detail in catmaid/CATMAID#1921.
