### PR TITLE
Add OAuth2 log-in support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,18 @@ Docker:
   For instance, use "America/New_York' for US east coast time. This way,
   maintenance tasks can be moved to whenever local midnight is.
 
+Administration:
+
+- External accounts can now be used to sign-in to a CATMAID instance (if
+  enabled) using OAuth2. The documentation has details on how to configure this.
+  This can allow users with e.g. an existing Orcid ID or GitHub account to
+  sign-in to a CATMAID instance. If enabled, there is now a menu displayed when
+  hovering the mouse over the "Login" button in the upper right corner.
+
+- Like every other new user, users created this way can be in default user
+  groups (`NEW_USER_DEFAULT_GROUPS` setting) and the default tool visibility
+  settings apply as well.
+
 Miscellaneous:
 
 - The user registration form fits now the overal layout better and include first

--- a/django/applications/catmaid/admin.py
+++ b/django/applications/catmaid/admin.py
@@ -13,6 +13,7 @@ from django.contrib import admin, messages
 from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.contrib.auth.admin import UserAdmin, GroupAdmin
 from django.contrib.auth.models import User, Group
+from django.contrib.sites.models import Site
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy
 from django.urls import reverse
@@ -531,6 +532,8 @@ admin.site.register(PointCloud, PointCloudAdmin)
 admin.site.register(User, CustomUserAdmin)
 admin.site.register(Group, CustomGroupAdmin)
 admin.site.register(GroupInactivityPeriod, GroupInactivityPeriodAdmin)
+admin.site.register(Site)
+
 # Register additional views
 admin.site.register_view('annotationimporter', 'Import annotations and tracing data',
                          view=ImportingWizard.as_view())

--- a/django/applications/catmaid/static/js/init.js
+++ b/django/applications/catmaid/static/js/init.js
@@ -971,7 +971,7 @@ var project;
     login_menu.update(Object.keys(CATMAID.extraAuthConfig).sort().map(cId => {
       let c = CATMAID.extraAuthConfig[cId];
       return {
-          action: CATMAID.makeURL(c.login_url),
+          action: c.login_url,
           title: `Login with ${c.name}`,
           note: "",
       };

--- a/django/applications/catmaid/static/js/init.js
+++ b/django/applications/catmaid/static/js/init.js
@@ -80,6 +80,11 @@ var project;
    * @type {Menu}
    */
   var user_menu;
+  /**
+   * A menu for login options.
+   * @type {Menu}
+   */
+  var login_menu;
 
   // Timeout reference for user edit domain updates.
   var edit_domain_timeout;
@@ -276,6 +281,7 @@ var project;
           CATMAID.client.contextHelpVisibilityEnforced = false;
 
           CATMAID._updateUserMenu();
+          CATMAID._updateLoginMenu();
         });
   });
 
@@ -478,6 +484,10 @@ var project;
 
     user_menu = new Menu();
     document.getElementById( "user_menu" ).appendChild( user_menu.getView() );
+
+    login_menu = new Menu();
+    document.getElementById( "login_menu" ).appendChild( login_menu.getView() );
+    CATMAID._updateLoginMenu();
 
     var self = this;
 
@@ -941,6 +951,8 @@ var project;
 
       // Update user menu
       CATMAID._updateUserMenu();
