### PR TITLE
Dependency handling with setuptools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,22 +53,16 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-py_${{ matrix.python-version }}-${{ hashFiles('django/requirements*.txt') }}
-      - run: pip install -r django/requirements-test.txt coveralls
+      - run: pip install ./django[test] coveralls
       - run: bash scripts/travis/setup_database.sh
       - run: bash scripts/travis/configure_catmaid.sh
       - run: bash scripts/travis/configure_pypy_libs.sh
         if: ${{ matrix.python-version == 'pypy3' }}
-      - run: |
-          cd django/projects
-          python manage.py migrate --noinput
+      - run: django/projects/manage.py migrate --noinput
         name: Apply migrations
-      - run: |
-          cd django/projects
-          python manage.py makemigrations catmaid
+      - run: django/projects/manage.py makemigrations catmaid
         name: Check migrations are up to date
-      - run: |
-          cd django/projects
-          coverage run manage.py test catmaid.tests
+      - run: coverage run django/projects/manage.py test catmaid.tests
         name: Run tests
 
   test-frontend:
@@ -94,7 +88,7 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-py_${{ matrix.python-version }}-${{ hashFiles('django/requirements.txt') }}
-      - run: pip install -r django/requirements.txt
+      - run: pip install ./django
       - run: bash scripts/travis/setup_database.sh
       - run: bash scripts/travis/configure_catmaid.sh
       - run: python django/projects/manage.py migrate --noinput

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
   versions might show a DatabaseError about threads. To fix this, add the
   ``numprocs = 1`` option to you supervisor config for Celery.
 
+- CATMAID's version is now reported slightly differently, in line with PEP440.
+  If you are using a release version, nothing will have changed.
+  Development versions are now reported as ``{release}.dev{commits}+g{hash}``,
+  where previously they were ``{release}-{commits}-g{hash}``.
+
+- CATMAID's dependencies (including extras associated with optional features)
+  can now be installed using pip: use ``pip install path/to/CATMAID/django[production,async,optional]``
+
 ### Features and enhancements
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - CATMAID's dependencies (including extras associated with optional features)
   can now be installed using pip: use ``pip install path/to/CATMAID/django[production,async,optional]``
 
+- virtualenvwrapper is no longer recommended, preferring the standard ``python -m venv``
+
 ### Features and enhancements
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,8 @@ RUN apt-get update -y  \
 COPY django/requirements.txt django/requirements-async.txt django/requirements-production.txt /home/django/
 ENV WORKON_HOME /opt/virtualenvs
 RUN mkdir -p /opt/virtualenvs \
-    && /bin/bash -c "source /usr/share/virtualenvwrapper/virtualenvwrapper.sh \
-    && mkvirtualenv catmaid -p /usr/bin/python3.8 \
-    && workon catmaid \
+    && /bin/bash -c "/usr/bin/python3.8 -m venv --upgrade-deps --prompt catmaid /home/env \
+    && source /home/env/bin/activate \
     && pip install -U pip setuptools \
     && pip install -r /home/django/requirements.txt \
     && pip install -r /home/django/requirements-async.txt \
@@ -53,8 +52,7 @@ COPY .git /home/.git
 RUN cd /home/ && git describe > /home/git-version && rm -r /home/.git
 
 # uWSGI setup
-RUN /bin/bash -c "source /usr/share/virtualenvwrapper/virtualenvwrapper.sh \
-    && workon catmaid \
+RUN /bin/bash -c "source /home/env/bin/activate \
     && pip install uwsgi" \
     && ln -s /home/scripts/docker/supervisor-catmaid.conf /etc/supervisor/conf.d/ \
     && mkdir -p /var/run/catmaid \

--- a/django/projects/mysite/utils.py
+++ b/django/projects/mysite/utils.py
@@ -38,10 +38,13 @@ def get_version():
             describe_info = version_file.read().rstrip().encode('utf-8').decode('utf-8')
         else:
             describe_info = out.rstrip().encode('utf-8').decode('utf-8')
-
-        return describe_info
     except:
-        return '{}-unknown'.format(BASE_VERSION)
+        describe_info = BASE_VERSION.split("-")[0] + "-0-unknown"
+
+    components = describe_info.split("-")
+    if len(components) == 1:
+        return components[0]
+    return "{}.dev{}+{}".format(*components)
 
 
 def relative(*path_components):

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=45", "wheel", "extreqs"]
+build-backend = "setuptools.build_meta"

--- a/django/requirements-dev.txt
+++ b/django/requirements-dev.txt
@@ -1,4 +1,2 @@
--r requirements-test.txt
--r requirements-doc.txt
 django-devserver==0.8.0
 sh==1.11

--- a/django/requirements-test.txt
+++ b/django/requirements-test.txt
@@ -1,4 +1,3 @@
--r requirements.txt
 django-migration-testcase==0.0.15
 selenium==3.141.0
 sauceclient==1.0.0

