### PR TITLE
Fix pg13-related build issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,9 +43,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: |
-          sudo apt purge postgresql-13
-          bash scripts/travis/install_postgres.sh
+      - run: bash scripts/travis/install_postgres.sh
       - run: bash scripts/travis/install_gdal.sh
       - run: sudo apt-get install -y -qq $(< packagelist-ubuntu-apt.txt)
         name: Install ubuntu requirements
@@ -86,9 +84,7 @@ jobs:
         with:
           node-version: '12'
       - run: npm install
-      - run: |
-          sudo apt purge postgresql-13
-          bash scripts/travis/install_postgres.sh
+      - run: bash scripts/travis/install_postgres.sh
       - run: bash scripts/travis/install_gdal.sh
       - run: sudo apt-get install -y -qq $(< packagelist-ubuntu-apt.txt)
         name: Install ubuntu requirements


### PR DESCRIPTION
At some point the ubuntu-18.04 image seems to have changed so that this
package isn't included, so trying to remove it broke the build.