+      // Update login menu
+      CATMAID._updateLoginMenu();
     } else {
       if (this._container) {
         this._container.classList.remove('authenticated');
@@ -950,6 +962,21 @@ var project;
 
   // Publicly accessible session
   CATMAID.session = null;
+
+  /**
+   * If there OAuth2 login providers enabled, they are dispalyed in a login
+   * menu.
+   */
+  CATMAID._updateLoginMenu = function() {
+    login_menu.update(Object.keys(CATMAID.extraAuthConfig).sort().map(cId => {
+      let c = CATMAID.extraAuthConfig[cId];
+      return {
+          action: CATMAID.makeURL(c.login_url),
+          title: `Login with ${c.name}`,
+          note: "",
+      };
+    }));
+  };
 
   CATMAID._updateUserMenu = function() {
       let userMenuItems = [{

--- a/django/applications/catmaid/static/libs/catmaid/CATMAID.js
+++ b/django/applications/catmaid/static/libs/catmaid/CATMAID.js
@@ -49,11 +49,15 @@ var requestQueue = new CATMAID.RequestQueue();
    *                                initial permissions (=null), use these instead.
    * @param {bool}   history        (Optional) Indicate if history tracking is
    *                                enabled in the back-end, default is true.
+   * @param {Object} extraAuthConfig (Optional) Maps installed extra
+   *                                authentication providers names to their
+   *                                configuration.
    * @param {Object} extConfig      (Optional) Maps installed extension names to
    *                                their configuration.
    */
   CATMAID.configure = function(backendURL, staticURL, staticExtURL,
-      csrfCookieName, cookieSuffix, permissions, history, extConfig) {
+      csrfCookieName, cookieSuffix, permissions, history, extraAuthConfig,
+      extConfig) {
     validateString(backendURL, "back-end URL");
     validateString(staticURL, "static URL");
     if (typeof staticExtURL === 'undefined') staticExtURL = '';
@@ -98,6 +102,13 @@ var requestQueue = new CATMAID.RequestQueue();
       configurable: true,
       writable: false,
       value: history === 'undefined' ? true : !!history
+    });
+
+    Object.defineProperty(CATMAID, "extraAuthConfig", {
+      enumerable: false,
+      configurable: true,
+      writable: false,
+      value: extraAuthConfig === 'undefined' ? {} : extraAuthConfig,
     });
 
     Object.defineProperty(CATMAID, "extensionConfig", {

--- a/django/applications/catmaid/templates/catmaid/index.html
+++ b/django/applications/catmaid/templates/catmaid/index.html
@@ -38,7 +38,8 @@
                 "{{ COOKIE_SUFFIX }}",
                 null,
                 {{ HISTORY_TRACKING|make_js_bool }},
-                {{ EXTENSION_CONFIG|safe }});
+                {{ EXTRA_AUTH_CONFIG|safe }},
+                {{ EXTENSION_CONFIG|safe }})
       CATMAID.CLIENT_VERSION = "{% catmaid_version %}";
       CATMAID.expandErrors = {{ EXPAND_FRONTEND_ERRORS|make_js_bool }};
     </script>
@@ -113,7 +114,9 @@
             <p><input type="text" id="account" name="account" size="8" /></p>
             <p>&nbsp;&nbsp;password&nbsp;</p>
             <p><input type="password" id="password" name="password" size="8" /></p>
-            <p>&nbsp;&nbsp;<a id="login" name="login" title="Login" href="#" onclick="CATMAID.client.login( document.getElementById( 'account' ).value, document.getElementById( 'password' ).value );">Login</a></p>
+            <div class="menu_item box" onpointerover="this.lastChild.style.display = 'block';" onpointerout="this.lastChild.style.display = 'none';">
+              <p>&nbsp;&nbsp;<a id="login" name="login" title="Login" href="#" onclick="CATMAID.client.login( document.getElementById( 'account' ).value, document.getElementById( 'password' ).value );">Login</a></p>
+              <div class="pulldown" id="login_menu"></div></div>
             {% if USER_REGISTRATION_ALLOWED %}
             <p>&nbsp;&nbsp;<a id="register" name="register" title="Create a new account"
               href="{% url 'catmaid:register' %}">Register</a>

--- a/django/applications/catmaid/templates/socialaccount/authentication_error.html
+++ b/django/applications/catmaid/templates/socialaccount/authentication_error.html
@@ -1,0 +1,20 @@
+<html>
+  <head>
+    <title>Social account login error: {{ auth_error.code }}</title>
+    <style>
+    h1 {
+      font-size: 2em;
+    }
+    h2 {
+      font-size: 1.5em;
+    }
+    </style>
+  </head>
+  <body>
+    <h1>Login error</h1>
+    <p>There was an error while trying to log in through a social
+    account. Error code: {{ auth_error.code }}.</p>
+    <h2>Details</h2>
+    <p class="details">{{ auth_error.exception }}</p>
+  </body>
+</html>

--- a/django/applications/catmaid/tests/test_history_tables.py
+++ b/django/applications/catmaid/tests/test_history_tables.py
@@ -292,6 +292,12 @@ class HistoryTableTests(TransactionTestCase):
         'pointcloud_group_object_permission',
         'pointcloud_user_object_permission',
         'spatial_ref_sys',
+        'socialaccount_socialapp',
+        'socialaccount_socialaccount',
+        'socialaccount_socialapp_sites',
+        'account_emailaddress',
+        'account_emailconfirmation',
+        'socialaccount_socialtoken',
     )
 
     def test_name_length_limits(self):

--- a/django/applications/catmaid/urls.py
+++ b/django/applications/catmaid/urls.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django.conf import settings
-from django.conf.urls import url
+from django.conf.urls import include, url
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import TemplateView

--- a/django/applications/catmaid/views/__init__.py
+++ b/django/applications/catmaid/views/__init__.py
@@ -8,7 +8,11 @@ from django.http import HttpResponseRedirect
 from django.views.generic import TemplateView
 from django.contrib import messages
 from django.contrib.auth.models import User, Group
+from django.contrib.sites.shortcuts import get_current_site
 from django.apps import apps
+
+from allauth.socialaccount import providers
+from allauth.utils import get_request_param
 
 class CatmaidView(TemplateView):
     """ This view adds extra context to its template. This extra context is
@@ -37,6 +41,22 @@ class CatmaidView(TemplateView):
             except:
                 pass
         context['EXTENSION_CONFIG'] = json.dumps(extension_config)
+
+        # Extra authentication provided through allauth. The login URL is
+        # basically constructed like in the allauth templatetags.
+        extra_auth_config = {}
+        site = get_current_site(self.request)
+        query = {}
+        next = get_request_param(self.request, 'next')
+        if next:
+            query['next'] = next
+        for sapp in site.socialapp_set.all():
+            provider = providers.registry.by_id(sapp.provider, self.request)
+            extra_auth_config[sapp.provider] = {
+                'name': provider.name,
+                'login_url': provider.get_login_url(self.request, **query),
+            }
+        context['EXTRA_AUTH_CONFIG'] = json.dumps(extra_auth_config)
 
         profile_context = self.request.user.userprofile.as_dict()
         context.update(profile_context)

--- a/django/projects/mysite/settings_base.py
+++ b/django/projects/mysite/settings_base.py
@@ -87,6 +87,9 @@ INSTALLED_APPS = (
     'rest_framework.authtoken',
     'rest_framework_swagger',
     'channels',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
 )
 
 LOGGING = {
@@ -145,11 +148,14 @@ TEMPLATES = [
                 'django.template.context_processors.media',
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
+                'django.template.context_processors.request', # Needed for allauth
                 'django.contrib.messages.context_processors.messages'
             ],
         }
     },
 ]
+
+ACCOUNT_EMAIL_VERIFICATION = 'none'
 
 # The URL requests are redirected after login
 LOGIN_REDIRECT_URL = '/'
@@ -158,10 +164,14 @@ LOGIN_REDIRECT_URL = '/'
 LOGIN_URL = '/accounts/login'
 
 AUTHENTICATION_BACKENDS = (
-    'django.contrib.auth.backends.ModelBackend', # default
+    # Default: allow login through regular Django users
+    'django.contrib.auth.backends.ModelBackend',
+    # Needed for object level permissions.
     'guardian.backends.ObjectPermissionBackend',
     # For API tokens. Disable if not using HTTPS:
     'rest_framework.authentication.TokenAuthentication',
+    # `allauth` specific authentication methods, such as login by e-mail
+    'allauth.account.auth_backends.AuthenticationBackend',
 )
 
 # If a request is authenticated through an API token permissions are

--- a/django/projects/mysite/settings_base.py
+++ b/django/projects/mysite/settings_base.py
@@ -157,8 +157,8 @@ TEMPLATES = [
 
 ACCOUNT_EMAIL_VERIFICATION = 'none'
 
-# The URL requests are redirected after login
-LOGIN_REDIRECT_URL = '/'
+# Redirect to start page after a login
+LOGIN_REDIRECT_URL = 'catmaid:home'
 
 # The URL where requests are redirected after login
 LOGIN_URL = '/accounts/login'

--- a/django/projects/mysite/urls.py
+++ b/django/projects/mysite/urls.py
@@ -28,6 +28,7 @@ admin.site.index_title = "CATMAID instance"
 # CATMAID
 urlpatterns = [
     url(r'^', include('catmaid.urls')),
+    url(r'^accounts/', include('allauth.urls')),
 ]
 
 # CATMAID extensions

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -5,6 +5,7 @@ cssmin==0.2.0
 Cython==0.29.14
 Django==3.0.6
 django-adminplus==0.5
+django-allauth==0.41.0
 django-formtools==2.2
 django-guardian==2.2.0
 django-pipeline==1.7.0

--- a/sphinx-doc/source/administrator.rst
+++ b/sphinx-doc/source/administrator.rst
@@ -21,5 +21,6 @@ Administrator Documentation
    additional_backends
    r_setup
    nblast
+   External sign-in using OAuth2 <oauth2>
    admin_faq
    catmaid_and_rds

--- a/sphinx-doc/source/oauth2.rst
+++ b/sphinx-doc/source/oauth2.rst
@@ -1,0 +1,102 @@
+.. _oauth2:
+
+Setting up OAuth2 providers for login
+=====================================
+
+CATMAID can use other OAuth2 services like GitHub or Orcid.org to sign users in.
+Internally a regular Django account is created that is linked to the selected
+remote service. These accounts respect the ``NEW_USER_DEFAULT_GROUPS`` setting
+and default tool configuration.
+
+Below there are instructions to set this up with GitHub and Orcid.org. A lot
+more services are supported, more details can be found on the
+`django-allauth <https://django-allauth.readthedocs.io/en/latest/installation.html>`_
+documentation.
+
+All OAuth2 providers have a parameter called "redirect URLs". When a user tries
+to login to such a service through CATMAID, a URL to a login API on this CATMAID
+server is sent along the login service. The login service has a white list of
+URLs that are passed in (the redirection URLs) and allows only a successful
+login if the passed in URL is on this white list.
+
+GitHub
+------
+
+1. Add GitHub support to installed applications in ``settings.py``::
+
+    INSTALLED_APPS += ('allauth.socialaccount.providers.github',)
+
+2. Create GitHub OAuth application:
+
+  https://github.com/settings/applications/new
+
+  Make sure that the "Authorization callback URL" machtes your setup. Generally,
+  the form is::
+
+    https://<catmaid-path>/accounts/github/login/callback/
+
+  For a local development setup, use this URL::
+
+    http://localhost:8000/accounts/github/login/callback/
+
+  This creates a *Client ID* and a *Client Secret*, which are needed in a later
+  step.
+
+3. Create a Site object in the CATMAID admin view with ``ID = 1``, or if you
+   have configured your own ``SIDE_ID`` in ``settings.py`` use this one.
+
+4. Create *Social application* using the GitHub provider in CATMAID's admin
+   view. Use *Client ID* and *Client Secret* created in step 2.
+
+5. The front-end should now display a menu for when hovering the mouse over the
+   Login button, showing the new entry "Login with GitHub". Clicking it should
+   ask your GitHub user account if CATMAID has permission to use it.
+
+Orcid.org
+---------
+
+To use Orcid.org as login service, their Public API is sufficient, which is
+available to everyone to everyone with an Orcid.org account. The details on how
+to create a new application and obtain the *Client ID* and *Client Secret* can
+be found on `orcid.org
+<https://support.orcid.org/hc/en-us/articles/360006897174>`_. Everyone with an
+Orcid ID can create new applications from the developer tools (available in the
+user account drop down menu). Remember to define the redirect URLs or domains
+properly. With this done, CATMAID can be configured like this:
+
+1. Add ORCID support to installed applications in ``settings.py``::
+
+    INSTALLED_APPS += ('allauth.socialaccount.providers.orcid',)
+
+2. Create a Site object in the CATMAID admin view with ``ID = 1``, or if you
+   have configured your own ``SIDE_ID`` in ``settings.py`` use this one.
+   Multiple login services can use the same site.
+
+4. Create *Social application* using the Orcid.org provider in CATMAID's admin
+   view. Use *Client ID* and *Client Secret* assigned in the Orcid.org sign-up
+   process.
+
+5. The front-end should now display a menu for when hovering the mouse over the
+   Login button, showing the new entry "Login with Orcid.org". Clicking it
+   should ask your Orcid user account if CATMAID has permission to use it.
+
+
+Orcid.org sandbox
+-----------------
+
+Obtaining an Orcid.org sandbox account is easier and a prerequisite of a
+production account. More details on the process can be found on `orcid.org
+<https://orcid.org/content/register-client-application-sandbox>`_. This process
+will also result in a *Client ID* and a *Client Secret*.
+
+The rest of the Orcid-Sandbox configuration is just like the production
+Orcid.org setup, but needs additionally the following entry in ``settings.py``::
+
+  SOCIALACCOUNT_PROVIDERS = {
+      'orcid': {
+          # Base domain of the API. Default value: 'orcid.org', for the production API
+          'BASE_DOMAIN':'sandbox.orcid.org',  # for the sandbox API
+          # Member API or Public API? Default: False (for the public API)
+          'MEMBER_API': True,  # for the member API
+      },
+  }


### PR DESCRIPTION
This makes it possible to use external services like Orcid.org or GitHub to sign-in to CATMAID instances. If enabled, a menu is shown with all enabled login methods when hovering the mouse over the Login button in the upper right corner. Nothing of the regular login-logic changes, this adds only optional additional functionality.

This uses [django-allauth](https://django-allauth.readthedocs.io/) for the actual OAuth2 logic, which is actively developed and under MIT license. Their documentation has a complete list of supported services (many). By default only the basic infrastructure is loaded, which doesn't add any overhead.  None of the extra log-in options are enabled by default. Our documentation has now some information on how to allow sign-in via GitHub and Orcid.org.

This feature is needed for a publicly accessible CATMAID instance, where users will be able to log-in and create their own working spaces.