--- a/django/setup.py
+++ b/django/setup.py
@@ -11,6 +11,7 @@ install_requires, extras_require = parse_requirement_files(
     HERE / "requirements.txt",
     asynch=HERE / "requirements-async.txt",
     dev=HERE / "requirements-dev.txt",
+    doc=HERE / "requirements-doc.txt",
     optional=HERE / "requirements-optional.txt",
     production=HERE / "requirements-production.txt",
     test=HERE / "requirements-test.txt",

--- a/django/setup.py
+++ b/django/setup.py
@@ -9,15 +9,10 @@ from extreqs import parse_requirement_files
 HERE = Path(__file__).resolve().parent
 
 version = run_path(str(HERE / "projects/mysite/utils.py"))["get_version"]()
-
+extra_names = ["async", "dev", "doc", "optional", "production", "test"]
 install_requires, extras_require = parse_requirement_files(
     HERE / "requirements.txt",
-    asynch=HERE / "requirements-async.txt",
-    dev=HERE / "requirements-dev.txt",
-    doc=HERE / "requirements-doc.txt",
-    optional=HERE / "requirements-optional.txt",
-    production=HERE / "requirements-production.txt",
-    test=HERE / "requirements-test.txt",
+    **{extra: HERE / f"requirements-{extra}.txt" for extra in extra_names},
 )
 
 packages: tp.List[str] = []

--- a/django/setup.py
+++ b/django/setup.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import typing as tp
+
+from setuptools import setup
+from extreqs import parse_requirement_files
+
+HERE = Path(__file__).resolve().parent
+
+install_requires, extras_require = parse_requirement_files(
+    HERE / "requirements.txt",
+    asynch=HERE / "requirements-async.txt",
+    dev=HERE / "requirements-dev.txt",
+    optional=HERE / "requirements-optional.txt",
+    production=HERE / "requirements-production.txt",
+    test=HERE / "requirements-test.txt",
+)
+
+packages: tp.List[str] = []
+package_dir: tp.Dict[str, str] = dict()
+# for where, kwargs in [
+#     ("applications", {}),
+#     ("projects", {"include": ["mysite*"]}),
+#     ("lib", {})
+# ]:
+#     for pkg in find_packages(where, **kwargs):
+#         packages.append(pkg)
+#         components = [where] + pkg.split(".")
+#         package_dir[pkg] = os.path.join(*components)
+
+setup(
+    name="CATMAID",
+    url="https://www.catmaid.org/",
+    author="CATMAID development team",
+    version="0.0.1",
+    description="Collaborative Annotation Toolkit for Massive Amounts of Image Data",
+    packages=packages,
+    package_dir=package_dir,
+    install_requires=install_requires,
+    extras_require=extras_require,
+    python_requires=">=3.8, <4.0",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+    ],
+    setup_requires=["setuptools", "wheel", "extreqs"],
+    # scripts=["projects/manage.py", "projects/run-gevent.py"],
+)

--- a/django/setup.py
+++ b/django/setup.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 from pathlib import Path
 import typing as tp
+from runpy import run_path
 
 from setuptools import setup
 from extreqs import parse_requirement_files
 
 HERE = Path(__file__).resolve().parent
