### PR TITLE
Docker updates, with CI build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@ django/configuration.py
 django/projects/mysite/django.wsgi
 django/projects/mysite/settings.py
 sphinx-doc/build/*
+.vagrant/
+data/
+temp/

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -8,7 +8,7 @@ defaults:
 
 jobs:
   build-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: docker build -t catmaid .

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,4 +11,5 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - run: git fetch --unshallow --tags --prune
       - run: docker build -t catmaid .

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,14 @@
+
+on: [push, pull_request]
+name: docker image
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: docker build -t catmaid .

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update -y \
     && add-apt-repository ppa:deadsnakes/ppa \
     && add-apt-repository -y ppa:nginx/stable \
     && apt-get update -y \
-    && apt-get install -y python3.8 python3.8-dev git python3-pip \
+    && apt-get install -y python3.9 python3.9-venv python3.9-dev git python3-pip \
     && apt-get install -y nginx supervisor \
     && apt-get install -y rabbitmq-server \
     && rm -rf /var/lib/apt/lists/*
@@ -31,15 +31,11 @@ RUN apt-get update -y  \
     && xargs apt-get install -y < /home/packagelist-ubuntu-apt.txt \
     && rm -rf /var/lib/apt/lists/*
 COPY django/requirements.txt django/requirements-async.txt django/requirements-production.txt /home/django/
-ENV WORKON_HOME /opt/virtualenvs
-RUN mkdir -p /opt/virtualenvs \
-    && /bin/bash -c "/usr/bin/python3.8 -m venv --upgrade-deps --prompt catmaid /home/env \
-    && source /home/env/bin/activate \
-    && pip install -U pip setuptools \
-    && pip install -r /home/django/requirements.txt \
-    && pip install -r /home/django/requirements-async.txt \
-    && pip install -r /home/django/requirements-production.txt \
-    "
+
+RUN /usr/bin/python3.9 -m venv --upgrade-deps --prompt catmaid /home/env \
+    && /home/env/bin/pip install -r /home/django/requirements.txt \
+    && /home/env/bin/pip install -r /home/django/requirements-async.txt \
+    && /home/env/bin/pip install -r /home/django/requirements-production.txt
 
 COPY . /home/
 
@@ -52,8 +48,7 @@ COPY .git /home/.git
 RUN cd /home/ && git describe > /home/git-version && rm -r /home/.git
 
 # uWSGI setup
-RUN /bin/bash -c "source /home/env/bin/activate \
-    && pip install uwsgi" \
+RUN /home/env/bin/pip install uwsgi \
     && ln -s /home/scripts/docker/supervisor-catmaid.conf /etc/supervisor/conf.d/ \
     && mkdir -p /var/run/catmaid \
     && chown www-data /var/run/catmaid \

--- a/sphinx-doc/source/installation.rst
+++ b/sphinx-doc/source/installation.rst
@@ -96,7 +96,7 @@ You can do this with the following command on Ubuntu
 
 Create a virtual environment based on the python binary at /usr/bin/python3.8:
 
-    /usr/bin/python3.8 -m venv --upgrade-deps --prompt catmaid /home/alice/catmaid/django/env
+    /usr/bin/python3.8 -m venv --prompt catmaid /home/alice/catmaid/django/env
 
 Whenever you are working with this environment in a new shell, you need to
 


### PR DESCRIPTION
- Use py39 for docker
- Remove virtualenvwrapper references
- GitHub Actions to make sure the docker image builds
- Remove `--upgrade-deps` from docs