### PR TITLE
3D viewer: add option to hide desmosome links

### DIFF
--- a/django/applications/catmaid/static/js/skeleton-model.js
+++ b/django/applications/catmaid/static/js/skeleton-model.js
@@ -18,6 +18,7 @@
       this.selected = true;
       this.pre_visible = true;
       this.post_visible = true;
+      this.desmosome_visible = true;
       this.text_visible = false;
       this.meta_visible = true;
       this.color = color || new THREE.Color(defaultColor);
@@ -40,6 +41,7 @@
       this.selected = v;
       this.pre_visible = v;
       this.post_visible = v;
+      this.desmosome_visible = v;
       if (!v) this.text_visible = v;
       this.meta_visible = v;
   };
@@ -49,6 +51,7 @@
     m.selected = this.selected;
     m.pre_visible = this.pre_visible;
     m.post_visible = this.post_visible;
+    m.desmosome_visible = this.desmosome_visible;
     m.text_visible = this.text_visible;
     m.meta_visible = this.meta_visible;
     m.opacity = this.opacity;
@@ -71,6 +74,7 @@
     this.selected = other.selected;
     this.pre_visible = other.pre_visible;
     this.post_visible = other.post_visible;
+    this.desmosome_visible = other.desmosome_visible;
     this.text_visible = other.text_visible;
     this.meta_visible = other.meta_visible;
     this.opacity = other.opacity;

--- a/django/applications/catmaid/static/js/widgets/3dviewer.js
+++ b/django/applications/catmaid/static/js/widgets/3dviewer.js
@@ -1667,6 +1667,7 @@
 
   WebGLApplication.prototype.setSkeletonPreVisibility = WebGLApplication.prototype._skeletonVizFn('Pre');
   WebGLApplication.prototype.setSkeletonPostVisibility = WebGLApplication.prototype._skeletonVizFn('Post');
+  WebGLApplication.prototype.setSkeletonDesmosomeVisibility = WebGLApplication.prototype._skeletonVizFn('Desmosome');
   WebGLApplication.prototype.setSkeletonTextVisibility = WebGLApplication.prototype._skeletonVizFn('Text');
   WebGLApplication.prototype.setSkeletonMetaVisibility = WebGLApplication.prototype._skeletonVizFn('Meta');
 
@@ -1854,6 +1855,7 @@
         var skeleton = skeletons[skid];
         skeleton.setPreVisibility(false, true);
         skeleton.setPostVisibility(false, true);
+        skeleton.setDesmosomeVisibility(false, true);
       });
 
       var restriction = this.options.connector_filter;
@@ -1922,6 +1924,7 @@
         var skeleton = skeletons[skid];
         skeleton.setPreVisibility(skeleton.skeletonmodel.pre_visible);
         skeleton.setPostVisibility(skeleton.skeletonmodel.post_visible);
+        skeleton.setDesmosomeVisibility(skeleton.skeletonmodel.desmosome_visible);
       });
     }
 
@@ -2185,6 +2188,7 @@
           skeleton.setActorVisibility(model.selected && model.opacity > 0);
           skeleton.setPreVisibility(model.pre_visible);
           skeleton.setPostVisibility(model.post_visible);
+          skeleton.setDesmosomeVisibility(model.desmosome_visible);
           skeleton.setTextVisibility(model.text_visible);
           skeleton.setMetaVisibility(model.meta_visible);
           skeleton.actorColor = model.color.clone();
@@ -3615,6 +3619,7 @@
       s.setActorVisibility(visMap[skid].actor ? visible : false);
       s.setPreVisibility(visMap[skid].pre ? visible : false);
       s.setPostVisibility(visMap[skid].post ? visible : false);
+      s.setDesmosomeVisibility(visMap[skid].desmosome ? visible : false);
       s.setTextVisibility(visMap[skid].text ? visible : false);
       s.setMetaVisibility(visMap[skid].meta ? visible : false);
     }
@@ -5887,6 +5892,8 @@
       this.staticContent.connectorLineColors.presynaptic_to.visible;
     var originalConnectorPostVisibility =
       this.staticContent.connectorLineColors.postsynaptic_to.visible;
+    var originalConnectorDesmosomeVisibility =
+      this.staticContent.connectorLineColors.desmosome_with.visible;
 
     // Hide everthing unpickable
     var o = CATMAID.tools.deepCopy(this.options);
@@ -5900,6 +5907,7 @@
     // Hide pre and post synaptic flags
     this.staticContent.connectorLineColors.presynaptic_to.visible = false;
     this.staticContent.connectorLineColors.postsynaptic_to.visible = false;
