### PR TITLE
More helpful errors in unit tests

### DIFF
--- a/django/applications/catmaid/tests/apis/common.py
+++ b/django/applications/catmaid/tests/apis/common.py
@@ -8,10 +8,10 @@ from guardian.shortcuts import assign_perm
 from guardian.management import create_anonymous_user
 
 from catmaid.models import Project, Treenode, User
-from catmaid.tests.common import init_consistent_data
+from catmaid.tests.common import init_consistent_data, AssertStatusMixin
 
 
-class CatmaidApiTestCase(TestCase):
+class CatmaidApiTestCase(TestCase, AssertStatusMixin):
     fixtures = ['catmaid_testdata']
 
     maxDiff = None

--- a/django/applications/catmaid/tests/apis/test_annotations.py
+++ b/django/applications/catmaid/tests/apis/test_annotations.py
@@ -57,7 +57,7 @@ class AnnotationsApiTests(CatmaidApiTestCase):
              'annotations[1]': 'B',
              'annotations[2]': 'C',
              'skeleton_ids[0]': skeleton_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         annotations = {a['name']:a['id'] for a in parsed_response['annotations']}
         for a in ('A', 'B', 'C'):
@@ -69,13 +69,13 @@ class AnnotationsApiTests(CatmaidApiTestCase):
             {'entity_ids[0]': neuron_id,
              'annotation_ids[0]': annotations['A'],
              'annotation_ids[1]': annotations['C']})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         response = self.client.post(
             '/%d/annotations/forskeletons' % (self.test_project_id,),
             {'skeleton_ids[0]': skeleton_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         linked_annotations = parsed_response['skeletons'][str(skeleton_id)]
@@ -92,7 +92,7 @@ class AnnotationsApiTests(CatmaidApiTestCase):
             '/%d/annotations/add' % (self.test_project_id,),
             {'annotations[0]': 'A',
              'skeleton_ids[0]': skeleton_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         annotations = {a['name']:a['id'] for a in parsed_response['annotations']}
         for a in ('A',):
@@ -102,7 +102,7 @@ class AnnotationsApiTests(CatmaidApiTestCase):
         expected_response = [{'name': 'A', 'id': annotation_id, 'users': [{'id': 3, 'name': 'test2'}]}]
 
         response = self.client.get('/%d/annotations/' % (self.test_project_id,))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         self.assertEqual(len(parsed_response['annotations']),
@@ -114,7 +114,7 @@ class AnnotationsApiTests(CatmaidApiTestCase):
         response = self.client.post(
             '/%d/annotations/add' % (self.test_project_id,),
             {'annotations[0]': 'B'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         annotations = {a['name']:a['id'] for a in parsed_response['annotations']}
         for a in ('B',):
@@ -124,7 +124,7 @@ class AnnotationsApiTests(CatmaidApiTestCase):
         expected_response.append({'name': 'B', 'id': annotation_id, 'users': []})
 
         response = self.client.get('/%d/annotations/' % (self.test_project_id,))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         self.assertEqual(len(parsed_response['annotations']),
@@ -154,7 +154,7 @@ class AnnotationsApiTests(CatmaidApiTestCase):
             '/%d/annotations/add' % (self.test_project_id,),
             {'annotations[0]': 'A',
              'skeleton_ids[0]': skeleton_id_a})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         annotations = {a['name']:a['id'] for a in parsed_response['annotations']}
         for a in ('A',):
@@ -165,7 +165,7 @@ class AnnotationsApiTests(CatmaidApiTestCase):
             '/%d/annotations/add' % (self.test_project_id,),
             {'annotations[0]': 'B',
              'skeleton_ids[0]': skeleton_id_b})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         annotations = {a['name']:a['id'] for a in parsed_response['annotations']}
         for a in ('B',):
@@ -176,7 +176,7 @@ class AnnotationsApiTests(CatmaidApiTestCase):
         response = self.client.post(
             '/%d/annotations/query-targets' % (self.test_project_id,),
             {'annotated_with[0]': ','.join(map(str, [annotation_id_a, annotation_id_b]))})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_entities = [
             {"skeleton_ids": [235],
@@ -195,7 +195,7 @@ class AnnotationsApiTests(CatmaidApiTestCase):
             '/%d/annotations/add' % (self.test_project_id,),
             {'annotations[0]': 'C',
              'skeleton_ids[0]': skeleton_id_a})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         annotations = {a['name']:a['id'] for a in parsed_response['annotations']}
         for a in ('C',):
@@ -206,7 +206,7 @@ class AnnotationsApiTests(CatmaidApiTestCase):
             '/%d/annotations/query-targets' % (self.test_project_id,),
             {'annotated_with[0]': ','.join(map(str, [annotation_id_a, annotation_id_b])),
              'annotated_with[1]': str(annotation_id_c)})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_entities = sorted([
             {"skeleton_ids": [235],
@@ -221,7 +221,7 @@ class AnnotationsApiTests(CatmaidApiTestCase):
             '/%d/annotations/add' % (self.test_project_id,),
             {'meta_annotations[0]': 'D',
              'annotations[0]': 'C'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         annotations = {a['name']:a['id'] for a in parsed_response['annotations']}
         for a in ('D',):
@@ -232,7 +232,7 @@ class AnnotationsApiTests(CatmaidApiTestCase):
             '/%d/annotations/query-targets' % (self.test_project_id,),
             {'annotated_with[0]': str(annotation_id_d),
              'sub_annotated_with[0]': str(annotation_id_d)})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_entities = [
             {"skeleton_ids": [235],
@@ -250,7 +250,7 @@ class AnnotationsApiTests(CatmaidApiTestCase):
         response = self.client.post(
             '/%d/annotations/query-targets' % (self.test_project_id,),
             {})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(parsed_response['totalRecords'], 17)
 
@@ -258,7 +258,7 @@ class AnnotationsApiTests(CatmaidApiTestCase):
         response = self.client.post(
             '/%d/annotations/query-targets' % (self.test_project_id,),
             {'name': 'downstream-A'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_entities = [
             {'skeleton_ids': [373],

--- a/django/applications/catmaid/tests/apis/test_connectors.py
+++ b/django/applications/catmaid/tests/apis/test_connectors.py
@@ -12,7 +12,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
     def test_list_connector_types(self):
         self.fake_authentication()
         response = self.client.get('/%d/connectors/types/' % self.test_project_id)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [
             {
@@ -113,7 +113,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                 '/%d/connectors/links/' % self.test_project_id, {
                     'relation_type': 'presynaptic_to',
                     'skeleton_ids': [0]})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
             'links': [],
@@ -126,7 +126,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                 '/%d/connectors/links/' % self.test_project_id, {
                     'relation_type': 'presynaptic_to',
                     'skeleton_ids': [0]})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
             'links': [],
@@ -141,7 +141,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                 '/%d/connectors/links/' % self.test_project_id, {
                     'relation_type': 'presynaptic_to',
                     'skeleton_ids': [235]})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
           'links': [
@@ -162,7 +162,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                 '/%d/connectors/links/' % self.test_project_id, {
                     'relation_type': 'postsynaptic_to',
                     'skeleton_ids': [373]})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
                 u'tags': {},
@@ -180,7 +180,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                     'skids[0]': 235,
                     'relation': 'presynaptic_to'
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = []
 
@@ -192,7 +192,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                     'skids[0]': 235,
                     'relation': 'postsynaptic_to'
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [[356, [6730.0, 2700.0, 0.0],
                             377, 373, 5, 3, [7620.0, 2890.0, 0.0],
@@ -211,7 +211,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                     'skids2[0]': 235,
                     'relation': 'presynaptic_to'
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = []
 
@@ -223,7 +223,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                     'skids2[0]': 235,
                     'relation': 'postsynaptic_to'
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [[356, [6730.0, 2700.0, 0.0],
                             377, 373, 5, 3, [7620.0, 2890.0, 0.0],
@@ -242,7 +242,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                     'connector_ids[0]': 356,
                     'connector_ids[1]': 2463
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [
             [356, {
@@ -268,7 +268,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/connector/create' % self.test_project_id,
                 {'x': 111, 'y': 222, 'z': 333, 'confidence': 3})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertTrue('connector_id' in parsed_response.keys())
         connector_id = parsed_response['connector_id']
@@ -290,7 +290,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/connector/delete' % self.test_project_id,
                 {'connector_id': connector_id, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
                 'message': u'Removed connector and class_instances',
@@ -337,7 +337,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/connector/info' % self.test_project_id,
                 {'pre[0]': 235, 'post[0]': 373})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [
                 [356, [6730.0, 2700.0, 0.0],
@@ -351,7 +351,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/connector/info' % self.test_project_id,
                 {'pre[0]': 235, 'post[0]': 373, 'cids[0]': 421})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [
                 [421, [6260.0, 3990.0, 0.0],
@@ -362,7 +362,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/connector/info' % self.test_project_id,
                 {'pre[0]': 2462, 'post[0]': 2468})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [
                 [2466, [6420.0, 5565.0, 0.0],
@@ -374,7 +374,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/connector/info' % self.test_project_id,
                 {'pre[0]': 2462, 'post[0]': 2462})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [
                 [2463, [7135.0, 5065.0, 0.0],
@@ -386,7 +386,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/connector/info' % self.test_project_id,
                 {'post[0]': 361})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [
                 [356, [6730.0, 2700.0, 0.0],
@@ -398,7 +398,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
         self.fake_authentication()
         response = self.client.get(
                 '/%d/connectors/%d/' % (self.test_project_id, 421))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
                 'partners': [
@@ -434,7 +434,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                     'connector_id': 421,
                     'relation_name': 'presynaptic_to'
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [{
                 'creation_time': '2011-10-07T07:02:22.656000+00:00',
@@ -450,7 +450,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                     'skeleton_ids[0]': 373,
                     'skeleton_ids[1]': 235,
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = []
 
@@ -476,7 +476,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                     'skeleton_ids[1]': 235,
                     'relation_type': 'postsynaptic_to',
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         expected_result = {
@@ -498,7 +498,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                     'skeleton_ids[1]': 235,
                     'without_relation_types[0]': 'presynaptic_to',
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         expected_result = {
@@ -522,7 +522,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                     'skeleton_ids[1]': 235,
                     'without_relation_types[0]': 'presynaptic_to',
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         expected_result = {
@@ -543,7 +543,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                     'skeleton_ids[1]': 235,
                     'with_tags': False,
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = []
 
@@ -567,7 +567,7 @@ class ConnectorsApiTests(CatmaidApiTestCase):
                     'skeleton_ids[1]': 235,
                     'with_partners': True,
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = []
         expected_result = {

--- a/django/applications/catmaid/tests/apis/test_datastores.py
+++ b/django/applications/catmaid/tests/apis/test_datastores.py
@@ -31,9 +31,9 @@ class DatastoresApiTests(CatmaidApiTestCase):
         self.assertTrue('error' in parsed_response)
         name = 'test-datastore'
         response = self.client.post(url, {'name': name})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         parsed_response = [p for p in parsed_response if p['name'] == name]
         self.assertEqual(len(parsed_response), 1)
@@ -56,11 +56,11 @@ class DatastoresApiTests(CatmaidApiTestCase):
                     'key': 'test a',
                     'value': '{"json": true, "scope": "user-instance"}'}),
                 content_type='application/x-www-form-urlencoded')
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertFalse('error' in parsed_response)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(len(parsed_response), 1)
         self.assertEqual(parsed_response[0]['key'], 'test a')
@@ -74,7 +74,7 @@ class DatastoresApiTests(CatmaidApiTestCase):
                 content_type='application/x-www-form-urlencoded')
         self.assertEqual(response.status_code, 204)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(len(parsed_response), 1)
         value = parsed_response[0]['value']
@@ -87,16 +87,16 @@ class DatastoresApiTests(CatmaidApiTestCase):
                     'project_id': self.test_project_id,
                     'value': '{"json": true, "scope": "user-project"}'}),
                 content_type='application/x-www-form-urlencoded')
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertFalse('error' in parsed_response)
         # Omitting project ID should return only global and user-instance keys.
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(len(parsed_response), 1)
         response = self.client.get(url, {'project_id': self.test_project_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(len(parsed_response), 2)
         self.assertEqual(parsed_response[0]['key'], 'test a')

--- a/django/applications/catmaid/tests/apis/test_labels.py
+++ b/django/applications/catmaid/tests/apis/test_labels.py
@@ -9,7 +9,7 @@ class LabelsApiTests(CatmaidApiTestCase):
     def test_labels(self):
         self.fake_authentication()
         response = self.client.get('/%d/labels/' % (self.test_project_id,))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         returned_labels = json.loads(response.content.decode('utf-8'))
         self.assertEqual(set(returned_labels),
                          set(["t",
@@ -98,14 +98,14 @@ class LabelsApiTests(CatmaidApiTestCase):
                                                                       393),
                                     {'tags': ",".join(['soma', 'fake'])})
         parsed_response = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         self.assertFalse('warning' in parsed_response)
 
         response = self.client.post('/%d/label/treenode/%d/update' % (self.test_project_id,
                                                                       395),
                                     {'tags': ",".join(['soma', 'fake'])})
         parsed_response = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         self.assertTrue('warning' in parsed_response)
         self.assertTrue('soma (2, max. 1)' in parsed_response['warning'])
 
@@ -115,7 +115,7 @@ class LabelsApiTests(CatmaidApiTestCase):
         url = f'/{self.test_project_id}/labels/stats'
         response = self.client.get(url)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         return response
 

--- a/django/applications/catmaid/tests/apis/test_links.py
+++ b/django/applications/catmaid/tests/apis/test_links.py
@@ -37,7 +37,7 @@ class LinksApiTests(CatmaidApiTestCase):
                 '/%d/link/delete' % self.test_project_id,
                 {'connector_id': connector_id, 'treenode_id': treenode_id,
                  'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
             'link_id': 382,
@@ -63,7 +63,7 @@ class LinksApiTests(CatmaidApiTestCase):
                     'link_type': link_type,
                     'state': make_nocheck_state()
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertIn('message', parsed_response)
         self.assertIn('link_id', parsed_response)
@@ -83,7 +83,7 @@ class LinksApiTests(CatmaidApiTestCase):
                     'link_type': link_type,
                     'state': make_nocheck_state()
                 })
-        self.assertEqual(response.status_code, 400)
+        self.assertStatus(response, 400)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertIn('error', parsed_response)
         error_message = f'Connector {to_id} does not have zero presynaptic connections.'
@@ -103,7 +103,7 @@ class LinksApiTests(CatmaidApiTestCase):
                     'link_type': link_type,
                     'state': make_nocheck_state()
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertIn('message', parsed_response)
         self.assertIn('link_id', parsed_response)

--- a/django/applications/catmaid/tests/apis/test_logs.py
+++ b/django/applications/catmaid/tests/apis/test_logs.py
@@ -38,7 +38,7 @@ class LogsApiTests(CatmaidApiTestCase):
         self.fake_authentication()
         response = self.client.post(
                 '/%d/logs/list' % self.test_project_id, {'user_id': 1})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
                 'iTotalDisplayRecords': 0,
@@ -58,7 +58,7 @@ class LogsApiTests(CatmaidApiTestCase):
                     'iSortCol_1': 3,  # x
                     'iSortDir_1': 'DESC'
                     })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
                 'iTotalDisplayRecords': 3,
@@ -77,7 +77,7 @@ class LogsApiTests(CatmaidApiTestCase):
                     'iDisplayStart': 1,
                     'iDisplayLength': 2
                     })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(2, parsed_response['iTotalDisplayRecords'])
         self.assertEqual(2, parsed_response['iTotalRecords'])
@@ -87,7 +87,7 @@ class LogsApiTests(CatmaidApiTestCase):
         self.fake_authentication()
         response = self.client.post(
                 '/%d/logs/list' % self.test_project_id, {})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(3, parsed_response['iTotalDisplayRecords'])
         self.assertEqual(3, parsed_response['iTotalRecords'])

--- a/django/applications/catmaid/tests/apis/test_messages.py
+++ b/django/applications/catmaid/tests/apis/test_messages.py
@@ -25,7 +25,7 @@ class MessagesApiTests(CatmaidApiTestCase):
         message_id = 3
 
         response = self.client.post(f'/messages/{message_id}/mark_read')
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         message = Message.objects.get(id=message_id)
@@ -48,7 +48,7 @@ class MessagesApiTests(CatmaidApiTestCase):
 
         response = self.client.post(
                 '/messages/list', {})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         def get_message(data, id):

--- a/django/applications/catmaid/tests/apis/test_neurons.py
+++ b/django/applications/catmaid/tests/apis/test_neurons.py
@@ -21,7 +21,7 @@ class NeuronsApiTests(CatmaidApiTestCase):
 
         url = '/%d/neurons/%s/rename' % (self.test_project_id, neuron_id)
         response = self.client.post(url, {'name': new_name})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
             'success': True,
@@ -63,7 +63,7 @@ class NeuronsApiTests(CatmaidApiTestCase):
         self.fake_authentication()
         url = '/%d/neurons/from-models' % (self.test_project_id,)
         response = self.client.post(url, {'model_ids': [235, 373]})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
             '235': 233,
@@ -77,7 +77,7 @@ class NeuronsApiTests(CatmaidApiTestCase):
         url = '/%d/neuron/%d/get-all-skeletons' % (self.test_project_id,
                                               233)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         parsed_data = json.loads(response.content.decode('utf-8'))
         self.assertEqual(len(parsed_data), 1)

--- a/django/applications/catmaid/tests/apis/test_nodes.py
+++ b/django/applications/catmaid/tests/apis/test_nodes.py
@@ -19,7 +19,7 @@ class NodesApiTests(CatmaidApiTestCase):
 
         response = self.client.get(
                 '/%d/nodes/most-recent' % self.test_project_id)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
                 'id': most_recent_node_id,
@@ -36,7 +36,7 @@ class NodesApiTests(CatmaidApiTestCase):
         response = self.client.get(
                 '/%d/nodes/most-recent' % self.test_project_id,
                 {'skeleton_id': skeleton_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
                 'id': most_recent_node_id,
@@ -57,7 +57,7 @@ class NodesApiTests(CatmaidApiTestCase):
                     'z': 4050,
                     'skeleton_id': 2388,
                     })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
                 "treenode_id": 2394,
@@ -78,7 +78,7 @@ class NodesApiTests(CatmaidApiTestCase):
                     'z': 0,
                     'neuron_id': 362,
                     })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
                 "treenode_id": 367,
@@ -95,7 +95,7 @@ class NodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/node/user-info' % (self.test_project_id),
                 {'node_ids': [367, 387]})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
             "367": {
@@ -126,7 +126,7 @@ class NodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/node/get_location' % (self.test_project_id),
                 {'tnid': treenode_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [383, 7850.0, 1970.0, 0.0]
         self.assertEqual(expected_result, parsed_response)
@@ -139,7 +139,7 @@ class NodesApiTests(CatmaidApiTestCase):
         response = self.client.post( '/%d/nodes/location' % self.test_project_id, {
             'node_ids': treenode_ids
         })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [
             [383, 7850.0, 1970.0, 0.0],
@@ -170,12 +170,12 @@ class NodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/label/treenode/%d/update' % (self.test_project_id, treenode_id),
                 {'tags': 'testlabel'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         treenode_id = 403
         response = self.client.post(
                 '/%d/label/treenode/%d/update' % (self.test_project_id, treenode_id),
                 {'tags': 'Testlabel'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         response = self.client.post(
                 '/%d/nodes/find-labels' % (self.test_project_id, ),
@@ -183,7 +183,7 @@ class NodesApiTests(CatmaidApiTestCase):
                  'y': 1790,
                  'z': 0,
                  'label_regex': '[Tt]estlabel'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [[387, [9030.0, 1480.0, 0.0], 380.131556174964, ["testlabel"]],
                            [403, [7840.0, 2380.0, 0.0], 1135.3413583588, ["Testlabel"]]]
@@ -204,7 +204,7 @@ class NodesApiTests(CatmaidApiTestCase):
                     't[0][1]': x,
                     't[0][2]': y,
                     't[0][3]': z})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
             'updated': 1,
@@ -285,7 +285,7 @@ class NodesApiTests(CatmaidApiTestCase):
 
         response = self.client.post(
                 '/%d/node/update' % self.test_project_id, param_dict)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
             'updated': 4,
@@ -364,7 +364,7 @@ class NodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/label/treenode/%d/update' % (self.test_project_id, 2374),
                 {'tags': 'test_treenode_label', 'delete_existing': 'false'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         expected_t_result = [
             [2374, 2372, 3310.0, 5190.0, 0.0, 5, -1.0, 2364, 1323093096.955, 5],
@@ -417,7 +417,7 @@ class NodesApiTests(CatmaidApiTestCase):
             'z2': 9,
             'labels': 'true',
         })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(len(expected_t_result), len(parsed_response[0]))
         self.assertEqual(len(expected_c_result), len(parsed_response[1]))
@@ -496,7 +496,7 @@ class NodesApiTests(CatmaidApiTestCase):
                 'z2': 9,
                 'treenode_ids': 2423,
                 'labels': False,})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(5, len(parsed_response))
         self.assertEqual(len(expected_t_result), len(parsed_response[0]))

--- a/django/applications/catmaid/tests/apis/test_projects.py
+++ b/django/applications/catmaid/tests/apis/test_projects.py
@@ -20,7 +20,7 @@ class ProjectsApiTests(CatmaidApiTestCase):
         # Check that, pre-authentication, we can see none of the
         # projects:
         response = self.client.get('/projects/')
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         result = json.loads(response.content.decode('utf-8'))
         self.assertEqual(len(result), 0)
 
@@ -32,7 +32,7 @@ class ProjectsApiTests(CatmaidApiTestCase):
         # Check that, pre-authentication, we can see two of the
         # projects:
         response = self.client.get('/projects/')
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         result = json.loads(response.content.decode('utf-8'))
         self.assertEqual(len(result), 1)
 
@@ -55,7 +55,7 @@ class ProjectsApiTests(CatmaidApiTestCase):
 
         # We expect four projects, one of them (project 2) is empty.
         response = self.client.get('/projects/')
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         result = json.loads(response.content.decode('utf-8'))
         self.assertEqual(len(result), 4)
 
@@ -87,7 +87,7 @@ class ProjectsApiTests(CatmaidApiTestCase):
         # Check that, pre-authentication, we can see none of the
         # projects:
         response = self.client.get('/projects/export')
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         result = json.loads(response.content.decode('utf-8'))
         self.assertEqual(len(result), 0)
 
@@ -104,7 +104,7 @@ class ProjectsApiTests(CatmaidApiTestCase):
         visible_projects = project.get_project_qs_for_user(test_user)
 
         response = self.client.get('/projects/export')
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         result = yaml.load(response.content.decode('utf-8'), Loader=yaml.FullLoader)
 
         # Expect a returned list with four projects

--- a/django/applications/catmaid/tests/apis/test_search.py
+++ b/django/applications/catmaid/tests/apis/test_search.py
@@ -14,7 +14,7 @@ class SearchApiTests(CatmaidApiTestCase):
         response = self.client.get(
                 '/%d/search' % self.test_project_id,
                 {'substring': 'tr'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [
                 {"id":374, "name":"downstream-A", "class_name":"neuron"},
@@ -28,7 +28,7 @@ class SearchApiTests(CatmaidApiTestCase):
         response = self.client.get(
                 '/%d/search' % self.test_project_id,
                 {'substring': 'bobobobobobobo'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = []
         self.assertEqual(expected_result, parsed_response)
@@ -40,7 +40,7 @@ class SearchApiTests(CatmaidApiTestCase):
         response = self.client.get(
                 '/%d/search' % self.test_project_id,
                 {'substring': 't'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [
                 {"id":465, "name":"tubby bye bye", "class_name":"driver_line"},
@@ -78,7 +78,7 @@ class SearchApiTests(CatmaidApiTestCase):
         response = self.client.get(
                 '/%d/search' % self.test_project_id,
                 {'substring': 'a'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [
                 {"id":485, "name":"Local", "class_name":"cell_body_location"},
@@ -102,7 +102,7 @@ class SearchApiTests(CatmaidApiTestCase):
         response = self.client.get(
                 '/%d/search' % self.test_project_id,
                 {'substring': 'uncertain end'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         # Expect only one result that has a node linked
@@ -138,7 +138,7 @@ class SearchApiTests(CatmaidApiTestCase):
         response = self.client.get(
                 '/%d/search' % self.test_project_id,
                 {'substring': 'c'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [
                 {"id":485, "name":"Local", "class_name":"cell_body_location"},

--- a/django/applications/catmaid/tests/apis/test_skeletons.py
+++ b/django/applications/catmaid/tests/apis/test_skeletons.py
@@ -45,7 +45,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
     def test_skeleton_root(self):
         self.fake_authentication()
         response = self.client.get('/%d/skeletons/%d/root' % (self.test_project_id, 235))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(parsed_response['root_id'], 237)
         self.assertAlmostEqual(parsed_response['x'], 1065)
@@ -58,7 +58,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
 
         orig_skeleton_id = 235
         response = self.client.get('/%d/skeleton/%d/swc' % (self.test_project_id, orig_skeleton_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         orig_swc_string = response.content.decode('utf-8')
 
         n_orig_skeleton_nodes = Treenode.objects.filter(skeleton_id=orig_skeleton_id).count()
@@ -74,7 +74,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post('/%d/skeletons/import' % (self.test_project_id,),
                 {'file.swc': swc_file, 'name': 'test'})
 
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         new_skeleton_id = parsed_response['skeleton_id']
         id_map = parsed_response['node_id_map']
@@ -127,7 +127,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
                 {'file.swc': swc_file2, 'name': 'test2', 'neuron_id':
                     neuron.id})
 
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         # Make sure there is still only one skeleton
@@ -154,7 +154,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
                 {'file.swc': swc_file2, 'name': 'test2', 'neuron_id': neuron.id,
                     'force': True})
 
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         # Make sure there is still only one skeleton
@@ -201,7 +201,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
                 {'file.swc': swc_file2, 'name': 'test3', 'skeleton_id':
                     skeleton.id})
 
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         last_skeleton_id = skeleton.id
         neuron = ClassInstance.objects.get(pk=parsed_response['neuron_id'])
@@ -217,7 +217,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         self.assertEqual(neuron.name, 'test3')
         self.assertEqual(skeleton.name, 'test3')
         self.assertNotEqual(neuron.id, last_neuron_id)
-        self.assertNotEqual(last_skeleton_id, skeleton.id) 
+        self.assertNotEqual(last_skeleton_id, skeleton.id)
 
         # Make sure there are as many nodes as expected for the imported
         # skeleton.
@@ -230,7 +230,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
                 {'file.swc': swc_file2, 'name': 'test2', 'skeleton_id': skeleton.id,
                     'force': True})
 
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         last_skeleton_edit_time = skeleton.edition_time
@@ -259,7 +259,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
             '/%d/skeleton/contributor_statistics_multiple' % (self.test_project_id,),
             {'skids[0]': 235})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_response = {
                 "pre_contributors": {"3": 3},
@@ -276,14 +276,14 @@ class SkeletonsApiTests(CatmaidApiTestCase):
 
         response = self.client.post(
             '/%d/skeleton/%d/contributor_statistics' % (self.test_project_id, 235))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(parsed_response, expected_response)
 
         response = self.client.post(
             '/%d/skeleton/contributor_statistics_multiple' % (self.test_project_id,),
             {'skids[0]': 235, 'skids[1]': 361})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_response = {
                 "pre_contributors": {"3": 3},
@@ -305,7 +305,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         skeleton_id = 235
         response = self.client.post(
             '/%d/skeleton/%s/node_count' % (self.test_project_id, skeleton_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_response = {
                 "count": 28,
@@ -314,7 +314,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
 
         response = self.client.post(
             '/%d/skeleton/node/%s/node_count' % (self.test_project_id, 253))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(parsed_response, expected_response)
 
@@ -327,7 +327,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
             '/%d/skeleton/split' % (self.test_project_id,),
             {'treenode_id': 2394, 'upstream_annotation_map': '{}', 'downstream_annotation_map': '{}'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         new_skeleton_id = parsed_response['new_skeleton_id']
 
@@ -339,7 +339,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
             '/%d/skeleton/split' % (self.test_project_id,),
             {'treenode_id': 237, 'upstream_annotation_map': '{}', 'downstream_annotation_map': '{}'})
-        self.assertEqual(response.status_code, 400)
+        self.assertStatus(response, 400)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertIn('error', parsed_response)
         error_message = "Can't split at the root node: it doesn't have a parent."
@@ -357,7 +357,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
              'annotations[1]': 'B',
              'annotations[2]': 'C',
              'skeleton_ids[0]': old_skeleton_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         # Expect an error if some annotations are not assigned.
         response = self.client.post(
@@ -391,7 +391,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
             {'treenode_id': 2394,
              'upstream_annotation_map':   json.dumps({'A': self.test_user_id, 'B': self.test_user_id}),
              'downstream_annotation_map': json.dumps({'A': self.test_user_id, 'B': self.test_user_id, 'C': self.test_user_id})})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         new_skeleton_id = parsed_response['new_skeleton_id']
 
@@ -399,7 +399,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
             '/%d/skeleton/annotationlist' % (self.test_project_id,),
             {'skeleton_ids[0]': old_skeleton_id,
              'skeleton_ids[1]': new_skeleton_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         old_skeleton_annotations = set([parsed_response['annotations'][str(aid['id'])] for aid in parsed_response['skeletons'][str(old_skeleton_id)]['annotations']])
         new_skeleton_annotations = set([parsed_response['annotations'][str(aid['id'])] for aid in parsed_response['skeletons'][str(new_skeleton_id)]['annotations']])
@@ -417,7 +417,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
              'source_skeleton_ids[1]': 373,
              'boolean_op': 'OR',
              'link_types': ['incoming', 'outgoing', 'gapjunction', 'attachment']})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
             "outgoing_reviewers": [],
@@ -438,7 +438,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
              'source_skeleton_ids[1]': 373,
              'boolean_op': 'AND',
              'link_types': ['incoming', 'outgoing', 'gapjunction', 'attachment']})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
             "outgoing_reviewers": [],
@@ -460,7 +460,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
 
         # Return untagged root
         response = self.client.post(url, {'treenode_id': 243})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         distsort = lambda end: end[2]
         parsed_response.sort(key=distsort)
@@ -475,9 +475,9 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/label/treenode/%d/update' % (self.test_project_id, 237),
                 {'tags': 'soma', 'delete_existing': 'false'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         response = self.client.post(url, {'treenode_id': 243})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         parsed_response.sort(key=distsort)
         expected_result.pop(0)
@@ -488,9 +488,9 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/label/treenode/%d/update' % (self.test_project_id, 261),
                 {'tags': 'End', 'delete_existing': 'false'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         response = self.client.post(url, {'treenode_id': 243})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         parsed_response.sort(key=distsort)
         expected_result.pop(0)
@@ -500,9 +500,9 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/label/treenode/%d/update' % (self.test_project_id, 277),
                 {'tags': 'mitochondria ends', 'delete_existing': 'false'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         response = self.client.post(url, {'treenode_id': 243})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         parsed_response.sort(key=distsort)
         self.assertEqual(parsed_response, expected_result)
@@ -516,18 +516,18 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/label/treenode/%d/update' % (self.test_project_id, treenode_id),
                 {'tags': 'testlabel'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         treenode_id = 393
         response = self.client.post(
                 '/%d/label/treenode/%d/update' % (self.test_project_id, treenode_id),
                 {'tags': 'Testlabel'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         # Label in other skeleton than should be ignored.
         treenode_id = 403
         response = self.client.post(
                 '/%d/label/treenode/%d/update' % (self.test_project_id, treenode_id),
                 {'tags': 'Testlabel'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         skeleton_id = 361
         treenode_id = 367
@@ -535,7 +535,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
                 '/%d/skeletons/%d/find-labels' % (self.test_project_id, skeleton_id),
                 {'treenode_id': treenode_id,
                  'label_regex': '[Tt]estlabel'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [[393, [6910.0, 990.0, 0.0], 3, ["Testlabel"]],
                            [387, [9030.0, 1480.0, 0.0], 4, ["testlabel"]]]
@@ -549,7 +549,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/skeletons/within-spatial-distance' % (self.test_project_id,),
                 {'treenode_id': treenode_id, 'distance': 2000, 'size_mode': 0})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [2468, 2388, 235, 2411, 2364]
         self.assertCountEqual(expected_result, parsed_response['skeletons'])
@@ -557,7 +557,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/skeletons/within-spatial-distance' % (self.test_project_id,),
                 {'treenode_id': treenode_id, 'distance': 2000, 'size_mode': 1})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [2462, 2433, 373]
         self.assertCountEqual(expected_result, parsed_response['skeletons'])
@@ -570,7 +570,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
             '/%d/skeleton/%d/permissions' % (self.test_project_id, skeleton_id,))
         expected_result = {'can_edit': True}
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(parsed_response, expected_result)
 
@@ -578,7 +578,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
             '/%d/annotations/add' % (self.test_project_id,),
             {'annotations[0]': 'locked', 'skeleton_ids[0]': skeleton_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         lock_annotation_id = parsed_response['annotations'][0]['id']
         skeleton_entity_id = parsed_response['annotations'][0]['entities'][0]
@@ -587,7 +587,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
             '/%d/skeleton/%d/permissions' % (self.test_project_id, skeleton_id,))
         expected_result = {'can_edit': True} # test2 has permissions for test1
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(parsed_response, expected_result)
 
@@ -595,19 +595,19 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
             '/%d/annotations/%d/remove' % (self.test_project_id, lock_annotation_id,),
             {'entity_ids[0]': skeleton_entity_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         self.fake_authentication('test0', 'test', True)
         response = self.client.post(
             '/%d/annotations/add' % (self.test_project_id,),
             {'annotations[0]': 'locked', 'skeleton_ids[0]': skeleton_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         self.fake_authentication()
         response = self.client.post(
             '/%d/skeleton/%d/permissions' % (self.test_project_id, skeleton_id,))
         expected_result = {'can_edit': False} # test2 does not have permission for test0
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(parsed_response, expected_result)
 
@@ -618,7 +618,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         skeleton_id = 235
         response = self.client.post(
                 '/%d/skeleton/%s/statistics' % (self.test_project_id, skeleton_id,),)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
                 'node_count': 28,
@@ -639,7 +639,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/skeleton/ancestry' % self.test_project_id,
                 {'skeleton_id': skeleton_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [
                 {"name":"downstream-B", "id":362, "class":"neuron"},
@@ -655,7 +655,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/skeleton/ancestry' % self.test_project_id,
                 {'skeleton_id': skeleton_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [
                 {"name":"neuron 2365", "id":2365, "class":"neuron"},
@@ -675,7 +675,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/skeleton/connectivity_matrix' % (self.test_project_id,),
                 params)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
                 '235': {'361': 1, '373': 2},
@@ -698,7 +698,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/skeleton/connectivity_matrix' % (self.test_project_id,),
                 params)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
             "235": {
@@ -814,7 +814,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         # Change confidence that affects 1 edge from 235 to 373
         response = self.client.post('/%d/treenodes/289/confidence' % self.test_project_id,
                 {'new_confidence': 3, 'state': '{"nocheck": true}'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         # Add confidence criteria, but not one that should affect the graph.
         response = self.client.post(
             '/%d/skeletons/confidence-compartment-subgraph' % self.test_project_id,
@@ -920,7 +920,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/skeleton/reroot' % self.test_project_id,
                 {'treenode_id': new_root})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result:Dict[str, Any] = {
                 'newroot': 2394,
@@ -932,7 +932,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
                     'from_id': link_from,
                     'to_id': link_to,
                     'annotation_set': '{}'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
                 'message': 'success',
@@ -960,7 +960,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/skeleton/connectors-by-partner' % self.test_project_id,
                 {'skids[0]': 235, 'skids[1]': 373})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         [[[c.sort() for c in p.values()] for p in t.values()] for t in parsed_response.values()]
         expected_result = {
@@ -987,7 +987,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         # No reviews
         url = '/%d/skeleton/%d/reviewed-nodes' % (self.test_project_id, skeleton_id)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result:Dict[str, Any] = {}
         self.assertEqual(expected_result, parsed_response)
@@ -1000,7 +1000,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         Review.objects.create(project_id=self.test_project_id, reviewer_id=3,
             review_time=review_time, skeleton_id=skeleton_id, treenode_id=263)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = {
                 '253': [[3, review_time], [2, review_time]],
                 '263': [[3, review_time]]}
@@ -1018,7 +1018,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/skeleton/reroot' % self.test_project_id,
                 {'treenode_id': new_root})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
                 'newroot': 407,
@@ -1043,7 +1043,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         # No reviews, single segment
         url = '/%d/skeletons/review-status' % (self.test_project_id)
         response = self.client.post(url, {'skeleton_ids[0]': skeleton_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = {'2388': [3, 0]}
         self.assertJSONEqual(response.content.decode('utf-8'), expected_result)
 
@@ -1056,14 +1056,14 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         Review.objects.create(project_id=self.test_project_id, reviewer_id=3,
             review_time=review_time, skeleton_id=skeleton_id, treenode_id=2394)
         response = self.client.post(url, {'skeleton_ids[0]': skeleton_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = {'2388': [3, 2]}
         self.assertJSONEqual(response.content.decode('utf-8'), expected_result)
 
         # Use empty whitelist
         response = self.client.post(url,
                 {'skeleton_ids[0]': skeleton_id, 'whitelist': 'true'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = {'2388': [3, 0]}
         self.assertJSONEqual(response.content.decode('utf-8'), expected_result)
 
@@ -1072,7 +1072,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
                 user_id=self.test_user_id, reviewer_id=2, accept_after=review_time)
         response = self.client.post(url,
                 {'skeleton_ids[0]': skeleton_id, 'whitelist': 'true'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = {'2388': [3, 1]}
         self.assertJSONEqual(response.content.decode('utf-8'), expected_result)
 
@@ -1085,7 +1085,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         # No reviews, single segment
         url = '/%d/skeletons/%d/review' % (self.test_project_id, skeleton_id)
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = [{'status': '0.00', 'id': 0, 'nr_nodes': 3, 'sequence': [
                 {'y': 6550.0, 'x': 3680.0, 'z': 0.0, 'rids': [], 'sup': [], 'user_id': 3, 'id': 2396},
                 {'y': 6030.0, 'x': 3110.0, 'z': 0.0, 'rids': [], 'sup': [], 'user_id': 3, 'id': 2394},
@@ -1101,7 +1101,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         Review.objects.create(project_id=self.test_project_id, reviewer_id=3,
             review_time=review_time, skeleton_id=skeleton_id, treenode_id=2394)
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = [{'status': '66.67', 'id': 0, 'nr_nodes': 3, 'sequence': [
                 {'y': 6550.0, 'x': 3680.0, 'z': 0.0, 'rids': [[3, review_time], [2, review_time]], 'sup': [], 'user_id': 3, 'id': 2396},
                 {'y': 6030.0, 'x': 3110.0, 'z': 0.0, 'rids': [[3, review_time]], 'sup': [], 'user_id': 3, 'id': 2394},
@@ -1120,12 +1120,12 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         response = self.client.post(url)
         expected_result[0]['sequence'][0]['rids'].append([2, review_time])
         expected_result[0]['sequence'][1]['rids'].append([3, review_time])
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         self.assertJSONEqual(response.content.decode('utf-8'), expected_result)
 
         # Test subarbor support
         response = self.client.post(url, {'subarbor_node_id': 2394})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result[0]['status'] = '100.00'
         expected_result[0]['nr_nodes'] = 2
         del expected_result[0]['sequence'][-1]
@@ -1136,7 +1136,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         self.fake_authentication()
         url = '/%d/skeleton/235/swc' % (self.test_project_id,)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         swc_output_for_skeleton_235 = '''
 237 0 1065 3035 0 0 -1
@@ -1175,7 +1175,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         self.fake_authentication()
         url = '/%d/skeleton/235/swc' % (self.test_project_id,)
         response = self.client.get(url, {'linearize_ids': 'true'})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         swc_output_for_skeleton_235 = '''
 1 0 1065 3035 0 0 -1
@@ -1217,7 +1217,7 @@ class SkeletonsApiTests(CatmaidApiTestCase):
 
         response = self.client.post(url, {'label_ids': label_ids})
 
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         self.assertJSONEqual(response.content.decode('utf-8'), expected_response)
 
 

--- a/django/applications/catmaid/tests/apis/test_stacks.py
+++ b/django/applications/catmaid/tests/apis/test_stacks.py
@@ -11,7 +11,7 @@ class StacksApiTests(CatmaidApiTestCase):
         test_stack_id = 3
 
         response = self.client.get('/%d/stack/%d/info' % (self.test_project_id, test_stack_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
             "attribution": None,

--- a/django/applications/catmaid/tests/apis/test_stats.py
+++ b/django/applications/catmaid/tests/apis/test_stats.py
@@ -42,7 +42,7 @@ class StatsApiTests(CatmaidApiTestCase):
                 '3': 89
             }
             response = self.client.get('/%d/stats/nodecount' % (self.test_project_id,))
-            self.assertEqual(response.status_code, 200)
+            self.assertStatus(response)
             parsed_response = json.loads(response.content.decode('utf-8'))
             self.assertEqual(parsed_response, expected_stats)
 
@@ -61,7 +61,7 @@ class StatsApiTests(CatmaidApiTestCase):
                     (self.test_project_id,), {
                         'with_imports': 'true' if with_imports else 'false'
                     })
-            self.assertEqual(response.status_code, 200)
+            self.assertStatus(response)
             parsed_response = json.loads(response.content.decode('utf-8'))
             self.assertEqual(parsed_response, expected_stats)
 
@@ -153,7 +153,7 @@ class StatsApiTests(CatmaidApiTestCase):
     def test_stats_summary(self):
         self.fake_authentication()
         response = self.client.get('/%d/stats/summary' % (self.test_project_id,))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = {
             "connectors_created": 0,
             'skeletons_created': 0,
@@ -426,7 +426,7 @@ class StatsApiTests(CatmaidApiTestCase):
                 'end_date': '2017-08-01',
                 'time_zone': 'UTC'
             })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(expected_stats, parsed_response)
 
@@ -438,7 +438,7 @@ class StatsApiTests(CatmaidApiTestCase):
                 'end_date': '2017-08-01',
                 'time_zone': 'UTC'
             })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(expected_stats, parsed_response)
 
@@ -706,7 +706,7 @@ class StatsApiTests(CatmaidApiTestCase):
                 'end_date': '2017-08-01',
                 'time_zone': 'America/New_York'
             })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(expected_stats, parsed_response)
 
@@ -718,7 +718,7 @@ class StatsApiTests(CatmaidApiTestCase):
                 'end_date': '2017-08-01',
                 'time_zone': 'America/New_York'
             })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(expected_stats, parsed_response)
 
@@ -805,7 +805,7 @@ class StatsApiTests(CatmaidApiTestCase):
 
         # Get SWC for a neuron
         response = self.client.get('/%d/skeleton/%d/swc' % (self.test_project_id, orig_skeleton_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         orig_swc_string = response.content.decode('utf-8')
 
         # Give user import permissions and Import SWC
@@ -814,7 +814,7 @@ class StatsApiTests(CatmaidApiTestCase):
         response = self.client.post('/%d/skeletons/import' % (self.test_project_id,),
                 {'file.swc': swc_file, 'name': 'test'})
 
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         new_skeleton_id = parsed_response['skeleton_id']
         id_map = parsed_response['node_id_map']

--- a/django/applications/catmaid/tests/apis/test_textlabels.py
+++ b/django/applications/catmaid/tests/apis/test_textlabels.py
@@ -36,7 +36,7 @@ class TextlabelsApiTests(CatmaidApiTestCase):
                 '/%d/textlabel/update' % self.test_project_id,
                 params)
         expected_result = ' '
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         self.assertEqual(expected_result, response.content.decode('utf-8'))
 
         label = Textlabel.objects.filter(id=textlabel_id)[0]
@@ -74,7 +74,7 @@ class TextlabelsApiTests(CatmaidApiTestCase):
                 '/%d/textlabel/update' % self.test_project_id,
                 params)
         expected_result = ' '
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         self.assertEqual(expected_result, response.content.decode('utf-8'))
 
         label = Textlabel.objects.filter(id=textlabel_id)[0]
@@ -118,7 +118,7 @@ class TextlabelsApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/textlabel/delete' % self.test_project_id,
                 {'tid': textlabel_id})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {'message': 'Success.'}
         self.assertEqual(expected_result, parsed_response)
@@ -157,7 +157,7 @@ class TextlabelsApiTests(CatmaidApiTestCase):
                     params)
 
             parsed_response = json.loads(response.content.decode('utf-8'))
-            self.assertEqual(response.status_code, 200)
+            self.assertStatus(response)
             self.assertEqual(label_count + 1 + i, Textlabel.objects.all().count())
             self.assertTrue('tid' in parsed_response.keys())
             label = get_object_or_404(Textlabel, id=parsed_response['tid'])
@@ -197,7 +197,7 @@ class TextlabelsApiTests(CatmaidApiTestCase):
                 'height': 7680,
                 'scale': 0.5,
                 'resolution': 5})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(expected_result, parsed_response)
 
@@ -237,6 +237,6 @@ class TextlabelsApiTests(CatmaidApiTestCase):
                 'height': 7680,
                 'scale': 0.5,
                 'resolution': 5})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(expected_result, parsed_response)

--- a/django/applications/catmaid/tests/apis/test_treenodes.py
+++ b/django/applications/catmaid/tests/apis/test_treenodes.py
@@ -20,7 +20,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         self.fake_authentication()
         response = self.client.get('/%d/skeletons/%d/node-overview' % \
                                     (self.test_project_id, 0))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = [[], [], []]
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(expected_result, parsed_response)
@@ -44,7 +44,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenodes/%d/confidence' % (self.test_project_id, treenode_id),
                 {'new_confidence': '4', 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         treenode = Treenode.objects.filter(id=treenode_id).get()
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
@@ -67,7 +67,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenodes/%d/confidence' % (self.test_project_id, treenode_id),
                 {'new_confidence': '5', 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         treenode = Treenode.objects.filter(id=treenode_id).get()
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
@@ -96,7 +96,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
                 '/%d/treenodes/%d/confidence' % (self.test_project_id, treenode_id),
                 {'new_confidence': '4', 'to_connector': 'true',
                  'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         connector = TreenodeConnector.objects.filter(id=treenode_connector_id).get()
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
@@ -119,7 +119,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenodes/%d/confidence' % (self.test_project_id, treenode_id),
                 {'new_confidence': '5', 'to_connector': 'true', 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         connector = TreenodeConnector.objects.filter(id=treenode_connector_id).get()
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
@@ -162,7 +162,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
             'confidence': 5,
             'parent_id': -1,
             'radius': 2})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         self.assertTrue('treenode_id' in parsed_response)
@@ -209,7 +209,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
             'confidence': 5,
             'parent_id': -1,
             'radius': 2})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         self.assertTrue('treenode_id' in parsed_response)
@@ -259,7 +259,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
             'parent_id': -1,
             'useneuron': neuron_id,
             'radius': 2})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         self.assertTrue('treenode_id' in parsed_response)
@@ -305,12 +305,12 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenodes/%d/parent' % (self.test_project_id, treenode_id),
                 {'parent_id': new_parent_id, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         response = self.client.post(
                 '/%d/%d/1/1/compact-skeleton' % (self.test_project_id, skeleton_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_response = [
                 [[377, None, 3, 7620.0, 2890.0, 0.0, -1.0, 5],
@@ -378,7 +378,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
             'parent_id': parent_id,
             'state': make_nocheck_state()})
 
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         self.assertTrue('treenode_id' in parsed_response)
@@ -435,7 +435,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
             'parent_id': parent_id,
             'state': make_nocheck_state()})
 
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         self.assertTrue('treenode_id' in parsed_response)
@@ -556,7 +556,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenode/delete' % self.test_project_id,
                 {'treenode_id': treenode_id, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = 'Removed treenode successfully.'
         self.assertEqual(expected_result, parsed_response['success'])
@@ -577,7 +577,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenode/delete' % self.test_project_id,
                 {'treenode_id': treenode_id, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {
             'success': 'Removed treenode successfully.',
@@ -616,7 +616,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenode/delete' % self.test_project_id,
                 {'treenode_id': treenode_id, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = 'Removed treenode successfully.'
         self.assertEqual(expected_result, parsed_response['success'])
@@ -648,7 +648,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
 
         response = self.client.get(
                 '/%d/treenodes/%s/info' % (self.test_project_id, treenode_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = {'skeleton_id': 235, 'neuron_id': 233, 'skeleton_name': 'skeleton 235', 'neuron_name': 'branched neuron'}
         self.assertEqual(expected_result, parsed_response)
@@ -670,7 +670,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenode/%d/radius' % (self.test_project_id, treenode_id),
                 {'radius': new_r, 'option': 0, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         expected = [(259, old_r), (257, new_r), (255, old_r)]
         for x in expected:
@@ -687,7 +687,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenode/%d/radius' % (self.test_project_id, treenode_id),
                 {'radius': new_r, 'option': 1, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         expected = [(261, new_r), (259, new_r), (257, new_r),
                     (255, old_r), (253, old_r)]
@@ -699,7 +699,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenode/%d/radius' % (self.test_project_id, treenode_id),
                 {'radius': new_r, 'option': 1, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         expected = [(253, old_r), (263, new_r), (265, new_r),
                     (269, old_r), (267, old_r)]
@@ -717,7 +717,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenode/%d/radius' % (self.test_project_id, treenode_id),
                 {'radius': new_r, 'option': 2, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         expected = [(261, old_r), (259, old_r), (257, new_r),
                     (255, new_r), (253, old_r)]
@@ -729,7 +729,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenode/%d/radius' % (self.test_project_id, treenode_id),
                 {'radius': new_r, 'option': 2, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         expected = [(255, new_r), (263, old_r), (253, new_r),
                     (251, new_r), (249, new_r), (247, new_r),
@@ -754,7 +754,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenode/%d/radius' % (self.test_project_id, treenode_id),
                 {'radius': new_r, 'option': 3, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         expected = [(261, old_r), (259, old_r), (257, new_r),
                     (255, new_r), (253, new_r), (251, 7)]
@@ -764,7 +764,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenode/%d/radius' % (self.test_project_id, treenode_id),
                 {'radius': new_r, 'option': 3, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         expected = [(253, new_r), (251, new_r), (249, new_r),
                     (247, new_r), (247, new_r), (245, new_r),
@@ -783,7 +783,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenode/%d/radius' % (self.test_project_id, treenode_id),
                 {'radius': new_r, 'option': 4, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
 
         expected = [(261, old_r), (259, old_r), (257, new_r),
                     (255, new_r), (253, new_r), (263, old_r),
@@ -803,7 +803,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenode/%d/radius' % (self.test_project_id, treenode_id),
                 {'radius': new_r, 'option': 5, 'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_response = {
             'success': True,
@@ -863,7 +863,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenodes/%d/previous-branch-or-root' % (self.test_project_id, treenode_id),
                 {'alt': 0})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         # Response should contain one branch.
         expected_result = [253, 3685.0, 2160.0, 0.0]
@@ -873,7 +873,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenodes/%d/previous-branch-or-root' % (self.test_project_id, treenode_id),
                 {'alt': 0})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         # Response should contain one branch.
         expected_result = [237, 1065.0, 3035.0, 0.0]
@@ -883,7 +883,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         response = self.client.post(
                 '/%d/treenodes/%d/previous-branch-or-root' % (self.test_project_id, treenode_id),
                 {'alt': 0})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         # Response should contain one branch.
         expected_result = [237, 1065.0, 3035.0, 0.0]
@@ -896,7 +896,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         treenode_id = 391
         response = self.client.post(
                 '/%d/treenodes/%d/next-branch-or-end' % (self.test_project_id, treenode_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         # Response should contain one branch.
         expected_result = [[[393, 6910.0, 990.0, 0.0],
@@ -907,7 +907,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         treenode_id = 253
         response = self.client.post(
                 '/%d/treenodes/%d/next-branch-or-end' % (self.test_project_id, treenode_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         # Response should contain two branches, and the larger branch headed by
         # node 263 should be first.
@@ -926,7 +926,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         treenode_id = 387
         response = self.client.post(
                 '/%d/treenodes/%d/children' % (self.test_project_id, treenode_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = []
         self.assertEqual(expected_result, parsed_response)
@@ -934,7 +934,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         treenode_id = 385
         response = self.client.post(
                 '/%d/treenodes/%d/children' % (self.test_project_id, treenode_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [[[387, 9030.0, 1480.0, 0.0]]]
         self.assertEqual(expected_result, parsed_response)
@@ -942,7 +942,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         treenode_id = 367
         response = self.client.post(
                 '/%d/treenodes/%d/children' % (self.test_project_id, treenode_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [[383, 7850.0, 1970.0, 0.0], [391, 6740.0, 1530.0, 0.0]]
         parsed_response = [p[0] for p in parsed_response]
@@ -958,7 +958,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
                 {'x': 1,
                  'y': -1,
                  'z': 0})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         parent_id = parsed_response['treenode_id']
         skeleton_id = parsed_response['skeleton_id']
@@ -970,14 +970,14 @@ class TreenodesApiTests(CatmaidApiTestCase):
                  'z': 2,
                  'parent_id': parent_id,
                  'state': make_nocheck_state()})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         child_id = parsed_response['treenode_id']
 
         # Initially no nodes should be supppressed
         response = self.client.get(
                 '/%d/treenodes/%d/suppressed-virtual/' % (self.test_project_id, child_id))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = []
         self.assertEqual(expected_result, parsed_response)
@@ -1001,7 +1001,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
                 '/%d/treenodes/%d/suppressed-virtual/' % (self.test_project_id, child_id),
                 {'location_coordinate': 2,
                  'orientation': 0})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         suppressed_id = parsed_response['id']
 
@@ -1015,7 +1015,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
         self.fake_authentication()
         response = self.client.get(
                 '/%d/skeletons/%d/node-overview' % (self.test_project_id, 235))
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = [[
                 [417, 415, 5, 4990.0, 4200.0, 0.0, -1.0, 3, 1323093096.0],
                 [415, 289, 5, 5810.0, 3950.0, 0.0, -1.0, 3, 1323093096.0],
@@ -1062,7 +1062,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
                 {
                     'treenode_ids': [261, 417, 415]
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = [
                 [261, 259, 2820.0, 1345.0, 0.0, 5, -1.0, 235, 1323093096.955, 3],
                 [415, 289, 5810.0, 3950.0, 0.0, 5, -1.0, 235, 1323093096.955, 3],
@@ -1080,7 +1080,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
                     'treenode_ids': [261, 417, 415],
                     'label_names': ['TODO']
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = [
                 [261, 259, 2820.0, 1345.0, 0.0, 5, -1.0, 235, 1323093096.955, 3],
         ]
@@ -1095,7 +1095,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
                 {
                     'label_names': ['TODO']
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = [
                 [261, 259, 2820.0, 1345.0, 0.0, 5, -1.0, 235, 1323093096.955, 3],
                 [349, 347, 3580.0, 3350.0, 252.0, 5, -1.0, 1, 1323093096.955, 3]
@@ -1112,7 +1112,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
                     'treenode_ids': [261, 417, 415],
                     'label_ids': [351]
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = [
                 [261, 259, 2820.0, 1345.0, 0.0, 5, -1.0, 235, 1323093096.955, 3],
         ]
@@ -1127,7 +1127,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
                 {
                     'label_ids': [351]
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = [
                 [261, 259, 2820.0, 1345.0, 0.0, 5, -1.0, 235, 1323093096.955, 3],
                 [349, 347, 3580.0, 3350.0, 252.0, 5, -1.0, 1, 1323093096.955, 3]
@@ -1143,7 +1143,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
                 {
                     'skeleton_ids': [235]
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = [
                 [237, None, 1065.0, 3035.0, 0.0, 5, -1.0, 235, 1323093096.955, 3],
                 [239, 237, 1135.0, 2800.0, 0.0, 5, -1.0, 235, 1323093096.955, 3],
@@ -1186,7 +1186,7 @@ class TreenodesApiTests(CatmaidApiTestCase):
                     'skeleton_ids': [235],
                     'label_names': ['TODO']
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         expected_result = [
                 [261, 259, 2820.0, 1345.0, 0.0, 5, -1.0, 235, 1323093096.955, 3],
         ]

--- a/django/applications/catmaid/tests/apis/test_volume.py
+++ b/django/applications/catmaid/tests/apis/test_volume.py
@@ -58,7 +58,7 @@ class VolumeTests(CatmaidApiTestCase):
             self.test_vol_1_id), {
                 'title': 'New title'
             })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(parsed_response, {
             'success': True,
@@ -91,7 +91,7 @@ class VolumeTests(CatmaidApiTestCase):
             self.test_vol_1_id), {
                 'comment': 'New comment'
             })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(parsed_response, {
             'success': True,
@@ -126,7 +126,7 @@ class VolumeTests(CatmaidApiTestCase):
                 {"cube.stl": f}
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(len(parsed_response), 1)
         self.assertTrue("cube.stl" in parsed_response)
@@ -135,7 +135,7 @@ class VolumeTests(CatmaidApiTestCase):
 
         response = self.client.get(f"/{self.test_project_id}/volumes/{cube_id}/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(parsed_response['name'], 'cube')
         self.assertEqual(parsed_response['bbox'], {
@@ -152,7 +152,7 @@ class VolumeTests(CatmaidApiTestCase):
                 {"cube.stl": f}
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(len(parsed_response), 1)
         self.assertTrue("cube.stl" in parsed_response)
@@ -163,4 +163,4 @@ class VolumeTests(CatmaidApiTestCase):
             f"/{self.test_project_id}/volumes/{cube_id}/export.stl",
             HTTP_ACCEPT="model/x.stl-ascii,model/stl")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)

--- a/django/applications/catmaid/tests/test_import_export.py
+++ b/django/applications/catmaid/tests/test_import_export.py
@@ -8,16 +8,17 @@ import yaml
 from guardian.shortcuts import assign_perm
 
 from django.http import HttpResponse
-from django.test import TestCase
 from django.test.client import Client
+from django.test import TestCase
 
 from catmaid.control import importer
 from catmaid.control.common import urljoin
 from catmaid.models import (Class, ClassInstance, Project, ProjectStack,
         Relation, Stack, StackClassInstance, StackGroup, StackStackGroup, User)
+from catmaid.tests.common import AssertStatusMixin
 
 
-class ImportExportTests(TestCase):
+class ImportExportTests(TestCase, AssertStatusMixin):
     """Test CATMAID's import and export functionality.
     """
     #fixtures = ['catmaid_project_stack_data']
@@ -363,13 +364,13 @@ class ImportExportTests(TestCase):
 
         # Export imported YAML data
         response = self.client.get('/projects/export')
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         result_yaml = yaml.load(response.content.decode('utf-8'), Loader=yaml.FullLoader)
         test_result(result_yaml)
 
         # Export imported JSON data
         response = self.client.get('/projects/export', HTTP_ACCEPT='application/json')
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         result_json = json.loads(response.content.decode('utf-8'),
                 object_hook=parse_list)
         test_result(result_json)

--- a/django/applications/catmaid/tests/test_skeleton_summary_tables.py
+++ b/django/applications/catmaid/tests/test_skeleton_summary_tables.py
@@ -11,9 +11,10 @@ from catmaid import history
 from catmaid.control import tracing
 from catmaid.models import Class, Project, User
 from catmaid.state import make_nocheck_state
+from catmaid.tests.common import AssertStatusMixin
 
 
-class SkeletonSummaryTableTests(TransactionTestCase):
+class SkeletonSummaryTableTests(TransactionTestCase, AssertStatusMixin):
     """Test the trigger based skeleton summary upate.
     """
 
@@ -43,7 +44,7 @@ class SkeletonSummaryTableTests(TransactionTestCase):
             WHERE skeleton_id = %(skeleton_id)s
 
         """, {
-            'skeleton_id': skeleton_id    
+            'skeleton_id': skeleton_id
         })
         summaries = list(map(lambda x: {
             'skeleton_id': x[0],
@@ -71,7 +72,7 @@ class SkeletonSummaryTableTests(TransactionTestCase):
             'parent_id': -1,
             'radius': 2
         })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         skeleton_id = parsed_response['skeleton_id']
@@ -92,7 +93,7 @@ class SkeletonSummaryTableTests(TransactionTestCase):
             'radius': 2,
             'state': make_nocheck_state()
         })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         # Expect updated summary setup
@@ -114,7 +115,7 @@ class SkeletonSummaryTableTests(TransactionTestCase):
             'radius': 2,
             'state': make_nocheck_state()
         })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         # Remember third node
@@ -134,7 +135,7 @@ class SkeletonSummaryTableTests(TransactionTestCase):
                     't[0][1]': 10,
                     't[0][2]': 11,
                     't[0][3]': 12})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         # Expect updated summary setup
@@ -149,7 +150,7 @@ class SkeletonSummaryTableTests(TransactionTestCase):
                     'state': make_nocheck_state(),
                     'treenode_id': third_node_id
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         # Expect updated summary setup
@@ -162,13 +163,13 @@ class SkeletonSummaryTableTests(TransactionTestCase):
         response = self.client.post('/%d/neurons/from-models' % self.project_id, {
             'model_ids[0]': skeleton_id
         })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         neuron_id = parsed_response[str(skeleton_id)]
 
         response = self.client.post(
                 f'/{self.project_id}/neuron/{neuron_id}/delete')
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         # Expect no summary entry for deleted skeleton
@@ -192,7 +193,7 @@ class SkeletonSummaryTableTests(TransactionTestCase):
                 'radius': 2,
                 'state': make_nocheck_state()
             })
-            self.assertEqual(response.status_code, 200)
+            self.assertStatus(response)
             parsed_response = json.loads(response.content.decode('utf-8'))
             parent = parsed_response['treenode_id']
             ids.append(parsed_response['treenode_id'])
@@ -249,7 +250,7 @@ class SkeletonSummaryTableTests(TransactionTestCase):
             'downstream_annotation_map': '{}',
             'state': make_nocheck_state()
         })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(parsed_response['existing_skeleton_id'], skeleton_id)
 
@@ -296,7 +297,7 @@ class SkeletonSummaryTableTests(TransactionTestCase):
             'annotation_set': '{}',
             'state': make_nocheck_state()
         })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         self.assertEqual(parsed_response['result_skeleton_id'], skeleton_id)
         self.assertEqual(parsed_response['deleted_skeleton_id'], skeleton_id_a)
@@ -326,7 +327,7 @@ class SkeletonSummaryTableTests(TransactionTestCase):
             'parent_id': -1,
             'radius': 2
         })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         skeleton_id = parsed_response['skeleton_id']

--- a/django/applications/catmaid/tests/test_transaction_log.py
+++ b/django/applications/catmaid/tests/test_transaction_log.py
@@ -13,9 +13,10 @@ from catmaid import history
 from catmaid.models import Class, Project, User
 from catmaid.control import tracing
 from catmaid.state import make_nocheck_state
+from catmaid.tests.common import AssertStatusMixin
 
 
-class TransactionLogTests(TransactionTestCase):
+class TransactionLogTests(TransactionTestCase, AssertStatusMixin):
     """Test the transaction log implementation, expecting an empty database.
     """
 
@@ -100,7 +101,7 @@ class TransactionLogTests(TransactionTestCase):
                     'execution_time': exec_time,
                     'label': label
                 })
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         return parsed_response
 
@@ -118,7 +119,7 @@ class TransactionLogTests(TransactionTestCase):
             'confidence': 5,
             'parent_id': -1,
             'radius': 2})
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
         transaction.commit()
 
@@ -171,7 +172,7 @@ class TransactionLogTests(TransactionTestCase):
             'parent_id': -1,
             'radius': 2})
         transaction.commit()
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         self.assertTrue('treenode_id' in parsed_response)
@@ -203,7 +204,7 @@ class TransactionLogTests(TransactionTestCase):
                     't[0][2]': 11.2,
                     't[0][3]': 16.2})
         transaction.commit()
-        self.assertEqual(response.status_code, 200)
+        self.assertStatus(response)
         parsed_response = json.loads(response.content.decode('utf-8'))
 
         after_update_tx_entries = self.get_tx_entries(cursor)


### PR DESCRIPTION
Tests which assert `self.assertEqual(response.statuscode, 200)` should now use the `self.assertStatus200(response)` method, which, if there is a non-200 code and the response content is JSON, will parse and print the error information.

Probably not ready to merge, just needed to make a PR to get the tests to run. There are some diamond inheritance chains but I think the MRO is fine.