### PR TITLE
Reduce lint noise

### DIFF
--- a/.travis.jshintignore
+++ b/.travis.jshintignore
@@ -29,3 +29,4 @@ django/applications/catmaid/static/libs/streamsaver/**
 django/applications/catmaid/static/libs/webm-writer.js/**
 **/static/apps/**
 **/static/tests/libs/**
+**/node_modules/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
 script:
   - flake8 --config=.travis.flake8 --statistics --count --exit-zero -q -q django
     # see "scripts" in package.json
-  - npm run lint
+  - npm run lint:js
   - npm run jsdoc
   - cd $TRAVIS_BUILD_DIR
   # Static type checking for Python, for now only as warning and when mypy is

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {},
   "scripts": {
     "lint:js": "jshint --config=.travis.jshintrc --exclude-path=.travis.jshintignore django/applications",
-    "lint:css": "csslint django/applications/catmaid/static/css",
+    "lint:css": "csslint --config=django/applications/catmaid/static/css/.csslintrc django/applications/catmaid/static/css",
     "lint": "npm-run-all lint:*",
     "jsdoc": "jsdoc -r django/applications/catmaid/static/js",
     "karma": "karma start karma.conf.js"


### PR DESCRIPTION
csslint is pure noise on travis, so that is disabled.
JShint now ignores node_modules.