### PR TITLE
Stack: use backend ID instead of index for mirrors

### DIFF
--- a/django/applications/catmaid/static/js/init.js
+++ b/django/applications/catmaid/static/js/init.js
@@ -2464,7 +2464,7 @@ var project;
    * @param  {number|string} reorientedStackID ID of the stack to open.
    * @param  {boolean} useExistingViewer True to add the stack to the existing,
    *                                     focused stack viewer.
-   * @param  {number}  mirrorIndex       An optional mirror index, defaults to
+   * @param  {number}  mirrorId          An optional mirror ID, defaults to
    *                                     the first available.
    * @param  {boolean} noLayout          Falsy to layout all available stack
    *                                     viewers (default).
@@ -2474,7 +2474,7 @@ var project;
    * @return {Promise}                   A promise yielding the stack viewer.
    */
   CATMAID.openProjectStack = function(projectID, reorientedStackID, useExistingViewer,
-      mirrorIndex, noLayout, handleErrors) {
+      mirrorId, noLayout, handleErrors) {
     if (project && project.id != projectID) {
       project.destroy();
     }
@@ -2486,7 +2486,7 @@ var project;
       .then(function(json) {
         return handle_openProjectStack(json,
             useExistingViewer ? project.focusedStackViewer : undefined,
-            mirrorIndex,
+            mirrorId,
             undefined,
             reorient)
           .then(function(stackViewer) {
@@ -2593,14 +2593,14 @@ var project;
    *
    * @param  {Object} e                JSON response from the stack info API.
    * @param  {StackViewer} stackViewer Viewer to which to add the stack.
-   * @param  {number}      mirrorIndex Optional mirror index, defaults to
+   * @param  {number}      mirrorId    Optional mirror ID, defaults to
    *                                   the first available.
    * @param  {Boolean} hide            The stack's layer will initially be
    *                                   hidden.
    * @return {Promise}                 A promise yielding the stack viewer
    *                                   containing the new stack.
    */
-  function handle_openProjectStack( e, stackViewer, mirrorIndex, hide, reorient )
+  function handle_openProjectStack( e, stackViewer, mirrorId, hide, reorient )
   {
     if (!stackViewer) {
       CATMAID.throwOnInsufficientWebGlContexts(1);
@@ -2691,7 +2691,7 @@ var project;
           stackViewer,
           "Image data (" + stack.title + ")",
           stack,
-          mirrorIndex,
+          mirrorId,
           !hideStackLayer,
           hideStackLayer ? 0 : 1,
           !useExistingViewer,

--- a/django/applications/catmaid/static/js/stack-viewer.js
+++ b/django/applications/catmaid/static/js/stack-viewer.js
@@ -322,7 +322,7 @@
     var title = this.primaryStack.title;
     var stackLayer = this._layers.get('StackLayer');
     if (stackLayer) {
-      var mirror = this.primaryStack.mirrors[stackLayer.mirrorIndex];
+      var mirror = this.primaryStack.mirrors[stackLayer.mirrorId];
       title = title + " | " + mirror.title;
     }
 

--- a/django/applications/catmaid/static/js/widgets/3dviewer.js
+++ b/django/applications/catmaid/static/js/widgets/3dviewer.js
@@ -4321,7 +4321,7 @@
       let stack = stackLayer.getStack();
       // Estimate number of data to be transferred.
       let zoomLevel = "max" === textureZoomLevel ? stack.MAX_S : Math.min(stack.MAX_S, textureZoomLevel);
-      let tileSource = stack.createTileSourceForMirror(stackLayer.mirrorIndex);
+      let tileSource = stack.createTileSourceForMirror(stackLayer.mirrorId);
       let nHTiles = getNZoomedParts(stack.dimension.x, zoomLevel, tileSource.tileWidth);
       let nVTiles = getNZoomedParts(stack.dimension.y, zoomLevel, tileSource.tileHeight);
 
@@ -4371,7 +4371,7 @@
 
         var zoomLevel = "max" === textureZoomLevel ? tileLayer.stack.MAX_S :
             Math.min(tileLayer.stack.MAX_S, textureZoomLevel);
-        var tileSource = tileLayer.stack.createTileSourceForMirror(tileLayer.mirrorIndex);
+        var tileSource = tileLayer.stack.createTileSourceForMirror(tileLayer.mirrorId);
         var geometry = this.createPlaneGeometry(tileLayer.stack, tileSource, zoomLevel);
 
         // Every tile in the z plane is made out of two triangles.

--- a/django/applications/catmaid/static/js/widgets/data-view.js
+++ b/django/applications/catmaid/static/js/widgets/data-view.js
@@ -403,7 +403,7 @@
         let imgSpan = rowSpan.appendChild(document.createElement('span'));
         if (p.stacks && p.stacks.length > 0) {
           let stack = p.stacks[0];
-          let mirror = stack.mirrors[this.sample_mirror_index];
+          let mirror = stack.mirrorsByPriority()[this.sample_mirror_index];
           if (mirror) {
             let tileSource = CATMAID.TileSources.get(mirror.id,
               mirror.tile_source_type, mirror.image_base, mirror.file_extension,


### PR DESCRIPTION
Fixes persistence of mirror preferences when set or priority of
available mirrors changes.

This resolves confusion when communicating with users about explicit
selection of mirrors and makes clear when priority/position sorting is
being used.
