### PR TITLE
Update packagelist to use python3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
   Instead of hard-coding the 1024px, the minimum tile size defined in the mirror
   set is used. Without any mirrors, no extra zoom levels will be assumed.
 
+- The recommended python version is now 3.8, although support for 3.6 is maintained.
+
 - A virtualenv update is required.
 
 ### Features and enhancements

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY packagelist-ubuntu-apt.txt /home/
 RUN apt-get update -y  \
     && xargs apt-get install -y < /home/packagelist-ubuntu-apt.txt \
     && rm -rf /var/lib/apt/lists/*
-COPY django/requirements.txt django/requirements-async.txt /home/django/
+COPY django/requirements.txt django/requirements-async.txt django/requirements-production.txt /home/django/
 ENV WORKON_HOME /opt/virtualenvs
 RUN mkdir -p /opt/virtualenvs \
     && /bin/bash -c "source /usr/share/virtualenvwrapper/virtualenvwrapper.sh \
@@ -35,7 +35,9 @@ RUN mkdir -p /opt/virtualenvs \
     && workon catmaid \
     && pip install -U pip setuptools \
     && pip install -r /home/django/requirements.txt \
-    && pip install -r /home/django/requirements-async.txt"
+    && pip install -r /home/django/requirements-async.txt \
+    && pip install -r /home/django/requirements-production.txt \
+    "
 
 COPY . /home/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -y \
     && add-apt-repository ppa:deadsnakes/ppa \
     && add-apt-repository -y ppa:nginx/stable \
     && apt-get update -y \
-    && apt-get install -y python3.6 python3.6-dev git python3-pip \
+    && apt-get install -y python3.8 python3.8-dev git python3-pip \
     && apt-get install -y nginx supervisor \
     && apt-get install -y rabbitmq-server \
     && rm -rf /var/lib/apt/lists/*
@@ -31,7 +31,7 @@ COPY django/requirements.txt django/requirements-async.txt /home/django/
 ENV WORKON_HOME /opt/virtualenvs
 RUN mkdir -p /opt/virtualenvs \
     && /bin/bash -c "source /usr/share/virtualenvwrapper/virtualenvwrapper.sh \
-    && mkvirtualenv catmaid -p /usr/bin/python3.6 \
+    && mkvirtualenv catmaid -p /usr/bin/python3.8 \
     && workon catmaid \
     && pip install -U pip setuptools \
     && pip install -r /home/django/requirements.txt \

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -28,6 +28,8 @@ and other administration related changes are listed in order.
   This also requires updating all installed R packages. In all likelihood this
   requires executing "manage.py catmaid_setup_nblast_environment".
 
+- The recommended python version is now 3.8, although support for 3.6 is maintained.
+
 - A virtualenv update is required.
 
 - For production environments it is now recommended to also install the Python

--- a/packagelist-ubuntu-apt.txt
+++ b/packagelist-ubuntu-apt.txt
@@ -3,7 +3,7 @@ postgresql-12-postgis-2.5
 gcc
 gfortran
 git
-python3.6-dev
+python3.8-dev
 postgresql-common
 libpq-dev
 libhdf5-serial-dev

--- a/scripts/vagrant/root.sh
+++ b/scripts/vagrant/root.sh
@@ -46,7 +46,7 @@ add-apt-repository ppa:git-core/ppa
 curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 
 # R PPA
-echo "deb https://cloud.r-project.org/bin/linux/ubuntu ${CODENAME}-cran35/" >> /etc/apt/sources.list
+echo "deb https://cloud.r-project.org/bin/linux/ubuntu ${CODENAME}-cran40/" >> /etc/apt/sources.list
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 
 apt-key update
@@ -69,4 +69,3 @@ systemctl restart postgresql
 # increase number of file watchers (IDEs need this)
 echo "fs.inotify.max_user_watches=524288" | tee -a /etc/sysctl.conf
 sysctl -p
-

--- a/scripts/vagrant/root.sh
+++ b/scripts/vagrant/root.sh
@@ -55,7 +55,7 @@ apt-get upgrade -y
 
 cd /CATMAID
 sudo xargs apt-get install -y < packagelist-ubuntu-apt.txt
-apt-get install -y nodejs python3-pip python3.6-venv python3-wheel git r-base
+apt-get install -y nodejs python3-pip python3.8-venv python3-wheel git r-base
 
 POSTGRES_VERSION=$(psql --version | awk '{print $3}' | awk -F '.' '{print $1}')
 

--- a/scripts/vagrant/user.sh
+++ b/scripts/vagrant/user.sh
@@ -6,15 +6,16 @@ set -x
 mkdir -p ~/.local/share
 
 # set up python environment
-python3.6 -m venv ~/catmaid-env
+python3.8 -m venv ~/catmaid-env
 source ~/catmaid-env/bin/activate
 echo "source ~/catmaid-env/bin/activate" >> ~/.bashrc
 
 # install python dependencies
 cd /CATMAID/django
-pip install -U pip
-pip install numpy
-pip install -r requirements-dev.txt -r requirements-optional.txt
+pip install -U pip setuptools wheel
+pip install -r requirements-dev.txt
+grep --invert-match "^cloud-volume" requirements-optional.txt > ~/requirements-nocloudvolume.txt
+pip install -r ~/requirements-nocloudvolume.txt
 
 # install node dependencies
 cd /CATMAID

--- a/scripts/vagrant/user.sh
+++ b/scripts/vagrant/user.sh
@@ -13,6 +13,7 @@ echo "source ~/catmaid-env/bin/activate" >> ~/.bashrc
 # install python dependencies
 cd /CATMAID/django
 pip install -U pip
+pip install numpy
 pip install -r requirements-dev.txt -r requirements-optional.txt
 
 # install node dependencies

--- a/sphinx-doc/source/contributing.rst
+++ b/sphinx-doc/source/contributing.rst
@@ -29,7 +29,7 @@ interface and suite of analysis tools which interact with the backend's HTTP
 API. The frontend also has its own APIs which allow new tools to be quickly
 constructed or expert users to perform novel analysis using the browser console.
 
-The backend is written primarily in Python 3.6 using the Django web framework.
+The backend is written primarily in Python 3.8 using the Django web framework.
 Annotations and metadata about stacks are stored in a PostgreSQL database. Most
 endpoints in the backend API expect and return JSON.
 

--- a/sphinx-doc/source/installation.rst
+++ b/sphinx-doc/source/installation.rst
@@ -21,7 +21,7 @@ Introduction
 The most fundamental dependencies of CATMAID are:
 
 1. PostgreSQL 12 and PostGIS 2.5
-2. Python 3.6, 3.7, 3.8 or PyPy3.6
+2. CPython 3.6, 3.7, 3.8, 3.9 or PyPy3.7 (CPython 3.8 is recommended)
 
 To get the required PostgreSQL version for Debian-based systems, such as
 Ubuntu, you have to add the officical Postgres repository as an
@@ -36,9 +36,8 @@ done so already)::
     wget --quiet -O - ${PG_KEY_URL} | sudo apt-key add -
     sudo apt-get update
 
-While newer Python versions are supported, we recommend the use of Python 3.6,
-because that's what we have most experience with at the moment. To be able to
-install it on Ubuntu 16.04 and earlier, the following needs to be done::
+While other Python versions are supported, we recommend the use of Python 3.8.
+To be able to install it on Ubuntu 16.04 and earlier, the following needs to be done::
 
     sudo add-apt-repository ppa:deadsnakes/ppa
     sudo apt-get update
@@ -52,7 +51,7 @@ or newer not  be available on your system, use the following PPA::
 
 And then you can install these dependencies with::
 
-    sudo apt-get install python3.6 postgresql-12 postgresql-12-postgis-2.5 gdal-bin
+    sudo apt-get install python3.8 postgresql-12 postgresql-12-postgis-2.5 gdal-bin
 
 CATMAID is based on the `Django web framework
 <https://www.djangoproject.com/>`_.  If you just wish to work on
@@ -77,7 +76,7 @@ the source code is in ``/home/alice/catmaid``::
 2. Install required Python packages
 ###################################
 
-We recommend the use of Python 3.6 or newer for production use. With a few
+We recommend the use of Python 3.8 or newer for production use. With a few
 limitations PyPy3 can be used as well (no cropping, no back-end plotting,
 no synapse clustering, no ontology clustering).
 
@@ -113,7 +112,7 @@ and call ``source ~/.bashrc`` again::
 To create a new virtualenv for CATMAID's Python dependencies,
 you can do::
 
-    mkvirtualenv --no-site-packages -p /usr/bin/python3.6 catmaid
+    mkvirtualenv --no-site-packages -p /usr/bin/python3.8 catmaid
 
 That will create a virtualenv in ``~/.virtualenvs/catmaid/``, and
 while your virtualenv is activated, Python libraries will be
@@ -143,7 +142,7 @@ shells, for example, you will need to activate it by running::
 
 .. note::
 
-   If you are using Python 3.6 on Ubuntu 14.04 and 16.04, never uninstall Python
+   If you are using Python 3.6 or newer on Ubuntu 14.04 and 16.04, never uninstall Python
    3.5, because it might break some parts of the system.
 
 Install all of the required Python packages with::


### PR DESCRIPTION
3.6 support has been dropped by the latest version of numpy. Although we're not using it yet, this gives us more head room, and is defensive for future changes. Note that 3.9's compatibility with our current `requirements.txt` is a bit more complicated (matplotlib 3.1.2 has no wheels for 3.9, so there are additional build dependencies which seem to be present on github actions, but not in vagrant).

Minor vagrant changes:

- Update to 20.04, using official box from ubuntu
  - Requires use of R v4.0
  - Don't manually resize partitions after disk size change; doesn't seem to be necessary
- Drop `cloud-volume`, which was breaking the provisioning

See #2114, #2115