### PR TITLE
Python 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,7 @@ jobs:
       - run: bash scripts/travis/setup_database.sh
       - run: bash scripts/travis/configure_catmaid.sh
       - run: bash scripts/travis/configure_pypy_libs.sh
+        if: ${{ matrix.python-version == 'pypy3' }}
       - run: |
           cd django/projects
           python manage.py migrate --noinput

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', 'pypy3']
+        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy3']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/django/requirements-optional.txt
+++ b/django/requirements-optional.txt
@@ -1,4 +1,4 @@
 rpy2==3.2.6
-pandas==0.24.1
+pandas==1.1.5
 h5py==2.10.0; platform_python_implementation != "PyPy"
 cloud-volume==2.1.0

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -27,6 +27,6 @@ python-dateutil==2.8.1
 pytz==2019.3
 PyYAML==5.3
 requests==2.22.0
-scipy==1.3.1
+scipy==1.5.4
 trimesh==3.5.13
 ujson==1.35

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -18,7 +18,7 @@ mock==3.0.5
 msgpack==0.6.2; platform_python_implementation != 'PyPy'
 msgpack_python==0.5.6
 networkx==2.4
-numpy==1.17.4
+numpy==1.19.5
 pillow==7.1.0
 progressbar2==3.47.0
 psycopg2-binary==2.8.6; platform_python_implementation != 'PyPy'


### PR DESCRIPTION
I suspect these tests will fail or take forever as some dependencies won't have wheels available for 3.9, but it's good to have the PR available.

Also skips the pypy-specific setup script for non-pypy builds.