### PR TITLE
Stack mirror export/import fixes

### DIFF
--- a/django/applications/catmaid/control/importer.py
+++ b/django/applications/catmaid/control/importer.py
@@ -114,10 +114,6 @@ class PreMirror(object):
         if not self.image_base:
             raise ValueError("Could not find valid image base for stack mirror")
 
-        # Make sure the image base has a trailing slash, because this is expected
-        if self.image_base[-1] != '/':
-            self.image_base = self.image_base + '/'
-
         # Test if the data is accessible through HTTP
         self.accessible = check_http_accessibility(self.image_base,
                 self.file_extension, auth=None)

--- a/django/applications/catmaid/control/project.py
+++ b/django/applications/catmaid/control/project.py
@@ -409,16 +409,10 @@ def export_project_data(projects) -> List:
 
     # Get information on all relevant stack mirrors
     cursor.execute("""
-        SELECT sm.id, sm.stack_id, sm.title, sm.image_base, sm.file_extension,
+        SELECT DISTINCT ON (sm.id) sm.id, sm.stack_id, sm.title, sm.image_base, sm.file_extension,
                 sm.tile_width, sm.tile_height, sm.tile_source_type, sm.position
         FROM project_stack ps
-        JOIN LATERAL (
-          SELECT *
-          FROM stack_mirror sm
-          WHERE sm.stack_id = ps.stack_id
-          LIMIT 1
-        ) sm
-          ON TRUE
+        JOIN stack_mirror sm ON sm.stack_id = ps.stack_id
         WHERE ps.project_id = ANY(%(user_project_ids)s::integer[])
         ORDER BY sm.id ASC, sm.position ASC
     """, {


### PR DESCRIPTION
- Project import: do not append trailing slash to mirror URL
- Project export: include all mirrors for stack
