### PR TITLE
Improve volume import performance

### DIFF
--- a/django/applications/catmaid/control/skeleton.py
+++ b/django/applications/catmaid/control/skeleton.py
@@ -4146,8 +4146,8 @@ def get_skeletons_in_bb(params) -> List:
 @api_view(['GET', 'POST'])
 @requires_user_role(UserRole.Browse)
 def skeletons_in_bounding_box(request:HttpRequest, project_id) -> JsonResponse:
-    """Get a list of all skeletons that intersect with the passed in bounding
-    box. Optionally, only a subsed of passed in skeletons can be tested against.
+    """Get a list of all skeletons that intersect with the query bounding
+    box. Optionally, only a subset of passed in skeletons can be tested against.
     ---
     parameters:
     - name: limit

--- a/django/applications/catmaid/control/volume.py
+++ b/django/applications/catmaid/control/volume.py
@@ -766,8 +766,8 @@ def import_volumes(request, project_id) -> Union[HttpResponse, JsonResponse]:
     if request.FILES:
         for uploadedfile in request.FILES.values():
             if uploadedfile.size > settings.IMPORTED_SKELETON_FILE_MAXIMUM_SIZE:  # todo: use different setting
-                return HttpResponse(
-                    f'File too large. Maximum file size is {settings.IMPORTED_SKELETON_FILE_MAXIMUM_SIZE} bytes.',
+                return JsonResponse(
+                    {"error": f'File too large. Maximum file size is {settings.IMPORTED_SKELETON_FILE_MAXIMUM_SIZE} bytes.'},
                     status=413)
 
             filename = uploadedfile.name
@@ -786,7 +786,9 @@ def import_volumes(request, project_id) -> Union[HttpResponse, JsonResponse]:
                 )
                 fnames_to_id[filename] = mesh_id = mesh.save()
             else:
-                return HttpResponse(f'File type "{extension}" not understood. Known file types: stl', status=415)
+                return JsonResponse(
+                    {"error": f'File type "{extension}" not understood. Known file types: stl'},
+                    status=415)
     elif 'format' in request.POST:
         fmt = request.POST.get('format')
         if fmt == 'stl':

--- a/django/applications/catmaid/control/volume.py
+++ b/django/applications/catmaid/control/volume.py
@@ -9,6 +9,7 @@ import re
 import struct
 import sys
 import trimesh
+import numpy as np
 from typing import Any, Callable, Dict, List, Sequence, Tuple, Union
 from xml.etree import ElementTree as ET
 
@@ -1384,18 +1385,10 @@ def get_volume_data(project_id, volume_ids):
 
         # For some reason, in this format vertices occur multiple times - we
         # have to collapse that to get a clean mesh
-        final_faces = []
-        final_vertices: List[Sequence[int]] = []
-
-        for t in faces:
-            this_faces = []
-            for v in t:
-                if vertices[v] not in final_vertices:
-                    final_vertices.append(vertices[v])
-
-                this_faces.append(final_vertices.index(vertices[v]))
-
-            final_faces.append(this_faces)
+        dedup_vertices, idx_map = np.unique(np.asarray(vertices), return_inverse=True, axis=0)
+        final_vertices: List[Sequence[int]] = list(dedup_vertices)
+        vert_idx_map = list(idx_map)
+        final_faces = [[vert_idx_map[v] for v in t] for t in faces]
 
         volumes[mesh_id] = {
             'name': mesh_name,


### PR DESCRIPTION
These are miscellaneous changes that improve import performance for large volume meshes (>100K vertices). For the meshes I was using these cumulative changes brought import time with the dev server from 50 minutes down to 5 seconds. PRing for CI and because I haven't touched CATMAID in ages.