### PR TITLE
Require Postgres 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ services:
   - postgresql
 addons:
   chrome: stable
-  postgresql: 10
   # SAUCE_USERNAME and SAUCE_ACCESS_KEY are defined as part of the Travis
   # project settings. GUI tests will be skipped if these are not defined.
   sauce_connect: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Notes
 
 - The version requires PostgreSQL 12. If you also want to upgrade PostGIS,
-  update PostGIS firstand run ``ALTER EXTENSION postgis UPDATE;`` in every
+  update PostGIS first and run ``ALTER EXTENSION postgis UPDATE;`` in every
   existing database in the cluster that should be upgraded. For docker-compose
   setups this database update is performed automatically if `DB_UPDATE=true` is
   set for the `db` container (watch the Docker output). CATMAID's documentation
@@ -33,7 +33,7 @@
 Docker:
 
 - Asynchronous tasks can now also be run inside the Docker container. Celery and
-  RabbitMQ are run by default, but can also be run in separte containers (see
+  RabbitMQ are run by default, but can also be run in separate containers (see
   CM_CELERY_BROKER_URL, CM_CELERY_WORKER_CONCURRENCY and CM_RUN_CELERY
   Docker environment variables).
 
@@ -49,6 +49,8 @@ Docker:
   added, updated or removed.
 - CSVs imported into the skeleton selection widget may contain nonexistent
   skeleton IDs, as intended.
+- Skeleton bulk updates like splits or joins should now be faster on setups with
+  spatial change events disabled (default).
 
 
 ## Maintenance updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
   configuration changes for Postgres 12. CATMAID's replication documentation
   explains what needs to be done.
 
+  In Postgres 12, JIT compilation is available to the planner by default. We
+  found that being more conservative with the use of it helped a few common
+  queries (like the tracing data field of view). We set the required minimum
+  cost of JIT use to 1,000,000 in ``postgresql.conf``::
+
+    jit_above_cost = 1000000
+
 - If R extensions are used, make sure to use R 3.6. On Ubuntu this can be made
   available by first installing the official R PPA repository:
 

--- a/django/applications/catmaid/control/graph2.py
+++ b/django/applications/catmaid/control/graph2.py
@@ -312,7 +312,9 @@ def populate_connectors(chunkIDs, chunks, cs, connectors) -> None:
 
 
 def subgraphs(digraph, skeleton_id) -> Tuple[List, Tuple]:
-    chunks = list(digraph.subgraph(c).copy() for c in weakly_connected_components(digraph))
+    # For consistency and easier testing, sort chunks by size
+    chunks = sorted((digraph.subgraph(c).copy() for c in \
+           weakly_connected_components(digraph)), key=len)
     if 1 == len(chunks):
         chunkIDs:Tuple = (str(skeleton_id),) # Note: Here we're loosening the implicit type
     else:

--- a/django/applications/catmaid/control/node.py
+++ b/django/applications/catmaid/control/node.py
@@ -1080,8 +1080,10 @@ class Postgis2dNodeProvider(PostgisNodeProvider):
     """
 
     TREENODE_STATEMENT_NAME = PostgisNodeProvider.TREENODE_STATEMENT_NAME + '_2d'
+    # MATERIALIZED seems to be needed at the moment, at least for large queries.
+    # For smaller FOVs, the NOT MATERIALIZED version seems to do better.
     treenode_query = """
-          WITH z_filtered_edge AS (
+          WITH z_filtered_edge AS MATERIALIZED (
             SELECT te.id, te.parent_id, te.edge
             FROM treenode_edge te
             WHERE floatrange(ST_ZMin(te.edge),
@@ -1264,7 +1266,7 @@ class Postgis2dBlurryNodeProvider(PostgisNodeProvider):
 
     TREENODE_STATEMENT_NAME = PostgisNodeProvider.TREENODE_STATEMENT_NAME + '_2d_blurry'
     treenode_query = """
-          WITH z_filtered_edge AS (
+          WITH z_filtered_edge AS MATERIALIZED (
               SELECT te.id, te.parent_id, te.edge
               FROM treenode_edge te
               WHERE floatrange(ST_ZMin(te.edge), ST_ZMax(te.edge), '[]') && floatrange({z1}, {z2}, '[)')

--- a/django/applications/catmaid/static/js/widgets/system-check.js
+++ b/django/applications/catmaid/static/js/widgets/system-check.js
@@ -253,7 +253,7 @@
   let databaseStats = {
     'version': {
       name: 'PostgreSQL Version',
-      comment: 'CATMAID requires at least version 10 of Postgres.',
+      comment: 'CATMAID requires at least version 12 of Postgres.',
     },
     'c_ratio': {
       name: 'Committed transactions ',

--- a/django/applications/catmaid/tests/apis/test_nodes.py
+++ b/django/applications/catmaid/tests/apis/test_nodes.py
@@ -6,6 +6,7 @@ from django.db import connection
 
 from catmaid.models import Connector, Treenode
 from catmaid.state import make_nocheck_state
+from catmaid.tests.common import round_list
 
 from .common import CatmaidApiTestCase
 
@@ -189,7 +190,7 @@ class NodesApiTests(CatmaidApiTestCase):
         parsed_response = json.loads(response.content.decode('utf-8'))
         expected_result = [[387, [9030.0, 1480.0, 0.0], 380.131556174964, ["testlabel"]],
                            [403, [7840.0, 2380.0, 0.0], 1135.3413583588, ["Testlabel"]]]
-        self.assertEqual(expected_result, parsed_response)
+        self.assertEqual(round_list(expected_result), round_list(parsed_response))
 
 
     def test_node_update_single_treenode(self):

--- a/django/applications/catmaid/tests/apis/test_skeletons.py
+++ b/django/applications/catmaid/tests/apis/test_skeletons.py
@@ -972,6 +972,15 @@ class SkeletonsApiTests(CatmaidApiTestCase):
 
         skeleton_id = 235
 
+        def first_element(l):
+            return l[0]
+
+        def sort_json_nodes(node_result):
+            for k,v in expected_result.items():
+                v.sort(key=first_element)
+                node_result[k] = v
+            return node_result
+
         # No reviews
         url = '/%d/skeleton/%d/reviewed-nodes' % (self.test_project_id, skeleton_id)
         response = self.client.get(url)
@@ -992,7 +1001,8 @@ class SkeletonsApiTests(CatmaidApiTestCase):
         expected_result = {
                 '253': [[2, review_time], [3, review_time]],
                 '263': [[3, review_time]]}
-        self.assertJSONEqual(response.content.decode('utf-8'), expected_result)
+        parsed_response = json.dumps(sort_json_nodes(json.loads(response.content.decode('utf-8'))))
+        self.assertJSONEqual(parsed_response, expected_result)
 
 
     def test_reroot_skeleton(self):

--- a/django/applications/catmaid/tests/common.py
+++ b/django/applications/catmaid/tests/common.py
@@ -72,3 +72,19 @@ class CatmaidTestCase(TestCase, AssertStatusMixin):
 
     def fake_authentication(self):
         self.client.login(username='temporary', password='temporary')
+
+
+def round_list(l, digits=6):
+    """Round floating point values in a list recursively to the specified number
+    of digits.
+    """
+    new_list = []
+    for v in l:
+        v_type = type(v)
+        if v_type == float:
+            new_list.append(round(v, digits))
+        elif v_type in (list, tuple):
+            new_list.append(round_list(v, digits))
+        else:
+            new_list.append(v)
+    return new_list

--- a/packagelist-ubuntu-14.04-apt.txt
+++ b/packagelist-ubuntu-14.04-apt.txt
@@ -1,5 +1,5 @@
-postgresql-11
-postgresql-11-postgis-2.5
+postgresql-12
+postgresql-12-postgis-2.5
 gcc
 gfortran
 git

--- a/packagelist-ubuntu-16.04-apt.txt
+++ b/packagelist-ubuntu-16.04-apt.txt
@@ -1,5 +1,5 @@
-postgresql-11
-postgresql-11-postgis-2.5
+postgresql-12
+postgresql-12-postgis-2.5
 gcc
 gfortran
 git

--- a/packagelist-ubuntu-18.04-apt.txt
+++ b/packagelist-ubuntu-18.04-apt.txt
@@ -1,5 +1,5 @@
-postgresql-11
-postgresql-11-postgis-2.5
+postgresql-12
+postgresql-12-postgis-2.5
 gcc
 gfortran
 git

--- a/scripts/docker/catmaid-entry.sh
+++ b/scripts/docker/catmaid-entry.sh
@@ -13,7 +13,7 @@ DB_NAME=$(sanitize "${DB_NAME:-catmaid}")
 DB_USER=$(sanitize "${DB_USER:-catmaid_user}")
 DB_PASS=$(sanitize "${DB_PASS:-catmaid_password}")
 DB_CONNECTIONS=$(sanitize "${DB_CONNECTIONS:-50}")
-DB_CONF_FILE=$(sanitize "${DB_CONF_FILE:-"/etc/postgresql/11/main/postgresql.conf"}")
+DB_CONF_FILE=$(sanitize "${DB_CONF_FILE:-"/etc/postgresql/12/main/postgresql.conf"}")
 DB_FORCE_TUNE=$(sanitize "${DB_FORCE_TUNE:-false}")
 DB_TUNE=$(sanitize "${DB_TUNE:-true}")
 DB_FIXTURE=$(sanitize "${DB_FIXTURE:-false}")
@@ -48,7 +48,7 @@ CM_RUN_CELERY=$(sanitize "${CM_RUN_CELERY:-true}")
 CM_CELERY_TIMEZONE=$(sanitize "${CM_CELERY_TIMEZONE:-""}")
 CM_RUN_ASGI=$(sanitize "${CM_RUN_ASGI:-true}")
 TIMEZONE=`readlink /etc/localtime | sed "s/.*\/\(.*\)$/\1/"`
-PG_VERSION='11'
+PG_VERSION='12'
 
 # Check if the first argument begins with a dash. If so, prepend "platform" to
 # the list of arguments.

--- a/scripts/travis/install_postgres.sh
+++ b/scripts/travis/install_postgres.sh
@@ -2,25 +2,28 @@
 
 set -ex
 
-echo "Installing Postgres 11"
+echo "Removing existing Postgres installation"
 sudo systemctl stop postgresql
 sudo apt-get remove -q 'postgresql-*'
+echo "Installing Postgres 12"
 sudo apt-get update -q
-sudo apt-get install -q postgresql-11 postgresql-client-11 postgresql-11-postgis-2.5 postgresql-11-postgis-2.5-scripts
+sudo apt-get install -q postgresql-12 postgresql-client-12 postgresql-12-postgis-2.5 postgresql-12-postgis-2.5-scripts
 
 # Drop existin database and crate a new one to make sure we run in a ramdisk and
 # on port 5432.
-sudo pg_dropcluster 11 main
-sudo mkdir -p /var/ramfs/postgresql/11/main
-sudo chown postgres:postgres /var/ramfs/postgresql/11/main
-sudo pg_createcluster -d /var/ramfs/postgresql/11/main -p 5432 11 main
+sudo pg_dropcluster 12 main
+sudo mkdir -p /var/ramfs/postgresql/12/main
+sudo chown postgres:postgres /var/ramfs/postgresql/12/main
+sudo pg_createcluster -d /var/ramfs/postgresql/12/main -p 5432 12 main
 
-# In case future Postgres version are not available on Travis and have to
-# installed manually, copying the existing hba file can save some time.
-sudo cp /etc/postgresql/{10,11}/main/pg_hba.conf
+# To work better with Travis, follow their default Postgres configuration and
+# set each host based authentication entry to "trust" rather than "md5" or
+# "peer". Alternatively, we could copy the existing hba file:
+# sudo cp /etc/postgresql/{10,12}/main/pg_hba.conf
+sudo sed -i -e 's/peer/trust/g' -e 's/md5/trust/g' /etc/postgresql/12/main/pg_hba.conf
 
-echo "Restarting Postgres 11"
-sudo systemctl start postgresql@11-main
+echo "Starting Postgres 12"
+sudo systemctl start postgresql@12-main
 
 echo "The following Postgres clusters are installed:"
 pg_lsclusters

--- a/sphinx-doc/source/administration.rst
+++ b/sphinx-doc/source/administration.rst
@@ -87,6 +87,24 @@ Update Python packages::
 
    pip install -r requirements.txt
 
+Should a database upgrade be required (e.g. Postgres 11 to 12 or PostGIS 2.5 to
+3), make sure to upgrade PostGIS first, by installing the new version for the
+current database and connect to every (!) database in the cluster and update the
+``postgis`` extension like this. This can be skipped if no database upgrade is
+required::
+
+  $ sudo -u postgres psql
+  > \c catmaid
+  > ALTER EXTENSION postgis UPDATE;
+  > \c <next-database>
+  > ALTER EXT…
+  > …
+
+Once, done perform, install the new database version and  upgrade the database
+cluster using ``pg_upgrade``. Using the ``--link`` option can safe time on large
+databases and has been robust in our experience. This step can also be skipped,
+if no database upgrade is needed.
+
 Synchronize the Django environment with the database::
 
    ./projects/manage.py migrate

--- a/sphinx-doc/source/administration.rst
+++ b/sphinx-doc/source/administration.rst
@@ -415,6 +415,14 @@ Database management system
   queries to set these parameters for each new connection.  Having those
   defaults set will improve the database performance slightly.
 
+* We found that making JIT compilation of queries less likely, helps with many
+  spatial queries, where cost estimates aren't very reliable in many cases. This
+  can be done by raising the default value for the ``jit_above_cost`` (100,000)
+  variable in the ``postgresql.conf`` file to a value of 1,000,000 or even
+  higher::
+
+    jit_above_cost = 1000000
+
 CATMAID
 ^^^^^^^
 

--- a/sphinx-doc/source/installation.rst
+++ b/sphinx-doc/source/installation.rst
@@ -20,7 +20,7 @@ Introduction
 
 The most fundamental dependencies of CATMAID are:
 
-1. PostgreSQL >= 11 and PostGIS >= 2.5 (recommended: PostgreSQL 12 + PostGIS 3)
+1. PostgreSQL 12 and PostGIS 2.5
 2. Python 3.5, 3.7 or PyPy3.6
 
 To get the required PostgreSQL version for Debian-based systems, such as
@@ -51,7 +51,7 @@ or newer not  be available on your system, use the following PPA::
 
 And then you can install these dependencies with::
 
-    sudo apt-get install python3.6 postgresql-11 gdal-bin
+    sudo apt-get install python3.6 postgresql-12 postgresql-12-postgis-2.5 gdal-bin
 
 CATMAID is based on the `Django web framework
 <https://www.djangoproject.com/>`_.  If you just wish to work on

--- a/sphinx-doc/source/installation.rst
+++ b/sphinx-doc/source/installation.rst
@@ -21,7 +21,7 @@ Introduction
 The most fundamental dependencies of CATMAID are:
 
 1. PostgreSQL 12 and PostGIS 2.5
-2. Python 3.5, 3.7 or PyPy3.6
+2. Python 3.6, 3.7 or PyPy3.6
 
 To get the required PostgreSQL version for Debian-based systems, such as
 Ubuntu, you have to add the officical Postgres repository as an
@@ -36,7 +36,8 @@ done so already)::
     wget --quiet -O - ${PG_KEY_URL} | sudo apt-key add -
     sudo apt-get update
 
-While Python 3.5 is supported, we recommend the use of Python 3.6. To be able to
+While newer Python versions are supported, we recommend the use of Python 3.6,
+because that's what we have most experience with at the moment. To be able to
 install it on Ubuntu 16.04 and earlier, the following needs to be done::
 
     sudo add-apt-repository ppa:deadsnakes/ppa

--- a/sphinx-doc/source/replication.rst
+++ b/sphinx-doc/source/replication.rst
@@ -35,7 +35,7 @@ effectively is read-only.
 Physical replication in Postgres performs a byte-by-byte copy of the database,
 based on the Write Ahead Log (WAL). Therefore it is important that both the
 primary server and all replicas run the same Postgres version. CATMAID requires
-Postgres 11 at the moment.
+Postgres 12 at the moment.
 
 Reachability and secure communication
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -150,17 +150,18 @@ Now the data of the primary server has to be copied over using
 ``pg_basebackup``. This has to be done as the ``postgres`` user::
 
   sudo -u postgres pg_basebackup -h my.primary.db.xyz -p 7432 \
-      -P --checkpoint=fast -U replication_user  -D /var/lib/postgresql/11/main/
+      -P --checkpoint=fast -U replication_user  -D /var/lib/postgresql/12/main/
 
-Assuming ``/var/lib/postgresql/11/main/`` is our data directory and
+Assuming ``/var/lib/postgresql/12/main/`` is our data directory and
 ``my.primry.db.xyz`` is the primary database server, listening on port ``7432``,
 this command should ask you for the password of the replication user on the
 primary and print progress information. This will take a while, depending on
 your database size, because all the data from the primary server is copied over.
 
 Of course the replica shouldn't write on its own to the database, instead it
-should follow the primary. In order to do that, make the following settings
-available in ``postgresql.conf``::
+should follow the primary. This is done by creating a file named
+``recovery.conf`` in the Postgres data directory
+(``/var/lib/postgresql/12/main/`` in this example)  with the following content::
 
   primary_conninfo      = 'host=my.primary.db.xyz port=7432 user=replication_user password=<password>'
   promote_trigger_file = '/tmp/MasterNow'


### PR DESCRIPTION
It would be nice if we could require Postgres 12 so that it would be possible to use some of the newer features (e.g. declarative partitioning). With the current version being 12.2, it had some time to stabilize and I have been running it locally and on a few production-like test setups and didn't run into any problems.

This only upgrade Postgres and not PostGIS, which I kept at version 2.5. The reason is that there is a not yet explained slowdown with Postgres 12 and PostGIS 3. Progress on this is tracked [here](https://trac.osgeo.org/postgis/ticket/4635).

A main difference to previous versions is that Postgres 12 will by default allow inlining of CTEs in many circumstances (except multiple dependencies or write operations), i.e. they aren't optimization fences by default. Acting a optimization barrier can however be enforced using the `MATERIALIZED` keyword.

I checked all our CTEs and looked at the query plans for the most heavily used ones (edge update trigger, spatial queries, etc.) and made sure that they are either faster or run at the same speed as before. Only the spatial queries profited from an explicit `MATERIALIZED` keyword, otherwise the default behavior seems fine.

The Docker image works also like before with the new Postgres version and I have a commit ready for the docker-compose setup to also use Postgres 12.