### PR TITLE
Matplotlib 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,11 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "nightly"
   - "pypy3.6-7.1.1"
 matrix:
   allow_failures:
-  - python: "3.8"
+  - python: "nightly"
 services:
   - postgresql
 addons:

--- a/django/applications/catmaid/control/useranalytics.py
+++ b/django/applications/catmaid/control/useranalytics.py
@@ -30,7 +30,7 @@ try:
     from pylab import figure
     from matplotlib.backends.backend_svg import FigureCanvasSVG
 except ImportError:
-    logger.warning("CATMAID was unable to laod the matplotlib module. "
+    logger.warning("CATMAID was unable to load the matplotlib module. "
         "User analytics will not be available")
 
 
@@ -352,7 +352,7 @@ def splitBout(bout,increment) -> List[Bout]:
         currtime = nexttime
     return boutListOut
 
-def generateErrorImage(msg) -> matplotlib.figure.Figure:
+def generateErrorImage(msg) -> "matplotlib.figure.Figure":
     """ Creates an empty image (based on image nr. 1) and adds a message to it.
     """
     fig = plt.figure(1, figsize=(6,6))
@@ -360,7 +360,9 @@ def generateErrorImage(msg) -> matplotlib.figure.Figure:
     fig.suptitle(msg)
     return fig
 
-def generateReport(user_id, project_id, activeTimeThresh, start_date, end_date, all_writes=True) -> matplotlib.figure.Figure:
+def generateReport(
+    user_id, project_id, activeTimeThresh, start_date, end_date, all_writes=True
+) -> "matplotlib.figure.Figure":
     """ nts: node times
         cts: connector times
         rts: review times """
@@ -455,7 +457,7 @@ def generateReport(user_id, project_id, activeTimeThresh, start_date, end_date, 
 
     return fig
 
-def dailyActivePlotFigure(activebouts, ax:matplotlib.axes.Axes, start_date, end_date) -> matplotlib.axes.Axes:
+def dailyActivePlotFigure(activebouts, ax:"matplotlib.axes.Axes", start_date, end_date) -> "matplotlib.axes.Axes":
     """ Draws a plot of all bouts during each day between <start_date> and
     <end_date> to the plot given by <ax>.
     """
@@ -486,7 +488,7 @@ def dailyActivePlotFigure(activebouts, ax:matplotlib.axes.Axes, start_date, end_
 
     return ax
 
-def eventsPerIntervalPerDayPlot(ax, times, start_date, end_date, interval=60) -> matplotlib.axes.Axes:
+def eventsPerIntervalPerDayPlot(ax, times, start_date, end_date, interval=60) -> "matplotlib.axes.Axes":
     if np.mod(24 * 60, interval) > 0:
         raise ValueError('Interval in minutes must divide the day evenly')
 

--- a/django/requirements-test.txt
+++ b/django/requirements-test.txt
@@ -2,4 +2,4 @@
 django-migration-testcase==0.0.13
 selenium==3.141.0
 sauceclient==1.0.0
-mypy==0.650; platform_python_implementation != 'PyPy'
+mypy==0.730; platform_python_implementation != 'PyPy'

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -14,7 +14,7 @@ django-taggit==1.1.0
 djangorestframework==3.10.3
 jsonfield==2.0.2
 kombu==4.5.0
-matplotlib==3.1.2
+matplotlib==3.1.2; platform_python_implementation != 'PyPy'
 mock==3.0.5
 msgpack==0.6.2; platform_python_implementation != 'PyPy'
 msgpack_python==0.5.6

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -14,7 +14,7 @@ django-taggit==1.1.0
 djangorestframework==3.10.3
 jsonfield==2.0.2
 kombu==4.5.0
-matplotlib==2.2.3
+matplotlib==3.1.2
 mock==3.0.5
 msgpack==0.6.2; platform_python_implementation != 'PyPy'
 msgpack_python==0.5.6

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -19,7 +19,7 @@ mock==3.0.5
 msgpack==0.6.2; platform_python_implementation != 'PyPy'
 msgpack_python==0.5.6
 networkx==1.11
-numpy==1.15.4
+numpy==1.17.4
 pillow==6.2.1
 progressbar2==3.46.0
 psycopg2-binary==2.8.3; platform_python_implementation != 'PyPy'


### PR DESCRIPTION
Matplotlib v2 is incompatible with python 3.8.

I'm not sure the extent to which unit tests could tell us if there's anything wrong with this, but I haven't come across any issues migrating other code from v2 to v3.