### PR TITLE
Update scipy, numpy, pandas

### DIFF
--- a/django/requirements-optional.txt
+++ b/django/requirements-optional.txt
@@ -1,4 +1,4 @@
 rpy2==3.2.6
-pandas==0.24.1
+pandas==1.1.5
 h5py==2.10.0; platform_python_implementation != "PyPy"
 cloud-volume==2.1.0

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -27,6 +27,6 @@ python-dateutil==2.8.1
 pytz==2019.3
 PyYAML==5.3
 requests==2.22.0
-scipy==1.3.1
+scipy==1.5.4
 trimesh==3.5.13
 ujson==1.35

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -18,7 +18,7 @@ mock==3.0.5
 msgpack==0.6.2; platform_python_implementation != 'PyPy'
 msgpack_python==0.5.6
 networkx==2.4
-numpy==1.17.4
+numpy==1.19.5
 pillow==7.1.0
 progressbar2==3.47.0
 psycopg2-binary==2.8.6; platform_python_implementation != 'PyPy'


### PR DESCRIPTION
All of these are packages with significant compiled components. They do not provide wheels for recent python (3.8/ 3.9), which complicates our CI and docker builds and may be what's breaking the 3.9 build. Moving to stable pandas is a bonus.

These are all 1 minor version behind the latest releases, because the latest releases have deprecated 3.6 support.