+
+version = run_path(str(HERE / "projects/mysite/utils.py"))["get_version"]()
 
 install_requires, extras_require = parse_requirement_files(
     HERE / "requirements.txt",
@@ -33,7 +36,7 @@ setup(
     name="CATMAID",
     url="https://www.catmaid.org/",
     author="CATMAID development team",
-    version="0.0.1",
+    version=version,
     description="Collaborative Annotation Toolkit for Massive Amounts of Image Data",
     packages=packages,
     package_dir=package_dir,
@@ -42,7 +45,7 @@ setup(
     python_requires=">=3.8, <4.0",
     classifiers=[
         "Development Status :: 3 - Alpha",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/packagelist-ubuntu-apt.txt
+++ b/packagelist-ubuntu-apt.txt
@@ -8,7 +8,6 @@ postgresql-common
 libpq-dev
 libhdf5-serial-dev
 libboost-dev
-virtualenvwrapper
 libboost-python-dev
 libxml2-dev
 libxslt1-dev

--- a/scripts/docker/catmaid-entry.sh
+++ b/scripts/docker/catmaid-entry.sh
@@ -82,8 +82,7 @@ init_catmaid () {
   fi
 
   echo "Loading virtualenv"
-  source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
-  workon catmaid
+  source /home/env/bin/activate
 
   if [ ! -f /home/django/projects/mysite/settings.py ] || ["$CM_FORCE_CONFIG_UPDATE" = true]; then
     echo "Setting up CATMAID"

--- a/sphinx-doc/source/dbmigration.rst
+++ b/sphinx-doc/source/dbmigration.rst
@@ -45,7 +45,7 @@ The main way to interact with South is with the help of ``manage.py``
 commands. South adds multiple commands to it, the most often used will probably
 be ``schemamigration`` to create new migrations and ``migrate`` to run
 migrations (see below). To use ``manage.py``, you need to be in the
-*virtualenv* environment (activate it with ``workon catmaid``). The commands
+*virtualenv* environment (activate it with ``source /home/alice/catmaid/django/env/bin/activate``). The commands
 in other parts of this page assume you are in the *virtualenv* and the folder
 where the ``manage.py`` file lives.
 

--- a/sphinx-doc/source/installation.rst
+++ b/sphinx-doc/source/installation.rst
@@ -94,41 +94,15 @@ You can do this with the following command on Ubuntu
        :split: 75
        :splitend:  \
 
-Virtualenv Wrapper needs to source your environment. Start a new terminal
-or if you are using the bash::
+Create a virtual environment:
 
-    source ~/.bashrc
+    /usr/bin/python3.8 -m venv --upgrade-deps --prompt catmaid /home/alice/catmaid/django/env
 
-Please test if ``virtualenvwrapper`` is set up correctly, by executing::
+Whenever you are working with this environment in a new shell, you need to
 
-    mkvirtualenv --version
+    source /home/alice/catmaid/django/env/bin/activate
 
-If it gives you a version, everything is fine. Otherwise, e.g. if the command
-``mkvirtualenv`` is not found, add the following line to your ``~/.bashrc`` file
-and call ``source ~/.bashrc`` again::
-
-    source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
-
-To create a new virtualenv for CATMAID's Python dependencies,
-you can do::
-
-    mkvirtualenv --no-site-packages -p /usr/bin/python3.8 catmaid
-
-That will create a virtualenv in ``~/.virtualenvs/catmaid/``, and
-while your virtualenv is activated, Python libraries will be
-imported from (and installed to) there. After creating the
-virtualenv as above, it will be activated for you, but in new
-shells, for example, you will need to activate it by running::
-
-    workon catmaid
-
-.. note::
-
-    Many distributions ship with an outdated version of Pip.
-    This is the tool we use to install Python packages within the virtualenv,
-    so let's update it first::
-
-        python -m pip install -U pip
+You can deactivate the environment with ``deactivate``.
 
 .. note::
 
@@ -148,19 +122,16 @@ shells, for example, you will need to activate it by running::
 Install all of the required Python packages with::
 
     cd /home/alice/catmaid/django
-    pip install -r requirements.txt
+    pip install .
 
 If that worked correctly, then the second-last line of output will begin
 ``Successfully installed``, and list the Python packages that have just been
 installed.
 
-If you set up a production environment, please also install the
-``requirements-production.txt`` file::
+CATMAID has a number of optional "extras".
+These extras are specified in the usual way:
 
-    pip install -r requirements-production.txt
-
-This will rebuild some dependencies from source. If asked whether existing
-packages should be replaced by the new version, answer with yes.
+    pip install '.[async,optional,production]'
 
 
 3. Install and configure PostgreSQL

--- a/sphinx-doc/source/installation.rst
+++ b/sphinx-doc/source/installation.rst
@@ -94,7 +94,7 @@ You can do this with the following command on Ubuntu
        :split: 75
        :splitend:  \
 
-Create a virtual environment:
+Create a virtual environment based on the python binary at /usr/bin/python3.8:
 
     /usr/bin/python3.8 -m venv --upgrade-deps --prompt catmaid /home/alice/catmaid/django/env
 
@@ -110,9 +110,7 @@ You can deactivate the environment with ``deactivate``.
    performance of back-end heavy endpoints. Most functionality is available,
    except for the following: Ontology clustering, Cropping, Synapse clustering,
    HDF 5 tiles and User analytics. To use PyPy, a new virtualenv using the PyPy
-   executable has to be created::
-
-       mkvirtualenv --no-site-packages -p /usr/bin/pypy catmaid
+   executable has to be created.
 
 .. note::
 


### PR DESCRIPTION
In short, this turns

```sh
pip install \
  -r django/requirements.txt \
  -r django/requirements-async.txt \
  -r django/requirements-dev.txt \
  -r django/requirements-doc.txt \
  -r django/requirements-optional.txt \
  -r django/requirements-production.txt \
  -r django/requirements-test.txt
```

into

```sh
pip install ./django[asynch,dev,doc,optional,production,test]
```

The requirements files themselves are unchanged. Note that the async extra is called "asynch", so that it doesn't collide with the `async` keyword.

Originally this was going to have a slightly broader scope, A) adding `manage.py` to the PATH so it can be called from anywhere, and B) installing all of CATMAID's packages as well, but both seem to be incompatible with how django handles settings.py.