### PR TITLE
imageblk tilesource: Fix bug that prevents non-xy orientations from working

### DIFF
--- a/django/applications/catmaid/static/js/tile-source.js
+++ b/django/applications/catmaid/static/js/tile-source.js
@@ -354,10 +354,10 @@
       return this.baseURL + this.tileWidth + '_' + this.tileHeight + '/' + col * this.tileWidth + '_' +
           row * this.tileHeight + '_' + slicePixelPosition[0] + '/' + this.fileExtension;
     } else if (stack.orientation === CATMAID.Stack.ORIENTATION_XZ) {
-      return baseURL + this.tileWidth + '_' + this.tileHeight + '/' + col * this.tileWidth + '_' +
+      return this.baseURL + this.tileWidth + '_' + this.tileHeight + '/' + col * this.tileWidth + '_' +
           slicePixelPosition[0] + '_' + row * this.tileHeight + '/' + this.fileExtension;
     } else if (stack.orientation === CATMAID.Stack.ORIENTATION_ZY) {
-      return baseURL + this.tileWidth + '_' + this.tileHeight + '/' + slicePixelPosition[0] + '_' +
+      return this.baseURL + this.tileWidth + '_' + this.tileHeight + '/' + slicePixelPosition[0] + '_' +
           row * this.tileHeight + '_' + col * this.tileWidth + '/' + this.fileExtension;
     }
   };


### PR DESCRIPTION
In experimenting with imageblk, I was unable to get non-xy orientations working in catmaid, always getting a weird error about baseURL not being defined.

Looks like it's a little javascript whoops.