### PR TITLE
Update 3dviewer.js node highlighting fixes #2269

### DIFF
--- a/django/applications/catmaid/static/js/widgets/3dviewer.js
+++ b/django/applications/catmaid/static/js/widgets/3dviewer.js
@@ -2154,7 +2154,7 @@
     var activeNodeDisplayed = activeNode.mesh.visible;
     var activeNodeSelected = !!SkeletonAnnotations.getActiveNodeId();
 
-    activeNode.setVisible(activeNodeSelected);
+    activeNode.setVisible(activeNodeDisplayed && activeNodeSelected);
     activeNode.updatePosition(this.space, this.options);
 
     if (activeNode.mesh.visible && this.options.follow_active) {


### PR DESCRIPTION
BugFix issue 2269 where the active node was being highlighted even when it was set not to highlighted under several circumstances.