### PR TITLE
Fix export connectors bug

### DIFF
--- a/django/applications/catmaid/management/commands/catmaid_export_data.py
+++ b/django/applications/catmaid/management/commands/catmaid_export_data.py
@@ -1151,7 +1151,7 @@ class Command(BaseCommand):
             will_export.append('connectors (only intra)')
         elif connector_mode == ConnectorMode.IntraConnectorsAndPlaceholders:
             will_export.append('connectors (intra + new placeholders)')
-        elif connector_mode == ConnectorMode.IntraConnectorsOnly:
+        elif connector_mode == ConnectorMode.IntraConnectorsAndOriginalPlaceholders:
             will_export.append('connectors (intra + original placeholders)')
         elif connector_mode != ConnectorMode.NoConnectors:
             logger.warn(f'Unknown connector mode: {connector_mode}')


### PR DESCRIPTION
Previously, the "intra_and_original_placeholders" option was not
picked up, likely due to a typo.