### PR TITLE
Ignore GUI tests when testing for non-mainline repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,9 @@ services:
 addons:
   chrome: stable
   postgresql: 10
-  sauce_connect:
-    username: catmaid
-    access_key:
-      secure: "rFiPF3KRokQqUaMHzr34wdt98pbYKyO47CFm9sJPO/HOKePhDCW6bMhiNa4x5Q2T5oAb0SRb/6CECExlGtA4mnzC5u47S8E9TidlZZ1m/n2TRZr2cvzhBJFhnYYZxcF8+6vCKq4DWVU+wD2/4wWktIHkcBJ9XMErl8HyICUHzLo="
+  # SAUCE_USERNAME and SAUCE_ACCESS_KEY are defined as part of the Travis
+  # project settings. GUI tests will be skipped if these are not defined.
+  sauce_connect: true
 before_install:
   - mkdir tmp
   - travis_retry sudo apt-get update -y -qq


### PR DESCRIPTION
This makes it possible to have CI tests being run successfully for other repos than the main upstream repo. Simply defining the Saucelab credentials outside of the Travis file and in the general project configuration (on the website), makes this happen automatically (after a few adjustments to disable GUI tests without these environment variables).

Additionally, this makes it possible for repos other than the mainline repo to enable GUI tests by simply adding the `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables through the Travis web interface.

I tried different setups, including build stages, but this becomes quickly verbose and redundant, because the Travis YAML format doesn't support configuring addons and secure environment variables on the stage level. Ultimately, the above solution is simpler anyway.

With this change, this PR from my personal repo should now also be green, because the GUI tests aren't run.