### PR TITLE
tools: extend dateToString, add nullish

### DIFF
--- a/django/applications/catmaid/static/js/tests/test_tools.js
+++ b/django/applications/catmaid/static/js/tests/test_tools.js
@@ -170,6 +170,22 @@ QUnit.test('Utilities test', function( assert ) {
         new Date(Date.UTC(2017, 10, 6, 3, 58, 32)), 'Test date is parsed correctly');
   })();
 
+  // Test dateToString
+  (function () {
+    const d = new Date('January 1, 2020 00:00:01Z');
+    assert.ok(CATMAID.tools.dateToString(d) === '2021-01-01 00:00:01');
+    assert.ok(CATMAID.tools.dateToString(d, "T", "") === '2021-01-01T000001');
+  })();
+
+  // Test nullish
+  (function () {
+    assert.ok(CATMAID.tools.nullish(undefined, null, 1) === 1);
+    assert.ok(CATMAID.tools.nullish() === undefined);
+    for (let falsy of [0, false, "", NaN]) {
+      assert.ok(CATMAID.tools.nullish(falsy) === falsy);
+    }
+  })();
+
   // Test Color construction util
   (function() {
     assert.deepEqual(CATMAID.tools.getColor(0), new THREE.Color(0, 0, 0),

--- a/django/applications/catmaid/static/js/tests/test_tools.js
+++ b/django/applications/catmaid/static/js/tests/test_tools.js
@@ -173,8 +173,8 @@ QUnit.test('Utilities test', function( assert ) {
   // Test dateToString
   (function () {
     const d = new Date('January 1, 2020 00:00:01Z');
-    assert.ok(CATMAID.tools.dateToString(d) === '2021-01-01 00:00:01');
-    assert.ok(CATMAID.tools.dateToString(d, "T", "") === '2021-01-01T000001');
+    assert.ok(CATMAID.tools.dateToString(d) === '2020-01-01 00:00:01');
+    assert.ok(CATMAID.tools.dateToString(d, "T", "") === '2020-01-01T000001');
   })();
 
   // Test nullish

--- a/django/applications/catmaid/static/js/tests/test_tools.js
+++ b/django/applications/catmaid/static/js/tests/test_tools.js
@@ -181,9 +181,10 @@ QUnit.test('Utilities test', function( assert ) {
   (function () {
     assert.ok(CATMAID.tools.nullish(undefined, null, 1) === 1);
     assert.ok(CATMAID.tools.nullish() === undefined);
-    for (let falsy of [0, false, "", NaN]) {
-      assert.ok(CATMAID.tools.nullish(falsy) === falsy);
-    }
+    assert.ok(CATMAID.tools.nullish(0) === 0);
+    assert.ok(CATMAID.tools.nullish(false) === false);
+    assert.ok(CATMAID.tools.nullish("") === "");
+    assert.ok(isNaN(CATMAID.tools.nullish(NaN)));
   })();
 
   // Test Color construction util

--- a/django/applications/catmaid/static/libs/catmaid/tools.js
+++ b/django/applications/catmaid/static/libs/catmaid/tools.js
@@ -431,22 +431,47 @@ CATMAID.tools = CATMAID.tools || {};
   })();
 
   /**
-   * Return a string representation of a Date instance with the format
-   * YYYY-MM-DD hh:mm:ss.
+   * Something like nullish coalescing with an arbitrary number of options.
+   *
+   * True nullish coalescing is better because it short-circuits.
+   * This should be deprecated when browser support for nullish coalescing improves:
+   * https://caniuse.com/mdn-javascript_operators_nullish_coalescing
+   * (90% as of 2021-09-07).
    */
-  tools.dateToString = function(d) {
-    var day = d.getDate();
-    if (day < 10) day = '0' + day;
-    var month = d.getUTCMonth() + 1; // 0-based
-    if (month < 10) month = '0' + month;
-    var hour = d.getHours();
-    if (hour < 10) hour = '0' + hour;
-    var min = d.getMinutes();
-    if (min < 10) min = '0' + min;
-    var sec = d.getSeconds();
-    if (sec < 10) sec = '0' + sec;
-    return d.getUTCFullYear() + '-' + month + '-' + day + ' ' +
-        hour + ":" + min + ":" + sec;
+  tools.nullish = function (...args) {
+    for (let arg of args) {
+      if (arg !== undefined && arg !== null) {
+        return arg;
+      }
+    }
+  };
+
+  function padNum(n, len) {
+    return n.toString().padStart(len, "0");
+  }
+
+  /**
+   * Return a string representation of a Date instance with an ISO-8601-like
+   * format; by default YYYY-MM-DD hh:mm:ss.
+   * Uses local time.
+   *
+   * @param {Date} [date=now] - defaults to right now
+   * @param {string} [dateTimeSep=" "] - separator between date and time parts
+   * @param {string} [timeSep="-"] - separator between hour/min/sec
+   * @returns {string}
+   */
+  tools.dateToString = function (date, dateTimeSep, timeSep) {
+    date = tools.nullish(date, new Date());
+    dateTimeSep = tools.nullish(dateTimeSep, " ");
+    timeSep = tools.nullish(timeSep, ":");
+
+    const year = padNum(date.getFullYear(), 4);
+    const mon = padNum(date.getMonth() + 1, 2);
+    const day = padNum(date.getDate(), 2);
+    const hour = padNum(date.getHours(), 2);
+    const min = padNum(date.getMinutes(), 2);
+    const sec = padNum(date.getSeconds(), 2);
+    return `${year}-${mon}-${day}${dateTimeSep}${hour}${timeSep}${min}${timeSep}${sec}`;
   };
 
   /**


### PR DESCRIPTION
- dateToString fix/extension
  - stop mixing UTC and locale-aware methods (see #2143)
  - allow custom separators, useful for timestamping filenames (`:` is difficult on windows, ` ` is generally difficult)
- Add function something like nullish coalescing
- Unit tests for both