+    this.staticContent.connectorLineColors.desmosome_with.visible = false;
 
     // Disable lighting and add plain ambient light
     var lightVisMap = this.lights.map(function(l) {
@@ -6194,6 +6202,8 @@
       originalConnectorPreVisibility;
     this.staticContent.connectorLineColors.postsynaptic_to.visible =
       originalConnectorPostVisibility;
+    this.staticContent.connectorLineColors.desmosome_with.visible =
+      originalConnectorDesmosomeVisibility;
 
     // If no color ID was found, no element was hit.
     if (colorId === 0) {
@@ -6461,11 +6471,13 @@
   WebGLApplication.prototype.Space.prototype.Skeleton.prototype.synapticTypes = ['presynaptic_to', 'postsynaptic_to', 'gapjunction_with', 'desmosome_with'];
   WebGLApplication.prototype.Space.prototype.Skeleton.prototype.synapticTypesToModelVisibility = {
     'presynaptic_to': 'pre_visible',
-    'postsynaptic_to': 'post_visible'
+    'postsynaptic_to': 'post_visible',
+    'desmosome_with': 'desmosome_visible'
   };
   WebGLApplication.prototype.Space.prototype.Skeleton.prototype.modelVisibilityToSynapticType = {
     'presynaptic_to': 'pre_visible',
-    'postsynaptic_to': 'post_visible'
+    'postsynaptic_to': 'post_visible',
+    'desmosome_with': 'desmosome_visible'
   };
 
 
@@ -6723,6 +6735,8 @@
   WebGLApplication.prototype.Space.prototype.Skeleton.prototype.setPreVisibility = WebGLApplication.prototype.Space.prototype.Skeleton.prototype.setSynapticVisibilityFn('presynaptic_to');
 
   WebGLApplication.prototype.Space.prototype.Skeleton.prototype.setPostVisibility = WebGLApplication.prototype.Space.prototype.Skeleton.prototype.setSynapticVisibilityFn('postsynaptic_to');
+
+  WebGLApplication.prototype.Space.prototype.Skeleton.prototype.setDesmosomeVisibility = WebGLApplication.prototype.Space.prototype.Skeleton.prototype.setSynapticVisibilityFn('desmosome_with');
 
   WebGLApplication.prototype.Space.prototype.Skeleton.prototype.setMetaVisibility = function(vis) {
     for (var idx in this.specialTagSpheres) {
@@ -8674,9 +8688,11 @@
     if (options.connector_filter) {
       this.setPreVisibility( false ); // the presynaptic edges and spheres
       this.setPostVisibility( false ); // the postsynaptic edges and spheres
+      this.setDesmosomeVisibility( false ); // the desmosome edges and spheres
     } else {
       this.setPreVisibility( this.skeletonmodel.pre_visible ); // the presynaptic edges and spheres
       this.setPostVisibility( this.skeletonmodel.post_visible ); // the postsynaptic edges and spheres
+      this.setDesmosomeVisibility( this.skeletonmodel.desmosome_visible ); // the desmosome edges and spheres
     }
 
     this.setTextVisibility( this.skeletonmodel.text_visible ); // the text labels

--- a/django/applications/catmaid/static/js/widgets/selection-table.js
+++ b/django/applications/catmaid/static/js/widgets/selection-table.js
@@ -23,7 +23,7 @@
     this.review_filter = 'Union'; // filter for review percentage: 'Union', 'Team' or 'Self'
     this.min_review_percent = 0;
     this.all_visible = true;
-    this.all_items_visible = {pre: true, post: true, text: false, meta: true};
+    this.all_items_visible = {pre: true, post: true, desmosome: true, text: false, meta: true};
     this.next_color_index = 0;
     this.batchColor = '#ffff00';
     this.batchOpacity = 1.0;
@@ -47,8 +47,8 @@
   };
 
   // Skeleton properties that are referenced at various locations.
-  SelectionTable.KnownVisibilities = ['pre', 'post', 'text', 'meta'];
-  SelectionTable.KnownVisibilityFields = ['pre_visible', 'post_visible', 'text_visible', 'meta_visible'];
+  SelectionTable.KnownVisibilities = ['pre', 'post', 'desmosome', 'text', 'meta'];
+  SelectionTable.KnownVisibilityFields = ['pre_visible', 'post_visible', 'desmosome_visible', 'text_visible', 'meta_visible'];
 
   SelectionTable._lastFocused = null; // Static reference to last focused instance
 
@@ -207,9 +207,9 @@
           self.linkVisibilities = this.checked;
         };
         var linkVizSettigs = document.createElement('label');
-        linkVizSettigs.setAttribute('title', 'If unchecked, pre/post/text/meta ' +
-            'visibility can also be controlled for all skeletons regardless of ' +
-            'their visibility.');
+        linkVizSettigs.setAttribute('title', 'If unchecked, pre/post/desmosome/' +
+            'text/meta visibility can also be controlled for all skeletons regardless' +
+            ' of their visibility.');
         linkVizSettigs.appendChild(linkVizSettigsCb);
         linkVizSettigsCb.checked = this.linkVisibilities;
         linkVizSettigs.appendChild(document.createTextNode(
@@ -231,6 +231,7 @@
                 '<th title="Select a neuron and control its visibility (3D viewer)">selected</th>' +
                 '<th title="Control visibility of pre-synaptic connections (3D viewer)">pre</th>' +
                 '<th title="Control visibility of post-synaptic connections (3D viewer)">post</th>' +
+                '<th title="Control visibility of desmosome connections (3D viewer)">desmo</th>' +
                 '<th title="Control visibility of tags (3D viewer)">text</th>' +
                 '<th title="Control visibility of special nodes (3D viewer)">meta</th>' +
                 '<th title="Control the color of a neuron (3D viewer)">color</th>' +
@@ -251,6 +252,7 @@
                 '<th><input type="checkbox" id="selection-table-show-all' + this.widgetID + '" checked /></th>' +
                 '<th><input type="checkbox" id="selection-table-show-all-pre' + this.widgetID + '" checked style="float: left" /></th>' +
                 '<th><input type="checkbox" id="selection-table-show-all-post' + this.widgetID + '" checked style="float: left" /></th>' +
+                '<th><input type="checkbox" id="selection-table-show-all-desmosome' + this.widgetID + '" checked style="float: left" /></th>' +
                 '<th><input type="checkbox" id="selection-table-show-all-text' + this.widgetID + '" style="float: left" /></th>' +
                 '<th><input type="checkbox" id="selection-table-show-all-meta' + this.widgetID + '" checked style="float: left" /></th>' +
                 '<th><button id="selection-table-batch-color-button' + this.widgetID +
@@ -360,7 +362,7 @@
 
             // The first checkbox controls all others
             if ("selected" === action) {
-              ['pre_visible', 'post_visible', 'text_visible', 'meta_visible'].forEach(function(other, k) {
+              ['pre_visible', 'post_visible', 'desmosome_visibe', 'text_visible', 'meta_visible'].forEach(function(other, k) {
                 if (visible && 2 === k) return; // don't make text visible
                 skeleton[other] = visible;
                 $('#skeleton' + other + table.widgetID + '-' + skeletonID).prop('checked', visible);
@@ -626,8 +628,8 @@
     this.updateTableInfo();
   };
 
-  /** Where 'type' is 'pre' or 'post' or 'text' or 'meta', which are the prefixes of
-   * the keys in SkeletonModel that end with "_visible". */
+  /** Where 'type' is 'pre' or 'post' or 'desmosome' or 'text' or 'meta', which are
+   * the prefixes of the keys in SkeletonModel that end with "_visible". */
   SelectionTable.prototype.toggleAllKeyUI = function(type) {
     var state = !this.all_items_visible[type];
     this.all_items_visible[type] = state;
@@ -802,6 +804,7 @@
             //if (!forceProperties) {
             model.meta_visible = this.all_items_visible['meta'];
             model.text_visible = this.all_items_visible['text'];
+            model.desmosome_visible = this.all_items_visible['desmosome'];
             model.pre_visible = this.all_items_visible['pre'];
             model.post_visible = this.all_items_visible['post'];
 
@@ -1370,6 +1373,13 @@
           "orderable": false,
           "visible": this.showVisibilityControls,
           "render": function(data, type, row, meta) {
+            return createCheckbox('desmosome_visible', row.skeleton);
+          }
+        },
+        {
+          "orderable": false,
+          "visible": this.showVisibilityControls,
+          "render": function(data, type, row, meta) {
             return createCheckbox('text_visible', row.skeleton);
           }
         },
@@ -1624,7 +1634,7 @@
       this.sortByReview(desc);
     } else if (4 === col) { // Selected
       this.sortBySelected(desc);
-    } else if (9 === col) { // Color
+    } else if (10 === col) { // Color
       this.sortByColor(desc);
     }
   };


### PR DESCRIPTION
There was no way to show skeletons with only their synapses and no
desmosomes. Desmosomes were shown even when all skeletons were hidden.
This was making it difficult to make nice figures.